### PR TITLE
Use logger instead of print

### DIFF
--- a/lib/src/internal/shard/shard.dart
+++ b/lib/src/internal/shard/shard.dart
@@ -528,7 +528,7 @@ class Shard implements IShard {
             if (manager.connectionManager.client.options.dispatchRawShardEvent) {
               manager.onRawEventController.add(RawEvent(this, rawPayload));
             } else {
-              print("UNKNOWN OPCODE: $rawPayload");
+              manager.logger.info("UNKNOWN OPCODE: $rawPayload");
             }
         }
         break;


### PR DESCRIPTION
# Description

Unknown events were previously logged with `print`. This PR changes this to use `Logger` instead, preventing console spam for larger bots.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
