### PR TITLE
Allow handlers on different nesting layers, closes #233

### DIFF
--- a/nyxx_interactions/lib/src/Interactions.dart
+++ b/nyxx_interactions/lib/src/Interactions.dart
@@ -241,6 +241,8 @@ class Interactions {
   void _assignCommandToHandler(SlashCommandBuilder builder, SlashCommand command) {
     final commandHashPrefix = "${command.id}|${command.name}";
 
+    var allowRootHandler = true;
+
     final subCommands = builder.options.where((element) => element.type == CommandOptionType.subCommand);
     if (subCommands.isNotEmpty) {
       for (final subCommand in subCommands) {
@@ -251,7 +253,7 @@ class Interactions {
         this._commandHandlers["$commandHashPrefix|${subCommand.name}"] = subCommand._handler!;
       }
 
-      return;
+      allowRootHandler = false;
     }
 
     final subCommandGroups = builder.options.where((element) => element.type == CommandOptionType.subCommandGroup);
@@ -269,6 +271,10 @@ class Interactions {
         }
       }
 
+      allowRootHandler = false;
+    }
+
+    if (!allowRootHandler) {
       return;
     }
 


### PR DESCRIPTION
# Description

Previously handlers could not be registered for both subcommands and sub-subcommands because of the way preventing root handlers on slash commands with subcommands was implemented. This PR reworks that system to allow both subcommands and sub-subcommands to have handlers, while still preventing slash commands with subcommands having roor handlers.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dartanalyzer --options analysis_options.yaml .`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
