### PR TITLE
Fix CliItegration plugin not working with IgnoreExceptions

### DIFF
--- a/lib/src/plugin/plugins/ignore_exception.dart
+++ b/lib/src/plugin/plugins/ignore_exception.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:isolate';
 
 import 'package:logging/logging.dart';
@@ -15,6 +16,10 @@ class IgnoreExceptions extends BasePlugin {
       final stackTrace = err[1] != null ? ". Stacktrace: \n${err[1]}" : "";
 
       logger.shout("Got Error: Message: [${err[0]}]$stackTrace");
+
+      if (err[0].startsWith('UnrecoverableNyxxError') as bool) {
+        Isolate.current.kill();
+      }
     });
 
     Isolate.current.addErrorListener(errorsPort.sendPort);


### PR DESCRIPTION
# Description

Fixes IgnoreExceptions catching UnrecoverableNyxxErrors and ignoring them, causing the bot to never stop from SIGINT/SIGKILL

Closes #255

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
