### PR TITLE
Multiple search platforms support

### DIFF
--- a/nyxx_lavalink/lib/lavalink.dart
+++ b/nyxx_lavalink/lib/lavalink.dart
@@ -8,7 +8,7 @@ import "dart:isolate";
 
 import "package:http/http.dart" show Client;
 import "package:logging/logging.dart";
-import "package:nyxx/nyxx.dart" show Nyxx, Snowflake, VoiceStateUpdateEvent, VoiceServerUpdateEvent, Disposable;
+import "package:nyxx/nyxx.dart" show Nyxx, Snowflake, VoiceStateUpdateEvent, VoiceServerUpdateEvent, Disposable, IEnum;
 
 part "src/_EventDispatcher.dart";
 part "src/Cluster.dart";

--- a/nyxx_lavalink/lib/lavalink.dart
+++ b/nyxx_lavalink/lib/lavalink.dart
@@ -8,7 +8,7 @@ import "dart:isolate";
 
 import "package:http/http.dart" show Client;
 import "package:logging/logging.dart";
-import "package:nyxx/nyxx.dart" show Nyxx, Snowflake, IntExtensions, VoiceStateUpdateEvent, VoiceServerUpdateEvent, Disposable;
+import "package:nyxx/nyxx.dart" show Nyxx, Snowflake, VoiceStateUpdateEvent, VoiceServerUpdateEvent, Disposable;
 
 part "src/_EventDispatcher.dart";
 part "src/Cluster.dart";

--- a/nyxx_lavalink/lib/lavalink.dart
+++ b/nyxx_lavalink/lib/lavalink.dart
@@ -27,6 +27,7 @@ part "src/model/TrackException.dart";
 part "src/model/TrackStart.dart";
 part "src/model/TrackStuck.dart";
 part "src/model/WebSocketClosed.dart";
+part "src/model/SearchPlatform.dart";
 
 part "src/node/Node.dart";
 part "src/node/nodeRunner.dart";

--- a/nyxx_lavalink/lib/src/model/SearchPlatform.dart
+++ b/nyxx_lavalink/lib/src/model/SearchPlatform.dart
@@ -1,20 +1,15 @@
 part of nyxx_lavalink;
 
 /// Search platforms supported by Lavalink
-enum SearchPlatform {
+class SearchPlatform extends IEnum<String> {
   /// Youtube
-  youtube,
+  static const youtube = SearchPlatform._create("ytsearch");
 
   /// Youtube Music
-  youtubeMusic,
+  static const youtubeMusic = SearchPlatform._create("ytmsearch");
 
   /// SoundCloud
-  soundcloud,
-}
+  static const soundcloud = SearchPlatform._create("scsearch");
 
-/// String presentation of the platform
-const Map<SearchPlatform, String> _stringPlatform = {
-  SearchPlatform.youtube: "ytsearch",
-  SearchPlatform.youtubeMusic: "ytmsearch",
-  SearchPlatform.soundcloud: "scsearch",
-};
+  const SearchPlatform._create(String value) : super(value);
+}

--- a/nyxx_lavalink/lib/src/model/SearchPlatform.dart
+++ b/nyxx_lavalink/lib/src/model/SearchPlatform.dart
@@ -1,0 +1,20 @@
+part of nyxx_lavalink;
+
+/// Search platforms supported by Lavalink
+enum SearchPlatform {
+  /// Youtube
+  youtube,
+
+  /// Youtube Music
+  youtubeMusic,
+
+  /// SoundCloud
+  soundcloud,
+}
+
+/// String presentation of the platform
+const Map<SearchPlatform, String> _stringPlatform = {
+  SearchPlatform.youtube: "ytsearch",
+  SearchPlatform.youtubeMusic: "ytmsearch",
+  SearchPlatform.soundcloud: "scsearch",
+};

--- a/nyxx_lavalink/lib/src/node/Node.dart
+++ b/nyxx_lavalink/lib/src/node/Node.dart
@@ -199,9 +199,9 @@ class Node {
   /// Searches a provided query on selected platform (YouTube by default),
   /// if the query is a link it's searched directly by the link
   Future<Tracks> autoSearch(
-    String query, [
+    String query, {
     SearchPlatform platform = SearchPlatform.youtube,
-  ]) async {
+  }) async {
     if (this._urlRegex.hasMatch(query)) {
       return searchTracks(query);
     }

--- a/nyxx_lavalink/lib/src/node/Node.dart
+++ b/nyxx_lavalink/lib/src/node/Node.dart
@@ -196,14 +196,17 @@ class Node {
     return Tracks._fromJson(jsonDecode(response.body) as Map<String, dynamic>);
   }
 
-  /// Searches a provided query on youtube, if the query is a link
-  /// it's searched directly by the link
-  Future<Tracks> autoSearch(String query) async {
+  /// Searches a provided query on selected platform (YouTube by default),
+  /// if the query is a link it's searched directly by the link
+  Future<Tracks> autoSearch(
+    String query, [
+    SearchPlatform platform = SearchPlatform.youtube,
+  ]) async {
     if (this._urlRegex.hasMatch(query)) {
       return searchTracks(query);
     }
 
-    return searchTracks("ytsearch:$query");
+    return searchTracks("${_stringPlatform[platform]}:$query");
   }
 
   /// Get the [PlayParameters] object for a specific track

--- a/nyxx_lavalink/lib/src/node/Node.dart
+++ b/nyxx_lavalink/lib/src/node/Node.dart
@@ -206,7 +206,7 @@ class Node {
       return searchTracks(query);
     }
 
-    return searchTracks("${_stringPlatform[platform]}:$query");
+    return searchTracks("${platform.value}:$query");
   }
 
   /// Get the [PlayParameters] object for a specific track

--- a/nyxx_lavalink/lib/src/node/nodeRunner.dart
+++ b/nyxx_lavalink/lib/src/node/nodeRunner.dart
@@ -61,7 +61,7 @@ Future<void> _handleNode(SendPort clusterPort) async {
             process(jsonDecode(data as String) as Map<String, dynamic>);
           }, onDone: () async {
             clusterPort.send({"cmd": "DISCONNECTED", "nodeId": node.nodeId});
-            connect();
+            await connect();
 
             return;
           },


### PR DESCRIPTION
# Description
Lavaplayer supports not only `ytsearch` prefix, but also `scsearch` (SoundCloud) and `ytmsearch` (Youtube Music) prefixes. So I implemented their support in `nyxx_lavalink`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dartanalyzer --options analysis_options.yaml .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
