### PR TITLE
Add missing `ActivityType` of 3

### DIFF
--- a/lib/src/core/user/presence.dart
+++ b/lib/src/core/user/presence.dart
@@ -272,6 +272,9 @@ class ActivityType extends IEnum<int> {
   /// Status type when listening to Spotify
   static const ActivityType listening = ActivityType._create(2);
 
+  /// Status type when watching
+  static const ActivityType watching = ActivityType._create(3);
+
   /// Custom status, not supported for bot accounts
   static const ActivityType custom = ActivityType._create(4);
 

--- a/lib/src/utils/builders/presence_builder.dart
+++ b/lib/src/utils/builders/presence_builder.dart
@@ -26,6 +26,9 @@ class ActivityBuilder implements Builder {
   /// Sets activity to listening
   factory ActivityBuilder.listening(String name) => ActivityBuilder(name, ActivityType.listening);
 
+  /// Sets activity to watching
+  factory ActivityBuilder.watching(String name) => ActivityBuilder(name, ActivityType.watching);
+
   @override
   RawApiMap build() => {
         "name": name,


### PR DESCRIPTION
# Description

Fixes nyxx-discord/nyxx#275 | Adds missing `ActivityType` 3 ('Watching' presence)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] Ran `dart analyze` or `make analyze` and fixed all issues
- [ ] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
