### PR TITLE
bug: Fixup invalid formatting of emoji in BaseGuildEmoji

### DIFF
--- a/lib/src/core/message/guild_emoji.dart
+++ b/lib/src/core/message/guild_emoji.dart
@@ -31,7 +31,7 @@ abstract class BaseGuildEmoji extends SnowflakeEntity implements IBaseGuildEmoji
   BaseGuildEmoji(RawApiMap raw) : super(Snowflake(raw["id"]));
 
   @override
-  String formatForMessage() => "<:$id>";
+  String formatForMessage() => "<:nyxx:$id>";
 
   @override
   String encodeForAPI() => id.toString();


### PR DESCRIPTION
# Description

Fixup invalid formatting of emoji in BaseGuildEmoji

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
