### PR TITLE
Expose builder parameter in IMember

### DIFF
--- a/lib/src/core/user/member.dart
+++ b/lib/src/core/user/member.dart
@@ -87,7 +87,13 @@ abstract class IMember implements SnowflakeEntity, Mentionable {
 
   /// Edits members. Allows to move user in voice channel, mute or deaf, change nick, roles.
   Future<void> edit(
-      {String? nick = "", List<SnowflakeEntity>? roles, bool? mute, bool? deaf, Snowflake? channel = const Snowflake.zero(), String? auditReason});
+      {@Deprecated('Use "builder" parameter') String? nick = "",
+      @Deprecated('Use "builder" parameter') List<SnowflakeEntity>? roles,
+      @Deprecated('Use "builder" parameter') bool? mute,
+      @Deprecated('Use "builder" parameter') bool? deaf,
+      @Deprecated('Use "builder" parameter') Snowflake? channel = const Snowflake.zero(),
+      MemberBuilder? builder,
+      String? auditReason});
 }
 
 class Member extends SnowflakeEntity implements IMember {


### PR DESCRIPTION
# Description
Hotfix for the `builder` parameter not being exposed.

## Connected issues & other potential problems

If changes in PR are connected to other issues or are affecting code in other parts of framework
(e.g. in main package or any other subpackage) make sure to link issue/PR and describe said problem 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
