### PR TITLE
Allow editing messages to remove content

### DIFF
--- a/lib/src/core/audit_logs/audit_log_entry.dart
+++ b/lib/src/core/audit_logs/audit_log_entry.dart
@@ -67,11 +67,9 @@ class AuditLogEntry extends SnowflakeEntity implements IAuditLogEntry {
     user = UserCacheable(client, Snowflake(raw["user_id"]));
     type = AuditLogEntryType._create(raw["action_type"] as int);
 
-    if (raw["options"] != null) {
-      options = raw["options"] as String;
-    }
+    options = raw["options"] as String?;
 
-    reason = raw["reason"] as String;
+    reason = raw["reason"] as String?;
   }
 }
 

--- a/lib/src/core/embed/embed.dart
+++ b/lib/src/core/embed/embed.dart
@@ -107,52 +107,60 @@ class Embed implements IEmbed {
 
   /// Creates an instance [Embed]
   Embed(RawApiMap raw) {
-    if (raw["title"] != null) {
-      title = raw["title"] as String;
-    }
+    title = raw["title"] as String?;
 
-    if (raw["url"] != null) {
-      url = raw["url"] as String;
-    }
+    url = raw["url"] as String?;
 
-    if (raw["type"] != null) {
-      type = raw["type"] as String;
-    }
+    type = raw["type"] as String?;
 
-    if (raw["description"] != null) {
-      description = raw["description"] as String;
-    }
+    description = raw["description"] as String?;
 
     if (raw["timestamp"] != null) {
       timestamp = DateTime.parse(raw["timestamp"] as String);
+    } else {
+      timestamp = null;
     }
 
     if (raw["color"] != null) {
       color = DiscordColor.fromInt(raw["color"] as int);
+    } else {
+      color = null;
     }
 
     if (raw["author"] != null) {
       author = EmbedAuthor(raw["author"] as RawApiMap);
+    } else {
+      author = null;
     }
 
     if (raw["video"] != null) {
       video = EmbedVideo(raw["video"] as RawApiMap);
+    } else {
+      video = null;
     }
 
     if (raw["image"] != null) {
       image = EmbedThumbnail(raw["image"] as RawApiMap);
+    } else {
+      image = null;
     }
 
     if (raw["footer"] != null) {
       footer = EmbedFooter(raw["footer"] as RawApiMap);
+    } else {
+      footer = null;
     }
 
     if (raw["thumbnail"] != null) {
       thumbnail = EmbedThumbnail(raw["thumbnail"] as RawApiMap);
+    } else {
+      thumbnail = null;
     }
 
     if (raw["provider"] != null) {
       provider = EmbedProvider(raw["provider"] as RawApiMap);
+    } else {
+      provider = null;
     }
 
     fields = [

--- a/lib/src/core/embed/embed_provider.dart
+++ b/lib/src/core/embed/embed_provider.dart
@@ -20,12 +20,8 @@ class EmbedProvider implements IEmbedProvider {
 
   /// Creates an instance of [EmbedProvider]
   EmbedProvider(RawApiMap raw) {
-    if (raw["name"] != null) {
-      name = raw["name"] as String?;
-    }
+    name = raw["name"] as String?;
 
-    if (raw["url"] != null) {
-      url = raw["url"] as String?;
-    }
+    url = raw["url"] as String?;
   }
 }

--- a/lib/src/core/guild/guild.dart
+++ b/lib/src/core/guild/guild.dart
@@ -493,6 +493,7 @@ class Guild extends SnowflakeEntity implements IGuild {
     mfaLevel = raw["mfa_level"] as int;
     verificationLevel = raw["verification_level"] as int;
     notificationLevel = raw["default_message_notifications"] as int;
+    available = !(raw["unavailable"] as bool? ?? false);
 
     icon = raw["icon"] as String?;
     discoverySplash = raw["discoverySplash"] as String?;
@@ -525,10 +526,14 @@ class Guild extends SnowflakeEntity implements IGuild {
 
     if (raw["embed_channel_id"] != null) {
       embedChannel = ChannelCacheable(client, Snowflake(raw["embed_channel_id"]));
+    } else {
+      embedChannel = null;
     }
 
     if (raw["system_channel_id"] != null) {
       systemChannel = ChannelCacheable(client, Snowflake(raw["system_channel_id"]));
+    } else {
+      systemChannel = null;
     }
 
     features = (raw["features"] as RawApiList).map((e) => GuildFeature.from(e.toString()));
@@ -576,10 +581,14 @@ class Guild extends SnowflakeEntity implements IGuild {
 
     if (raw["rules_channel_id"] != null) {
       rulesChannel = ChannelCacheable(client, Snowflake(raw["rules_channel_id"]));
+    } else {
+      rulesChannel = null;
     }
 
     if (raw["public_updates_channel_id"] != null) {
       publicUpdatesChannel = CacheableTextChannel<ITextChannel>(client, Snowflake(raw["public_updates_channel_id"]));
+    } else {
+      publicUpdatesChannel = null;
     }
 
     stageInstances = [

--- a/lib/src/core/guild/guild_preview.dart
+++ b/lib/src/core/guild/guild_preview.dart
@@ -97,19 +97,13 @@ class GuildPreview extends SnowflakeEntity implements IGuildPreview {
   GuildPreview(this.client, RawApiMap raw) : super(Snowflake(raw["id"])) {
     name = raw["name"] as String;
 
-    if (iconHash != null) {
-      iconHash = raw["icon"] as String;
-    }
+    iconHash = raw["icon"] as String?;
 
-    if (splashHash != null) {
-      splashHash = raw["splash"] as String;
-    }
+    splashHash = raw["splash"] as String?;
 
-    if (discoveryHash != null) {
-      discoveryHash = raw["discovery_splash"] as String;
-    }
+    discoveryHash = raw["discovery_splash"] as String?;
 
-    emojis = [for (var rawEmoji in raw["emojis"]) GuildEmoji(client, rawEmoji as RawApiMap, id)];
+    emojis = [for (final rawEmoji in raw["emojis"]) GuildEmoji(client, rawEmoji as RawApiMap, id)];
 
     features = (raw["features"] as RawApiList).map((e) => GuildFeature.from(e.toString()));
 

--- a/lib/src/core/user/member.dart
+++ b/lib/src/core/user/member.dart
@@ -192,11 +192,6 @@ class Member extends SnowflakeEntity implements IMember {
 
     roles = [for (var id in raw["roles"]) RoleCacheable(client, Snowflake(id), guild)];
 
-    // TODO: remove this; hoisted_role is never present in member object
-    // if (raw["hoisted_role"] != null) {
-    //   hoistedRole = RoleCacheable(client, Snowflake(raw["hoisted_role"]), guild);
-    // }
-
     joinedAt = DateTime.parse(raw["joined_at"] as String).toUtc();
 
     if (client.cacheOptions.userCachePolicyLocation.objectConstructor) {

--- a/lib/src/core/user/member.dart
+++ b/lib/src/core/user/member.dart
@@ -131,6 +131,7 @@ class Member extends SnowflakeEntity implements IMember {
 
   /// Highest role of member
   @override
+  @Deprecated('Use `roles` and sort by position instead. Attempting to use this field will throw an error.')
   late final Cacheable<Snowflake, IRole> hoistedRole;
 
   /// When the user starting boosting the guild
@@ -191,13 +192,12 @@ class Member extends SnowflakeEntity implements IMember {
 
     roles = [for (var id in raw["roles"]) RoleCacheable(client, Snowflake(id), guild)];
 
-    if (raw["hoisted_role"] != null) {
-      hoistedRole = RoleCacheable(client, Snowflake(raw["hoisted_role"]), guild);
-    }
+    // TODO: remove this; hoisted_role is never present in member object
+    // if (raw["hoisted_role"] != null) {
+    //   hoistedRole = RoleCacheable(client, Snowflake(raw["hoisted_role"]), guild);
+    // }
 
-    if (raw["joined_at"] != null) {
-      joinedAt = DateTime.parse(raw["joined_at"] as String).toUtc();
-    }
+    joinedAt = DateTime.parse(raw["joined_at"] as String).toUtc();
 
     if (client.cacheOptions.userCachePolicyLocation.objectConstructor) {
       final userRaw = raw["user"] as RawApiMap;

--- a/lib/src/events/channel_events.dart
+++ b/lib/src/events/channel_events.dart
@@ -78,6 +78,8 @@ class ChannelPinsUpdateEvent implements IChannelPinsUpdateEvent {
   ChannelPinsUpdateEvent(RawApiMap raw, INyxx client) {
     if (raw["d"]["last_pin_timestamp"] != null) {
       lastPingTimestamp = DateTime.parse(raw["d"]["last_pin_timestamp"] as String);
+    } else {
+      lastPingTimestamp = null;
     }
 
     channel = CacheableTextChannel<ITextChannel>(client, Snowflake(raw["d"]["channel_id"]));

--- a/lib/src/internal/http_endpoints.dart
+++ b/lib/src/internal/http_endpoints.dart
@@ -1125,6 +1125,10 @@ class HttpEndpoints implements IHttpEndpoints {
 
   @override
   Future<IMessage> editMessage(Snowflake channelId, Snowflake messageId, MessageBuilder builder) async {
+    if (!builder.canBeUsedAsNewMessage()) {
+      return Future.error(ArgumentError("Cannot edit a message to have neither content nor embeds"));
+    }
+
     HttpResponse response;
     if (builder.hasFiles()) {
       response = await httpHandler.execute(MultipartRequest("/channels/$channelId/messages/$messageId", builder.getMappedFiles().toList(),

--- a/lib/src/utils/builders/embed_builder.dart
+++ b/lib/src/utils/builders/embed_builder.dart
@@ -39,7 +39,7 @@ class EmbedBuilder extends Builder {
   EmbedAuthorBuilder? author;
 
   /// Embed custom fields;
-  late final List<EmbedFieldBuilder> fields;
+  late List<EmbedFieldBuilder> fields;
 
   /// Creates clean instance [EmbedBuilder]
   EmbedBuilder() {

--- a/lib/src/utils/builders/message_builder.dart
+++ b/lib/src/utils/builders/message_builder.dart
@@ -152,13 +152,13 @@ class MessageBuilder {
   Future<IMessage> send(ISend entity) => entity.sendMessage(this);
 
   /// Returns if this instance of message builder can be used when editing message
-  bool canBeUsedAsNewMessage() => content.isNotEmpty || embeds != null || (files != null && files!.isNotEmpty);
+  bool canBeUsedAsNewMessage() => content.isNotEmpty || (embeds != null && embeds!.isNotEmpty) || (files != null && files!.isNotEmpty);
 
   RawApiMap build([AllowedMentions? defaultAllowedMentions]) {
     allowedMentions ??= defaultAllowedMentions;
 
     return <String, dynamic>{
-      if (content.isNotEmpty) "content": content.toString(),
+      "content": content.toString(),
       if (embeds != null) "embeds": [for (final e in embeds!) e.build()],
       if (allowedMentions != null) "allowed_mentions": allowedMentions!.build(),
       if (replyBuilder != null) "message_reference": replyBuilder!.build(),

--- a/test/integration/integration.dart
+++ b/test/integration/integration.dart
@@ -57,7 +57,7 @@ main() async {
 
     expect(guildPreview.discoveryURL(), isNull);
     expect(guildPreview.splashURL(), isNull);
-    expect(guildPreview.iconURL(), isNull);
+    expect(guildPreview.iconURL(), isNotNull);
   });
 
   test("basic message functionality", () async {
@@ -123,11 +123,9 @@ main() async {
 
     expect(message.attachments, hasLength(2));
 
-    final editedMessage = await message.edit(
-      MessageBuilder()
-          ..attachments = [message.attachments.first.toBuilder()]
-          ..files = [AttachmentBuilder.path('test/files/3.png')]
-    );
+    final editedMessage = await message.edit(MessageBuilder()
+      ..attachments = [message.attachments.first.toBuilder()]
+      ..files = [AttachmentBuilder.path('test/files/3.png')]);
 
     expect(editedMessage.attachments, hasLength(2));
 

--- a/test/unit/builders_test.dart
+++ b/test/unit/builders_test.dart
@@ -162,6 +162,7 @@ main() {
       expect(
           result,
           equals({
+            'content': '',
             'embeds': [
               {'description': 'test1'},
               {'description': 'test2'}


### PR DESCRIPTION
# Description

Includes `content` field in message payload even if it is empty to allow users to edit their messages to remove content. Also includes some fixes concerning `late final` fields that were not always initialised correctly.

## Connected issues & other potential problems

Closes #312

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
