### PR TITLE
Feature/specific shards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ test-*.dart
 **/coverage/**
 coverage.json
 lcov.info
+.vscode/

--- a/lib/src/client_options.dart
+++ b/lib/src/client_options.dart
@@ -41,6 +41,9 @@ class ClientOptions {
   /// The total number of shards.
   int? shardCount;
 
+  /// A list of shards to spawn on this instance of nyxx.
+  List<int>? shards;
+
   /// The number of messages to cache for each channel.
   int messageCacheSize;
 
@@ -81,7 +84,8 @@ class ClientOptions {
       this.initialPresence,
       this.shutdownHook,
       this.shutdownShardHook,
-      this.dispatchRawShardEvent = false});
+      this.dispatchRawShardEvent = false,
+      this.shards});
 }
 
 /// When identifying to the gateway, you can specify an intents parameter which

--- a/lib/src/client_options.dart
+++ b/lib/src/client_options.dart
@@ -42,7 +42,7 @@ class ClientOptions {
   int? shardCount;
 
   /// A list of shards to spawn on this instance of nyxx.
-  List<int>? shards;
+  List<int>? shardIds;
 
   /// The number of messages to cache for each channel.
   int messageCacheSize;
@@ -85,7 +85,7 @@ class ClientOptions {
       this.shutdownHook,
       this.shutdownShardHook,
       this.dispatchRawShardEvent = false,
-      this.shards});
+      this.shardIds});
 }
 
 /// When identifying to the gateway, you can specify an intents parameter which

--- a/lib/src/core/guild/guild.dart
+++ b/lib/src/core/guild/guild.dart
@@ -1,4 +1,5 @@
 import 'package:nyxx/src/core/guild/scheduled_event.dart';
+import 'package:nyxx/src/internal/exceptions/invalid_shard_exception.dart';
 import 'package:nyxx/src/nyxx.dart';
 import 'package:nyxx/src/core/channel/invite.dart';
 import 'package:nyxx/src/core/snowflake.dart';
@@ -468,7 +469,10 @@ class Guild extends SnowflakeEntity implements IGuild {
       throw UnsupportedError("Cannot use this property with NyxxRest");
     }
 
-    return (client as NyxxWebsocket).shardManager.shards.firstWhere((_shard) => _shard.guilds.contains(id));
+    return (client as NyxxWebsocket).shardManager.shards.firstWhere(
+          (_shard) => _shard.guilds.contains(id),
+          orElse: throw InvalidShardException('Cannot find shard for this guild!'),
+        );
   }
 
   /// Creates an instance of [Guild]

--- a/lib/src/internal/connection_manager.dart
+++ b/lib/src/internal/connection_manager.dart
@@ -63,13 +63,12 @@ class ConnectionManager {
 
   Future<void> propagateReady() async {
     _shardsReady++;
-    if (client.ready || _shardsReady < (client.options.shardCount ?? 1)) {
+    if (client.ready || _shardsReady < client.shardManager.numShards) {
       return;
     }
 
-    if (!client.ready) {
-      (client.eventsWs as WebsocketEventController).onReadyController.add(ReadyEvent(client));
-    }
+    (client.eventsWs as WebsocketEventController).onReadyController.add(ReadyEvent(client));
+
     client.ready = true;
     _logger.info("Connected and ready! Logged as `${client.self.tag}`");
   }

--- a/lib/src/internal/shard/shard.dart
+++ b/lib/src/internal/shard/shard.dart
@@ -322,7 +322,7 @@ class Shard implements IShard {
             "guild_subscriptions": manager.connectionManager.client.options.guildSubscriptions,
             "intents": manager.connectionManager.client.intents,
             if (manager.connectionManager.client.options.initialPresence != null) "presence": manager.connectionManager.client.options.initialPresence!.build(),
-            "shard": <int>[id, manager.numShards]
+            "shard": <int>[id, manager.totalNumShards]
           };
 
           send(OPCodes.identify, identifyMsg);

--- a/lib/src/internal/shard/shard_manager.dart
+++ b/lib/src/internal/shard/shard_manager.dart
@@ -133,25 +133,29 @@ class ShardManager implements IShardManager {
       throw UnrecoverableNyxxError("Number of shards cannot be lower than 1.");
     }
 
-    List<int> toSpawn;
+    List<int> toSpawn = _getShardsToSpawn();
+
+    logger.fine("Starting shard manager. Number of shards to spawn: $numShards");
+    _connect(toSpawn);
+  }
+
+  List<int> _getShardsToSpawn() {
     if (connectionManager.client.options.shards != null) {
       if (connectionManager.client.options.shardCount == null) {
         throw UnrecoverableNyxxError('Cannot specify shards to spawn without specifying total number of shards');
       }
-      // Clone list to prevent original list from being modified with removeLast()
-      toSpawn = List.of(connectionManager.client.options.shards!);
 
-      for (final id in toSpawn) {
+      for (final id in connectionManager.client.options.shards!) {
         if (id < 0 || id >= totalNumShards) {
           throw UnrecoverableNyxxError('Invalid shard ID: $id');
         }
       }
-    } else {
-      toSpawn = List.generate(totalNumShards, (id) => id);
-    }
 
-    logger.fine("Starting shard manager. Number of shards to spawn: $numShards");
-    _connect(toSpawn);
+      // Clone list to prevent original list from being modified with removeLast()
+      return List.of(connectionManager.client.options.shards!);
+    } else {
+      return List.generate(totalNumShards, (id) => id);
+    }
   }
 
   /// Sets presences on every shard

--- a/lib/src/internal/shard/shard_manager.dart
+++ b/lib/src/internal/shard/shard_manager.dart
@@ -127,7 +127,7 @@ class ShardManager implements IShardManager {
   /// Starts shard manager
   ShardManager(this.connectionManager, this.maxConcurrency) {
     totalNumShards = connectionManager.client.options.shardCount ?? connectionManager.recommendedShardsNum;
-    numShards = connectionManager.client.options.shards?.length ?? totalNumShards;
+    numShards = connectionManager.client.options.shardIds?.length ?? totalNumShards;
 
     if (totalNumShards < 1) {
       throw UnrecoverableNyxxError("Number of shards cannot be lower than 1.");
@@ -140,19 +140,19 @@ class ShardManager implements IShardManager {
   }
 
   List<int> _getShardsToSpawn() {
-    if (connectionManager.client.options.shards != null) {
+    if (connectionManager.client.options.shardIds != null) {
       if (connectionManager.client.options.shardCount == null) {
         throw UnrecoverableNyxxError('Cannot specify shards to spawn without specifying total number of shards');
       }
 
-      for (final id in connectionManager.client.options.shards!) {
+      for (final id in connectionManager.client.options.shardIds!) {
         if (id < 0 || id >= totalNumShards) {
           throw UnrecoverableNyxxError('Invalid shard ID: $id');
         }
       }
 
       // Clone list to prevent original list from being modified with removeLast()
-      return List.of(connectionManager.client.options.shards!);
+      return List.of(connectionManager.client.options.shardIds!);
     } else {
       return List.generate(totalNumShards, (id) => id);
     }


### PR DESCRIPTION
# Description

Add an option to `ClientOptions` that allows users to specify specific shard IDs to spawn on any instance of NyxxWebsocket.

Closes #265 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
