### PR TITLE
Fixes name and format never being initilized for PartialSticker

### DIFF
--- a/lib/src/core/message/sticker.dart
+++ b/lib/src/core/message/sticker.dart
@@ -1,12 +1,12 @@
-import 'package:nyxx/src/nyxx.dart';
+import 'package:nyxx/src/core/guild/guild.dart';
 import 'package:nyxx/src/core/snowflake.dart';
 import 'package:nyxx/src/core/snowflake_entity.dart';
-import 'package:nyxx/src/core/guild/guild.dart';
 import 'package:nyxx/src/core/user/user.dart';
 import 'package:nyxx/src/internal/cache/cacheable.dart';
+import 'package:nyxx/src/nyxx.dart';
 import 'package:nyxx/src/typedefs.dart';
-import 'package:nyxx/src/utils/enum.dart';
 import 'package:nyxx/src/utils/builders/sticker_builder.dart';
+import 'package:nyxx/src/utils/enum.dart';
 
 /// Base interface for all sticker types
 abstract class ISticker implements SnowflakeEntity {
@@ -80,7 +80,10 @@ class PartialSticker extends Sticker implements IPartialSticker {
   StickerType get type => StickerType.partial;
 
   /// Creates an instance of [PartialSticker]
-  PartialSticker(RawApiMap raw, INyxx client) : super(raw, client);
+  PartialSticker(RawApiMap raw, INyxx client) : super(raw, client) {
+    name = raw["name"] as String;
+    format = StickerFormat.from(raw["format_type"] as int);
+  }
 }
 
 abstract class IGuildSticker implements ISticker {


### PR DESCRIPTION
# Description

I initiated `name` and `format` for PartialSticker.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
