### PR TITLE
Add context menu command message types

### DIFF
--- a/nyxx/lib/src/core/message/MessageType.dart
+++ b/nyxx/lib/src/core/message/MessageType.dart
@@ -22,9 +22,10 @@ class MessageType extends IEnum<int> {
   static const MessageType guildDiscoveryGracePeriodFinalWarning = MessageType._create(17);
   static const MessageType threadCreated = MessageType._create(18);
   static const MessageType reply = MessageType._create(19);
-  static const MessageType applicationCommand = MessageType._create(20);
+  static const MessageType chatInputCommand = MessageType._create(20);
   static const MessageType threadStarterMessage = MessageType._create(21);
   static const MessageType guildInviteRemainder = MessageType._create(22);
+  static const MessageType contextMenuCommand = MessageType._create(23);
 
   /// Creates instance of [MessageType] from [value].
   MessageType.from(int? value) : super(value ?? 0);


### PR DESCRIPTION
# Description

- Added CONTEXT_MENU_COMMAND
- renamed `applicationCommand` to `chatInputCommand` to better follow suit with discord docs

Fixes #175 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dartanalyzer --options analysis_options.yaml .`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
