### PR TITLE
User accent color should be casted as an int.

### DIFF
--- a/nyxx/lib/src/core/user/User.dart
+++ b/nyxx/lib/src/core/user/User.dart
@@ -74,7 +74,7 @@ class User extends SnowflakeEntity with Mentionable, IMessageAuthor implements I
 
     this.bannerHash = raw["banner"] as String?;
     if (raw["accent_color"] != null) {
-      this.accentColor = DiscordColor.fromHexString(raw["accent_color"] as String);
+      this.accentColor = DiscordColor.fromInt(raw["accent_color"] as int);
     } else {
       this.accentColor = null;
     }


### PR DESCRIPTION
# Description
User accent color is an integer rather then a string.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dartanalyzer --options analysis_options.yaml .`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
