### PR TITLE
Fix member not being initialiased in IMessage

### DIFF
--- a/lib/src/core/message/message.dart
+++ b/lib/src/core/message/message.dart
@@ -358,6 +358,8 @@ class Message extends SnowflakeEntity implements IMessage {
       if (client.cacheOptions.memberCachePolicyLocation.objectConstructor && client.cacheOptions.memberCachePolicy.canCache(member!)) {
         guild?.getFromCache()?.members[member!.id] = member!;
       }
+    } else {
+      member = null;
     }
 
     roleMentions = [


### PR DESCRIPTION
# Description

Fix an issue with the member field not being initialised in the Message constructor when no member was received from the Discord API.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
