### PR TITLE
bug: Nullable close code

### DIFF
--- a/lib/src/internal/shard/shard.dart
+++ b/lib/src/internal/shard/shard.dart
@@ -229,7 +229,7 @@ class Shard implements IShard {
     final closeCode = data["errorCode"] as int?;
 
     if (closeCode == null) {
-      manager.logger.fine("Received null close. Payload: `$data`");
+      manager.logger.warning("Received null close = client is probably closing. Payload: `$data`");
       return;
     }
 

--- a/lib/src/internal/shard/shard.dart
+++ b/lib/src/internal/shard/shard.dart
@@ -226,7 +226,12 @@ class Shard implements IShard {
   }
 
   void _handleError(dynamic data) {
-    final closeCode = data["errorCode"] as int;
+    final closeCode = data["errorCode"] as int?;
+
+    if (closeCode == null) {
+      manager.logger.fine("Received null close. Payload: `$data`");
+      return;
+    }
 
     _connected = false;
     _heartbeatTimer.cancel();


### PR DESCRIPTION
# Description

Fixes a bug where when closing shard, shard emits `DISCONNECT` message without closeCode

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
