### PR TITLE
Add Student Hub types

### DIFF
--- a/nyxx/lib/src/core/channel/Channel.dart
+++ b/nyxx/lib/src/core/channel/Channel.dart
@@ -71,7 +71,7 @@ class ChannelType extends IEnum<int> {
   static const ChannelType guildPublicThread = ChannelType._create(11);
   static const ChannelType guildPrivateThread = ChannelType._create(12);
 
-	/// Channel in a Student Hub containing the listed servers
+  /// Channel in a Student Hub containing the listed servers
   static const ChannelType guildDirectory = ChannelType._create(14);
 
   /// Type of channel is unknown

--- a/nyxx/lib/src/core/channel/Channel.dart
+++ b/nyxx/lib/src/core/channel/Channel.dart
@@ -71,6 +71,9 @@ class ChannelType extends IEnum<int> {
   static const ChannelType guildPublicThread = ChannelType._create(11);
   static const ChannelType guildPrivateThread = ChannelType._create(12);
 
+	/// Channel in a Student Hub containing the listed servers
+  static const ChannelType guildDirectory = ChannelType._create(14);
+
   /// Type of channel is unknown
   static const ChannelType unknown = ChannelType._create(1337);
 

--- a/nyxx/lib/src/core/guild/GuildFeature.dart
+++ b/nyxx/lib/src/core/guild/GuildFeature.dart
@@ -56,7 +56,7 @@ class GuildFeature extends IEnum<String> {
   /// Guild has access to create private threads
   static const GuildFeature privateThreadsEnabled = GuildFeature._create("PRIVATE_THREADS");
 
-	/// Guild is a Student Hub
+  /// Guild is a Student Hub
   static const GuildFeature studentHub = GuildFeature._create("HUB");
 
   /// Creates instance of [GuildFeature] from [value].

--- a/nyxx/lib/src/core/guild/GuildFeature.dart
+++ b/nyxx/lib/src/core/guild/GuildFeature.dart
@@ -56,6 +56,9 @@ class GuildFeature extends IEnum<String> {
   /// Guild has access to create private threads
   static const GuildFeature privateThreadsEnabled = GuildFeature._create("PRIVATE_THREADS");
 
+	/// Guild is a Student Hub
+  static const GuildFeature studentHub = GuildFeature._create("HUB");
+
   /// Creates instance of [GuildFeature] from [value].
   GuildFeature.from(String? value) : super(value ?? "");
   const GuildFeature._create(String? value) : super(value ?? "");


### PR DESCRIPTION
# Description

Add the Student Hub types as referenced in #197, not too much use right now as bots cannot join student hubs. This fixes #197 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] Ran `dartanalyzer --options analysis_options.yaml .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
