### PR TITLE
[feature/bug] Implement/Fix events in ShardManager

### DIFF
--- a/nyxx/lib/src/internal/_ConnectionManager.dart
+++ b/nyxx/lib/src/internal/_ConnectionManager.dart
@@ -54,8 +54,11 @@ class _ConnectionManager {
   }
 
   Future<void> propagateReady() async {
-    this._shardsReady++;
+    if (!_client.ready) {
+      _client._events.onReady.add(ReadyEvent._new(_client));
+    }
 
+    this._shardsReady++;
     if(_client.ready || this._shardsReady < (_client._options.shardCount ?? 1)) {
       return;
     }
@@ -70,9 +73,6 @@ class _ConnectionManager {
     final response = httpResponse as HttpResponseSuccess;
     _client.app = ClientOAuth2Application._new(response.jsonBody as RawApiMap, _client);
 
-    if (!_client.ready) {
-      _client._events.onReady.add(ReadyEvent._new(_client));
-    }
     _client.ready = true;
     _logger.info("Connected and ready! Logged as `${_client.self.tag}`");
   }

--- a/nyxx/lib/src/internal/shard/ShardManager.dart
+++ b/nyxx/lib/src/internal/shard/ShardManager.dart
@@ -15,6 +15,9 @@ class ShardManager implements Disposable {
   /// Emitted when the shard encounters a connection error.
   late final Stream<Shard> onDisconnect = this._onDisconnect.stream;
 
+  /// Emitted when the shard resumed its connection
+  late final Stream<Shard> onResume = this._onDisconnect.stream;
+
   /// Emitted when shard receives member chunk.
   late final Stream<MemberChunkEvent> onMemberChunk = this._onMemberChunk.stream;
 
@@ -24,6 +27,7 @@ class ShardManager implements Disposable {
 
   final StreamController<Shard> _onConnect = StreamController.broadcast();
   final StreamController<Shard> _onDisconnect = StreamController.broadcast();
+  final StreamController<Shard> _onResume = StreamController.broadcast();
   final StreamController<MemberChunkEvent> _onMemberChunk = StreamController.broadcast();
   final StreamController<RawEvent> _onRawEvent = StreamController.broadcast();
 


### PR DESCRIPTION
# Description

Fixed events in `ShardManager`:
 - `onConnect`
 - `onDisconnect`

Implented `RESUME` dispatch opcode:
 - added `onResume` event

Fix bug of snowballing invocation of `propagateReady` method 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] Ran `dartanalyzer --options analysis_options.yaml .`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
