### PR TITLE
Fix target id property and add guild audit logs options

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -18,6 +18,7 @@ export "src/core/application/oauth2_application.dart" show IOAuth2Application;
 export 'src/core/audit_logs/audit_log.dart' show IAuditLog;
 export 'src/core/audit_logs/audit_log_change.dart' show ChangeKeyType, IAuditLogChange;
 export 'src/core/audit_logs/audit_log_entry.dart' show IAuditLogEntry, AuditLogEntryType;
+export 'src/core/audit_logs/audit_log_options.dart' show IAuditLogOptions;
 export 'src/core/channel/cacheable_text_channel.dart' show ICacheableTextChannel;
 export 'src/core/channel/channel.dart' show IChannel, ChannelType;
 export 'src/core/channel/dm_channel.dart' show IDMChannel;

--- a/lib/src/core/audit_logs/audit_log_entry.dart
+++ b/lib/src/core/audit_logs/audit_log_entry.dart
@@ -56,7 +56,7 @@ class AuditLogEntry extends SnowflakeEntity implements IAuditLogEntry {
   @override
   late final String? reason;
 
-  /// Creates na instance of [AuditLogEntry]
+  /// Creates an instance of [AuditLogEntry]
   AuditLogEntry(RawApiMap raw, INyxx client) : super(Snowflake(raw["id"] as String)) {
     targetId = raw["target_id"] as String;
 

--- a/lib/src/core/audit_logs/audit_log_entry.dart
+++ b/lib/src/core/audit_logs/audit_log_entry.dart
@@ -74,12 +74,7 @@ class AuditLogEntry extends SnowflakeEntity implements IAuditLogEntry {
       options = null;
     }
     
-
-    if(raw["reason"] != null) {
-      reason = raw["reason"] as String;
-    } else {
-      reason = null;
-    }
+    reason = raw["reason"] as String?;
   }
 }
 

--- a/lib/src/core/audit_logs/audit_log_entry.dart
+++ b/lib/src/core/audit_logs/audit_log_entry.dart
@@ -89,6 +89,9 @@ class AuditLogEntryType extends IEnum<int> {
   static const AuditLogEntryType memberBanRemove = AuditLogEntryType._create(23);
   static const AuditLogEntryType memberUpdate = AuditLogEntryType._create(24);
   static const AuditLogEntryType memberRoleUpdate = AuditLogEntryType._create(25);
+  static const AuditLogEntryType memberMove = AuditLogEntryType._create(26);
+  static const AuditLogEntryType memberDisconnect = AuditLogEntryType._create(27);
+  static const AuditLogEntryType botAdd = AuditLogEntryType._create(28);
   static const AuditLogEntryType roleCreate = AuditLogEntryType._create(30);
   static const AuditLogEntryType roleUpdate = AuditLogEntryType._create(31);
   static const AuditLogEntryType roleDelete = AuditLogEntryType._create(32);
@@ -108,6 +111,18 @@ class AuditLogEntryType extends IEnum<int> {
   static const AuditLogEntryType integrationCreate = AuditLogEntryType._create(80);
   static const AuditLogEntryType integrationUpdate = AuditLogEntryType._create(81);
   static const AuditLogEntryType integrationDelete = AuditLogEntryType._create(82);
+  static const AuditLogEntryType stageInstanceCreate = AuditLogEntryType._create(83);
+  static const AuditLogEntryType stageInstanceUpdate = AuditLogEntryType._create(84);
+  static const AuditLogEntryType stageInstanceDelete = AuditLogEntryType._create(85);
+  static const AuditLogEntryType stickerCreate = AuditLogEntryType._create(90);
+  static const AuditLogEntryType stickerUpdate = AuditLogEntryType._create(91);
+  static const AuditLogEntryType stickerDelete = AuditLogEntryType._create(92);
+  static const AuditLogEntryType guildScheduledEventCreate = AuditLogEntryType._create(100);
+  static const AuditLogEntryType guildScheduledEventUpdate = AuditLogEntryType._create(101);
+  static const AuditLogEntryType guildScheduledEventDelete = AuditLogEntryType._create(102);
+  static const AuditLogEntryType threadCreate = AuditLogEntryType._create(110);
+  static const AuditLogEntryType threadUpdate = AuditLogEntryType._create(111);
+  static const AuditLogEntryType threadDelete = AuditLogEntryType._create(112);
 
   const AuditLogEntryType._create(int value) : super(value);
 

--- a/lib/src/core/audit_logs/audit_log_entry.dart
+++ b/lib/src/core/audit_logs/audit_log_entry.dart
@@ -6,6 +6,7 @@ import 'package:nyxx/src/core/user/user.dart';
 import 'package:nyxx/src/internal/cache/cacheable.dart';
 import 'package:nyxx/src/typedefs.dart';
 import 'package:nyxx/src/utils/enum.dart';
+import 'package:nyxx/src/core/audit_logs/audit_log_options.dart';
 
 abstract class IAuditLogEntry implements SnowflakeEntity {
   /// Id of the affected entity (webhook, user, role, etc.)
@@ -21,7 +22,7 @@ abstract class IAuditLogEntry implements SnowflakeEntity {
   AuditLogEntryType get type;
 
   /// Additional info for certain action types
-  String? get options;
+  IAuditLogOptions? get options;
 
   /// The reason for the change
   String? get reason;
@@ -49,7 +50,7 @@ class AuditLogEntry extends SnowflakeEntity implements IAuditLogEntry {
 
   /// Additional info for certain action types
   @override
-  late final String? options;
+  late final IAuditLogOptions? options;
 
   /// The reason for the change
   @override
@@ -68,10 +69,17 @@ class AuditLogEntry extends SnowflakeEntity implements IAuditLogEntry {
     type = AuditLogEntryType._create(raw["action_type"] as int);
 
     if (raw["options"] != null) {
-      options = raw["options"] as String;
+      options = AuditLogOptions(raw["options"] as RawApiMap);
+    } else {
+      options = null;
     }
+    
 
-    reason = raw["reason"] as String;
+    if(raw["reason"] != null) {
+      reason = raw["reason"] as String;
+    } else {
+      reason = null;
+    }
   }
 }
 

--- a/lib/src/core/audit_logs/audit_log_entry.dart
+++ b/lib/src/core/audit_logs/audit_log_entry.dart
@@ -73,7 +73,7 @@ class AuditLogEntry extends SnowflakeEntity implements IAuditLogEntry {
     } else {
       options = null;
     }
-    
+
     reason = raw["reason"] as String?;
   }
 }

--- a/lib/src/core/audit_logs/audit_log_entry.dart
+++ b/lib/src/core/audit_logs/audit_log_entry.dart
@@ -57,7 +57,7 @@ class AuditLogEntry extends SnowflakeEntity implements IAuditLogEntry {
 
   /// Creates na instance of [AuditLogEntry]
   AuditLogEntry(RawApiMap raw, INyxx client) : super(Snowflake(raw["id"] as String)) {
-    targetId = raw["targetId"] as String;
+    targetId = raw["target_id"] as String;
 
     changes = [
       if (raw["changes"] != null)

--- a/lib/src/core/audit_logs/audit_log_options.dart
+++ b/lib/src/core/audit_logs/audit_log_options.dart
@@ -1,0 +1,107 @@
+import 'package:nyxx/nyxx.dart';
+
+/// Additionnal info for certain [action types](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events)
+abstract class IAuditLogOptions {
+  /// The channel in which the entites were targeted.
+  /// 
+  /// Shows only in: 
+  /// - [AuditLogEntryType.memberMove]; 
+  /// - [AuditLogEntryType.messagePin];
+  /// - [AuditLogEntryType.messageUnpin];
+  /// - [AuditLogEntryType.messageDelete];
+  /// - [AuditLogEntryType.stageInstanceCreate];
+  /// - [AuditLogEntryType.stageInstanceUpdate] and [AuditLogEntryType.stageInstanceDelete] action types
+  Snowflake? get channelId;
+
+  /// The number of entities targeted.
+  /// Shows only in: 
+  /// - [AuditLogEntryType.messageDelete];
+  /// - [AuditLogEntryType.messageBulkDelete];
+  /// - [AuditLogEntryType.memberDisconnect] and [AuditLogEntryType.memberMove] action types 
+  int? get count;
+
+  /// The number of days after which inactive users will be kicked.
+  /// Shows only in: [AuditLogEntryType.memberPrune] action types
+  String? get deleteMemberDelay;
+
+  /// Id of the overwritten entity.
+  /// Shows only in: 
+  /// - [AuditLogEntryType.channelOverwriteCreate];
+  /// - [AuditLogEntryType.channelOverwriteUpdate] and [AuditLogEntryType.channelOverwriteDelete] action types
+  Snowflake? get id;
+
+  /// The number of the members removed by the prune.
+  /// Shows only in: [AuditLogEntryType.memberPrune] action types
+  int? get pruneCount;
+
+  /// The id of the message that was targeted.
+  /// Shows only in: [AuditLogEntryType.messagePin] and [AuditLogEntryType.messageUnpin] action types
+  Snowflake? get messageId;
+
+  /// The name of the role that was targeted. (Not present if [overwrittenType] is `member`).
+  /// Shows only in: 
+  /// - [AuditLogEntryType.channelOverwriteCreate];
+  /// - [AuditLogEntryType.channelOverwriteUpdate] and [AuditLogEntryType.channelOverwriteDelete] action types
+  String? get roleName;
+
+  /// Type of overwritten entity.
+  /// One of: 
+  ///   - `role`
+  ///   - `member`
+  ///
+  /// Shows only in: 
+  String? get overwrittenType;
+
+  /// The constructor for the [IAuditLogOptions]
+  IAuditLogOptions(RawApiMap raw);
+}
+
+class AuditLogOptions implements IAuditLogOptions {
+  @override
+  late final Snowflake? channelId;
+
+  @override
+  late final int? count;
+
+  @override
+  late final String? deleteMemberDelay;
+
+  @override
+  late final Snowflake? id;
+
+  @override
+  late final int? pruneCount;
+
+  @override
+  late final Snowflake? messageId;
+
+  @override
+  late final String? roleName;
+
+  @override
+  late final String? overwrittenType;
+
+  AuditLogOptions(RawApiMap raw) {
+    channelId = (raw['channel_id'] as String?)?.toSnowflake();
+    count = raw['count'] as int?;
+    deleteMemberDelay = raw['delete_member_days'] as String?;
+    id = (raw['id'] as String?)?.toSnowflake();
+    pruneCount = (raw['members_removed'] as String?) != null ? int.parse(raw['members_removed'] as String) : null;
+    messageId = (raw['message_id'] as String?)?.toSnowflake();
+    roleName = raw['role_name'] as String?;
+    if(raw['type'] != null) {
+      switch(raw['type']) {
+        case '0':
+          overwrittenType = 'role';
+          break;
+        case '1':
+          overwrittenType = 'member';
+          break;
+        default:
+          overwrittenType = null;
+      }
+    } else {
+      overwrittenType = null;
+    }
+  }
+}

--- a/lib/src/core/audit_logs/audit_log_options.dart
+++ b/lib/src/core/audit_logs/audit_log_options.dart
@@ -24,7 +24,7 @@ abstract class IAuditLogOptions {
   String? get roleName;
 
   /// Type of overwritten entity.
-  /// One of: 
+  /// One of:
   ///   - `role`
   ///   - `member`
   String? get overwrittenType;
@@ -66,8 +66,8 @@ class AuditLogOptions implements IAuditLogOptions {
     pruneCount = (raw['members_removed'] as String?) != null ? int.parse(raw['members_removed'] as String) : null;
     messageId = (raw['message_id'] as String?)?.toSnowflake();
     roleName = raw['role_name'] as String?;
-    if(raw['type'] != null) {
-      switch(raw['type']) {
+    if (raw['type'] != null) {
+      switch (raw['type']) {
         case '0':
           overwrittenType = 'role';
           break;

--- a/lib/src/core/audit_logs/audit_log_options.dart
+++ b/lib/src/core/audit_logs/audit_log_options.dart
@@ -3,55 +3,30 @@ import 'package:nyxx/nyxx.dart';
 /// Additionnal info for certain [action types](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events)
 abstract class IAuditLogOptions {
   /// The channel in which the entites were targeted.
-  /// 
-  /// Shows only in: 
-  /// - [AuditLogEntryType.memberMove]; 
-  /// - [AuditLogEntryType.messagePin];
-  /// - [AuditLogEntryType.messageUnpin];
-  /// - [AuditLogEntryType.messageDelete];
-  /// - [AuditLogEntryType.stageInstanceCreate];
-  /// - [AuditLogEntryType.stageInstanceUpdate] and [AuditLogEntryType.stageInstanceDelete] action types
   Snowflake? get channelId;
 
   /// The number of entities targeted.
-  /// Shows only in: 
-  /// - [AuditLogEntryType.messageDelete];
-  /// - [AuditLogEntryType.messageBulkDelete];
-  /// - [AuditLogEntryType.memberDisconnect] and [AuditLogEntryType.memberMove] action types 
   int? get count;
 
   /// The number of days after which inactive users will be kicked.
-  /// Shows only in: [AuditLogEntryType.memberPrune] action types
   String? get deleteMemberDelay;
 
   /// Id of the overwritten entity.
-  /// Shows only in: 
-  /// - [AuditLogEntryType.channelOverwriteCreate];
-  /// - [AuditLogEntryType.channelOverwriteUpdate] and [AuditLogEntryType.channelOverwriteDelete] action types
   Snowflake? get id;
 
   /// The number of the members removed by the prune.
-  /// Shows only in: [AuditLogEntryType.memberPrune] action types
   int? get pruneCount;
 
   /// The id of the message that was targeted.
-  /// Shows only in: [AuditLogEntryType.messagePin] and [AuditLogEntryType.messageUnpin] action types
   Snowflake? get messageId;
 
   /// The name of the role that was targeted. (Not present if [overwrittenType] is `member`).
-  /// Shows only in: 
-  /// - [AuditLogEntryType.channelOverwriteCreate];
-  /// - [AuditLogEntryType.channelOverwriteUpdate] and [AuditLogEntryType.channelOverwriteDelete] action types
   String? get roleName;
 
   /// Type of overwritten entity.
   /// One of: 
   ///   - `role`
   ///   - `member`
-  ///
-  /// Shows only in: 
-  /// - [AuditLogEntryType.channelOverwriteCreate];
-  /// - [AuditLogEntryType.channelOverwriteUpdate] and [AuditLogEntryType.channelOverwriteDelete] action types
   String? get overwrittenType;
 
   /// The constructor for the [IAuditLogOptions]

--- a/lib/src/core/audit_logs/audit_log_options.dart
+++ b/lib/src/core/audit_logs/audit_log_options.dart
@@ -1,7 +1,7 @@
 import 'package:nyxx/nyxx.dart';
 
 /// Additionnal info for certain action types
-/// 
+///
 /// [Look here for more](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events)
 abstract class IAuditLogOptions {
   /// The channel in which the entites were targeted.
@@ -68,19 +68,15 @@ class AuditLogOptions implements IAuditLogOptions {
     pruneCount = (raw['members_removed'] as String?) != null ? int.parse(raw['members_removed'] as String) : null;
     messageId = (raw['message_id'] as String?)?.toSnowflake();
     roleName = raw['role_name'] as String?;
-    if (raw['type'] != null) {
-      switch (raw['type']) {
-        case '0':
-          overwrittenType = 'role';
-          break;
-        case '1':
-          overwrittenType = 'member';
-          break;
-        default:
-          overwrittenType = null;
-      }
-    } else {
-      overwrittenType = null;
+    switch (raw['type']) {
+      case '0':
+        overwrittenType = 'role';
+        break;
+      case '1':
+        overwrittenType = 'member';
+        break;
+      default:
+        overwrittenType = null;
     }
   }
 }

--- a/lib/src/core/audit_logs/audit_log_options.dart
+++ b/lib/src/core/audit_logs/audit_log_options.dart
@@ -62,7 +62,7 @@ class AuditLogOptions implements IAuditLogOptions {
 
   AuditLogOptions(RawApiMap raw) {
     channelId = (raw['channel_id'] as String?)?.toSnowflake();
-    count = raw['count']  != null ? int.parse(raw['count'] as String) : null;
+    count = raw['count'] != null ? int.parse(raw['count'] as String) : null;
     deleteMemberDelay = raw['delete_member_days'] as String?;
     id = (raw['id'] as String?)?.toSnowflake();
     pruneCount = (raw['members_removed'] as String?) != null ? int.parse(raw['members_removed'] as String) : null;

--- a/lib/src/core/audit_logs/audit_log_options.dart
+++ b/lib/src/core/audit_logs/audit_log_options.dart
@@ -62,7 +62,7 @@ class AuditLogOptions implements IAuditLogOptions {
 
   AuditLogOptions(RawApiMap raw) {
     channelId = (raw['channel_id'] as String?)?.toSnowflake();
-    count = raw['count'] as int?;
+    count = raw['count']  != null ? int.parse(raw['count'] as String) : null;
     deleteMemberDelay = raw['delete_member_days'] as String?;
     id = (raw['id'] as String?)?.toSnowflake();
     pruneCount = (raw['members_removed'] as String?) != null ? int.parse(raw['members_removed'] as String) : null;

--- a/lib/src/core/audit_logs/audit_log_options.dart
+++ b/lib/src/core/audit_logs/audit_log_options.dart
@@ -50,6 +50,8 @@ abstract class IAuditLogOptions {
   ///   - `member`
   ///
   /// Shows only in: 
+  /// - [AuditLogEntryType.channelOverwriteCreate];
+  /// - [AuditLogEntryType.channelOverwriteUpdate] and [AuditLogEntryType.channelOverwriteDelete] action types
   String? get overwrittenType;
 
   /// The constructor for the [IAuditLogOptions]

--- a/lib/src/core/audit_logs/audit_log_options.dart
+++ b/lib/src/core/audit_logs/audit_log_options.dart
@@ -67,7 +67,7 @@ class AuditLogOptions implements IAuditLogOptions {
   /// Type of overwritten entity.
   /// One of:
   ///  - `role`
-  /// - `member`
+  ///  - `member`
   @override
   late final String? overwrittenType;
 

--- a/lib/src/core/audit_logs/audit_log_options.dart
+++ b/lib/src/core/audit_logs/audit_log_options.dart
@@ -11,7 +11,7 @@ abstract class IAuditLogOptions {
   int? get count;
 
   /// The number of days after which inactive users will be kicked.
-  Duration? get deleteMemberDays;
+  Duration? get deleteMemberDuration;
 
   /// Id of the overwritten entity.
   Snowflake? get id;
@@ -46,7 +46,7 @@ class AuditLogOptions implements IAuditLogOptions {
 
   /// The number of days after which inactive users will be kicked.
   @override
-  late final Duration? deleteMemberDays;
+  late final Duration? deleteMemberDuration;
 
   /// Id of the overwritten entity.
   @override
@@ -74,7 +74,7 @@ class AuditLogOptions implements IAuditLogOptions {
   AuditLogOptions(RawApiMap raw) {
     channelId = (raw['channel_id'] as String?)?.toSnowflake();
     count = raw['count'] != null ? int.parse(raw['count'] as String) : null;
-    deleteMemberDays = (raw['delete_member_days'] as String?) != null ? Duration(days: int.parse(raw['delete_member_days'] as String)) : null;
+    deleteMemberDuration = (raw['delete_member_days'] as String?) != null ? Duration(days: int.parse(raw['delete_member_days'] as String)) : null;
     id = (raw['id'] as String?)?.toSnowflake();
     pruneCount = (raw['members_removed'] as String?) != null ? int.parse(raw['members_removed'] as String) : null;
     messageId = (raw['message_id'] as String?)?.toSnowflake();

--- a/lib/src/core/audit_logs/audit_log_options.dart
+++ b/lib/src/core/audit_logs/audit_log_options.dart
@@ -30,9 +30,6 @@ abstract class IAuditLogOptions {
   ///   - `role`
   ///   - `member`
   String? get overwrittenType;
-
-  /// The constructor for the [IAuditLogOptions]
-  IAuditLogOptions(RawApiMap raw);
 }
 
 class AuditLogOptions implements IAuditLogOptions {

--- a/lib/src/core/audit_logs/audit_log_options.dart
+++ b/lib/src/core/audit_logs/audit_log_options.dart
@@ -1,6 +1,8 @@
 import 'package:nyxx/nyxx.dart';
 
-/// Additionnal info for certain [action types](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events)
+/// Additionnal info for certain action types
+/// 
+/// [Look here for more](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events)
 abstract class IAuditLogOptions {
   /// The channel in which the entites were targeted.
   Snowflake? get channelId;

--- a/lib/src/core/audit_logs/audit_log_options.dart
+++ b/lib/src/core/audit_logs/audit_log_options.dart
@@ -36,27 +36,38 @@ abstract class IAuditLogOptions {
 }
 
 class AuditLogOptions implements IAuditLogOptions {
+  /// The channel in which the entites were targeted.
   @override
   late final Snowflake? channelId;
 
+  /// The number of entities targeted.
   @override
   late final int? count;
 
+  /// The number of days after which inactive users will be kicked.
   @override
   late final Duration? deleteMemberDays;
 
+  /// Id of the overwritten entity.
   @override
   late final Snowflake? id;
 
+  /// The number of the members removed by the prune.
   @override
   late final int? pruneCount;
 
+  /// The id of the message that was targeted.
   @override
   late final Snowflake? messageId;
 
+  /// The name of the role that was targeted. (Not present if [overwrittenType] is `member`).
   @override
   late final String? roleName;
 
+  /// Type of overwritten entity.
+  /// One of:
+  ///  - `role`
+  /// - `member`
   @override
   late final String? overwrittenType;
 

--- a/lib/src/core/audit_logs/audit_log_options.dart
+++ b/lib/src/core/audit_logs/audit_log_options.dart
@@ -11,7 +11,7 @@ abstract class IAuditLogOptions {
   int? get count;
 
   /// The number of days after which inactive users will be kicked.
-  String? get deleteMemberDelay;
+  Duration? get deleteMemberDays;
 
   /// Id of the overwritten entity.
   Snowflake? get id;
@@ -43,7 +43,7 @@ class AuditLogOptions implements IAuditLogOptions {
   late final int? count;
 
   @override
-  late final String? deleteMemberDelay;
+  late final Duration? deleteMemberDays;
 
   @override
   late final Snowflake? id;
@@ -63,7 +63,7 @@ class AuditLogOptions implements IAuditLogOptions {
   AuditLogOptions(RawApiMap raw) {
     channelId = (raw['channel_id'] as String?)?.toSnowflake();
     count = raw['count'] != null ? int.parse(raw['count'] as String) : null;
-    deleteMemberDelay = raw['delete_member_days'] as String?;
+    deleteMemberDays = (raw['delete_member_days'] as String?) != null ? Duration(days: int.parse(raw['delete_member_days'] as String)) : null;
     id = (raw['id'] as String?)?.toSnowflake();
     pruneCount = (raw['members_removed'] as String?) != null ? int.parse(raw['members_removed'] as String) : null;
     messageId = (raw['message_id'] as String?)?.toSnowflake();


### PR DESCRIPTION
Add options for guild audit logs, before was set as a string nullable
Also add new audit logs events & fix targetId.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
	- `targetId` does not throw error anymore
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
	- Audit logs options is now `IAuditLogOptions?` instead of `String?`
# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage