### PR TITLE
GuildStickers from raw should have a nullable String type.

### DIFF
--- a/nyxx/lib/src/core/message/Sticker.dart
+++ b/nyxx/lib/src/core/message/Sticker.dart
@@ -74,7 +74,7 @@ class GuildSticker extends ISticker {
 
   GuildSticker._new(RawApiMap raw, INyxx client) : super._new(raw, client) {
     this.name = raw["name"] as String;
-    this.description = raw["description"] as String;
+    this.description = raw["description"] as String?;
     this.format = StickerFormat.from(raw["format_type"] as int);
     this.type = StickerType.from(raw["type"] as int);
 


### PR DESCRIPTION
# Description
GuildStickers RawApiMap for description should be a nullable String, since sticker descriptions can be null.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dartanalyzer --options analysis_options.yaml .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
