### PR TITLE
Add previous state to *UpdateEvents

### DIFF
--- a/lib/src/core/message/message.dart
+++ b/lib/src/core/message/message.dart
@@ -366,6 +366,32 @@ class Message extends SnowflakeEntity implements IMessage {
     ];
   }
 
+  Message.copy(Message other)
+      : client = other.client,
+        super(other.id) {
+    author = other.author;
+    content = other.content;
+    channel = other.channel;
+    editedTimestamp = other.editedTimestamp;
+    mentions = other.mentions;
+    embeds = other.embeds;
+    attachments = other.attachments;
+    pinned = other.pinned;
+    tts = other.tts;
+    mentionEveryone = other.mentionEveryone;
+    reactions = other.reactions;
+    type = other.type;
+    flags = other.flags;
+    partialStickers = other.partialStickers;
+    referencedMessage = other.referencedMessage;
+    components = other.components;
+    nonce = other.nonce;
+    applicationId = other.applicationId;
+    crossPostReference = other.crossPostReference;
+    member = other.member;
+    roleMentions = other.roleMentions;
+  }
+
   /// Suppresses embeds in message. Can be executed in other users messages.
   @override
   Future<IMessage> suppressEmbeds() => client.httpEndpoints.suppressMessageEmbeds(channel.id, id);

--- a/lib/src/events/channel_events.dart
+++ b/lib/src/events/channel_events.dart
@@ -93,6 +93,9 @@ class ChannelPinsUpdateEvent implements IChannelPinsUpdateEvent {
 abstract class IChannelUpdateEvent {
   /// The channel after the update.
   IChannel get updatedChannel;
+
+  /// The channel before the update, if it was cached.
+  IChannel? get oldChannel;
 }
 
 /// Sent when a channel is updated.
@@ -101,15 +104,18 @@ class ChannelUpdateEvent implements IChannelUpdateEvent {
   @override
   late final IChannel updatedChannel;
 
+  @override
+  late final IChannel? oldChannel;
+
   /// Creates na instance of [ChannelUpdateEvent]
   ChannelUpdateEvent(RawApiMap raw, INyxx client) {
     updatedChannel = Channel.deserialize(client, raw["d"] as RawApiMap);
 
-    final oldChannel = client.channels[updatedChannel.id];
+    oldChannel = client.channels[updatedChannel.id];
 
     // Move messages to new channel
     if (updatedChannel is ITextChannel && oldChannel is ITextChannel) {
-      (updatedChannel as ITextChannel).messageCache.addAll(oldChannel.messageCache);
+      (updatedChannel as ITextChannel).messageCache.addAll((oldChannel as ITextChannel).messageCache);
     }
 
     client.channels[updatedChannel.id] = updatedChannel;

--- a/lib/src/events/message_events.dart
+++ b/lib/src/events/message_events.dart
@@ -334,6 +334,9 @@ abstract class IMessageUpdateEvent {
   /// Edited message with updated fields
   IMessage? get updatedMessage;
 
+  /// The message before it was updated, if it was cached.
+  IMessage? get oldMessage;
+
   /// Id of channel where message was edited
   CacheableTextChannel<ITextChannel> get channel;
 
@@ -346,6 +349,9 @@ class MessageUpdateEvent implements IMessageUpdateEvent {
   /// Edited message with updated fields
   @override
   late final IMessage? updatedMessage;
+
+  @override
+  late final IMessage? oldMessage;
 
   /// Id of channel where message was edited
   @override
@@ -365,10 +371,13 @@ class MessageUpdateEvent implements IMessageUpdateEvent {
       return;
     }
 
-    updatedMessage = channelInstance.messageCache[messageId];
-    if (updatedMessage == null) {
+    oldMessage = channelInstance.messageCache[messageId];
+
+    if (oldMessage == null) {
       return;
     }
+
+    updatedMessage = Message.copy(oldMessage as Message);
 
     if (raw["d"]["content"] != updatedMessage!.content) {
       (updatedMessage! as Message).content = raw["d"]["content"].toString();
@@ -399,5 +408,7 @@ class MessageUpdateEvent implements IMessageUpdateEvent {
         for (final rawRow in raw['d']["components"]) [for (final componentRaw in rawRow["components"]) MessageComponent.deserialize(componentRaw as RawApiMap)]
       ];
     }
+
+    channelInstance.messageCache[messageId] = updatedMessage!;
   }
 }

--- a/lib/src/events/voice_state_update_event.dart
+++ b/lib/src/events/voice_state_update_event.dart
@@ -6,6 +6,9 @@ abstract class IVoiceStateUpdateEvent {
   /// Used to represent a user's voice connection status.
   IVoiceState get state;
 
+  /// The previous voice state, if it was cached.
+  IVoiceState? get oldState;
+
   /// Raw gateway response
   RawApiMap get raw;
 }
@@ -16,6 +19,9 @@ class VoiceStateUpdateEvent implements IVoiceStateUpdateEvent {
   @override
   late final IVoiceState state;
 
+  @override
+  late final IVoiceState? oldState;
+
   /// Raw gateway response
   @override
   final RawApiMap raw;
@@ -23,6 +29,8 @@ class VoiceStateUpdateEvent implements IVoiceStateUpdateEvent {
   /// Creates na instance of [VoiceStateUpdateEvent]
   VoiceStateUpdateEvent(this.raw, INyxx client) {
     state = VoiceState(client, raw["d"] as RawApiMap);
+
+    oldState = state.guild?.getFromCache()?.voiceStates[state.user.id];
 
     if (state.channel != null) {
       state.guild?.getFromCache()?.voiceStates[state.user.id] = state;


### PR DESCRIPTION
# Description

Exposes the state that was cached before the update event where it is possible. This allows user to see what actually changed in the state,

## Connected issues & other potential problems
 
Closes #300 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
