### PR TITLE
Make IHttpResponseError sublass Exception

### DIFF
--- a/lib/src/internal/http/http_response.dart
+++ b/lib/src/internal/http/http_response.dart
@@ -61,7 +61,7 @@ class HttpResponseSuccess extends HttpResponse implements IHttpResponseSucess {
   HttpResponseSuccess(http.StreamedResponse response) : super(response);
 }
 
-abstract class IHttpResponseError implements IHttpResponse, Error {
+abstract class IHttpResponseError implements IHttpResponse, Error, Exception {
   /// Message why http request failed
   String get errorMessage;
 


### PR DESCRIPTION
# Description

Exceptions are described as "[A class] intended to convey information to the user about a failure, so that the error can be addressed programmatically. It is intended to be caught, and it should contain useful data fields."

Errors are described as "Error objects thrown in the case of a program failure. An `Error` object represents a program failure that the programmer should have avoided. [...] These are not errors that a caller should expect or catch - if they occur, the program is erroneous, and terminating the program may be the safest response."

Reading these two descriptions, it seems appropriate that `IHttpResponseError` should subclass `Exception` and not `Error`, as the program can continue after receiving one, are not always avoidable by the programmer, and should be caught and handled appropriately.

However, since removing the `Error` superclass would be a breaking change, this PR simply adds `Exception` to `IHttpResponseError`'s inheritance chain so it can be caught with `try { ... } on Exception { ... }` blocks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
