### PR TITLE
Add `@bannerUrl()` method

### DIFF
--- a/lib/src/core/user/user.dart
+++ b/lib/src/core/user/user.dart
@@ -163,7 +163,7 @@ class User extends SnowflakeEntity implements IUser {
 
   /// The user's banner url.
   @override
-  String? bannerUrl({String? format, int? size}) => client.httpEndpoints.userBannerURL(id, bannerHash, format: format, size: size);
+  String? bannerUrl({String? format, int? size}) => client.httpEndpoints.getUserBannerURL(id, bannerHash, format: format, size: size);
 
   /// Sends a message to user.
   @override

--- a/lib/src/core/user/user.dart
+++ b/lib/src/core/user/user.dart
@@ -50,6 +50,9 @@ abstract class IUser implements SnowflakeEntity, ISend, Mentionable, IMessageAut
 
   /// Gets the [DMChannel] for the user.
   FutureOr<IDMChannel> get dmChannel;
+
+  /// The user's banner url.
+  String? bannerUrl({String? format, int? size});
 }
 
 /// Represents a single user of Discord, either a human or a bot, outside of any specific guild's context.
@@ -157,6 +160,10 @@ class User extends SnowflakeEntity implements IUser {
   /// In case if user does not have avatar, default discord avatar will be returned with specified size and png format.
   @override
   String avatarURL({String format = "webp", int size = 128}) => client.httpEndpoints.userAvatarURL(id, avatar, discriminator, format: format, size: size);
+
+  /// The user's banner url.
+  @override
+  String? bannerUrl({String? format, int? size}) => client.httpEndpoints.userBannerURL(id, bannerHash, format: format, size: size);
 
   /// Sends a message to user.
   @override

--- a/lib/src/core/user/user.dart
+++ b/lib/src/core/user/user.dart
@@ -163,7 +163,7 @@ class User extends SnowflakeEntity implements IUser {
 
   /// The user's banner url.
   @override
-  String? bannerUrl({String? format, int? size}) => client.httpEndpoints.getUserBannerURL(id, bannerHash, format: format, size: size);
+  String? bannerUrl({String? format, int? size}) => client.httpEndpoints.userBannerURL(id, bannerHash, format: format, size: size);
 
   /// Sends a message to user.
   @override

--- a/lib/src/internal/http_endpoints.dart
+++ b/lib/src/internal/http_endpoints.dart
@@ -170,6 +170,9 @@ abstract class IHttpEndpoints {
   /// Returns url to user avatar
   String userAvatarURL(Snowflake userId, String? avatarHash, int discriminator, {String format = "webp", int size = 128});
 
+  /// Returns url to user banner
+  String? userBannerURL(Snowflake userId, String? bannerHash, {String? format, int? size});
+
   /// Returns url to member avatar url
   String memberAvatarURL(Snowflake memberId, Snowflake guildId, String avatarHash, {String format = "webp"});
 
@@ -858,6 +861,31 @@ class HttpEndpoints implements IHttpEndpoints {
     }
 
     return "https://cdn.${Constants.cdnHost}/embed/avatars/${discriminator % 5}.png?size=$size";
+  }
+
+  @override
+  String? userBannerURL(Snowflake userId, String? bannerHash, {String? format, int? size}) {
+    if (bannerHash != null) {
+      var url = "${Constants.cdnUrl}/banners/$userId/$bannerHash.";
+
+      if (format == null) {
+        if (bannerHash.startsWith("a_")) {
+          url += "gif";
+        } else {
+          url += "webp";
+        }
+      } else {
+        url += format;
+      }
+
+      if (size != null) {
+        url += "?size=$size";
+      }
+
+      return url;
+    }
+
+    return null;
   }
 
   @override

--- a/lib/src/internal/http_endpoints.dart
+++ b/lib/src/internal/http_endpoints.dart
@@ -394,7 +394,7 @@ abstract class IHttpEndpoints {
   Future<void> deleteGuildSticker(Snowflake guildId, Snowflake stickerId);
 
   /// Returns url of user banner
-  String? getUserBannerURL(Snowflake userId, String? hash, {String? format, int? size});
+  String? userBannerURL(Snowflake userId, String? hash, {String? format, int? size});
 
   Stream<GuildEvent> fetchGuildEvents(Snowflake guildId, {bool withUserCount = false});
   Future<GuildEvent> createGuildEvent(Snowflake guildId, GuildEventBuilder builder);
@@ -1583,28 +1583,29 @@ class HttpEndpoints implements IHttpEndpoints {
       "${Constants.cdnUrl}/guilds/$guildId/users/$memberId/avatars/$avatarHash.$format";
 
   @override
-  String? getUserBannerURL(Snowflake userId, String? hash, {String? format, int? size}) {
-    if (hash != null) {
-      var url = "${Constants.cdnUrl}/banners/$userId/$hash.";
 
-      if (format == null) {
-        if (hash.startsWith("a_")) {
-          url += "gif";
-        } else {
-          url += "webp";
-        }
+  @override
+  String? userBannerURL(Snowflake userId, String? hash, {String? format, int? size}) {
+    if (hash == null) {
+      return null;
+    }
+    var url = "${Constants.cdnUrl}/banners/$userId/$hash.";
+
+    if (format == null) {
+      if (hash.startsWith("a_")) {
+        url += "gif";
       } else {
-        url += format;
+        url += "webp";
       }
-
-      if (size != null) {
-        url += "?size=$size";
-      }
-
-      return url;
+    } else {
+      url += format;
     }
 
-    return null;
+    if (size != null) {
+      url += "?size=$size";
+    }
+
+    return url;
   }
 
   @override

--- a/lib/src/internal/http_endpoints.dart
+++ b/lib/src/internal/http_endpoints.dart
@@ -170,9 +170,6 @@ abstract class IHttpEndpoints {
   /// Returns url to user avatar
   String userAvatarURL(Snowflake userId, String? avatarHash, int discriminator, {String format = "webp", int size = 128});
 
-  /// Returns url to user banner
-  String? userBannerURL(Snowflake userId, String? bannerHash, {String? format, int? size});
-
   /// Returns url to member avatar url
   String memberAvatarURL(Snowflake memberId, Snowflake guildId, String avatarHash, {String format = "webp"});
 
@@ -397,7 +394,7 @@ abstract class IHttpEndpoints {
   Future<void> deleteGuildSticker(Snowflake guildId, Snowflake stickerId);
 
   /// Returns url of user banner
-  String getUserBannerURL(Snowflake userId, String hash, {String format = "png"});
+  String? getUserBannerURL(Snowflake userId, String? hash, {String? format, int? size});
 
   Stream<GuildEvent> fetchGuildEvents(Snowflake guildId, {bool withUserCount = false});
   Future<GuildEvent> createGuildEvent(Snowflake guildId, GuildEventBuilder builder);
@@ -861,31 +858,6 @@ class HttpEndpoints implements IHttpEndpoints {
     }
 
     return "https://cdn.${Constants.cdnHost}/embed/avatars/${discriminator % 5}.png?size=$size";
-  }
-
-  @override
-  String? userBannerURL(Snowflake userId, String? bannerHash, {String? format, int? size}) {
-    if (bannerHash != null) {
-      var url = "${Constants.cdnUrl}/banners/$userId/$bannerHash.";
-
-      if (format == null) {
-        if (bannerHash.startsWith("a_")) {
-          url += "gif";
-        } else {
-          url += "webp";
-        }
-      } else {
-        url += format;
-      }
-
-      if (size != null) {
-        url += "?size=$size";
-      }
-
-      return url;
-    }
-
-    return null;
   }
 
   @override
@@ -1611,7 +1583,29 @@ class HttpEndpoints implements IHttpEndpoints {
       "${Constants.cdnUrl}/guilds/$guildId/users/$memberId/avatars/$avatarHash.$format";
 
   @override
-  String getUserBannerURL(Snowflake userId, String hash, {String format = "png"}) => "${Constants.cdnUrl}/banners/$userId/$hash.$format";
+  String? getUserBannerURL(Snowflake userId, String? hash, {String? format, int? size}) {
+    if (hash != null) {
+      var url = "${Constants.cdnUrl}/banners/$userId/$hash.";
+
+      if (format == null) {
+        if (hash.startsWith("a_")) {
+          url += "gif";
+        } else {
+          url += "webp";
+        }
+      } else {
+        url += format;
+      }
+
+      if (size != null) {
+        url += "?size=$size";
+      }
+
+      return url;
+    }
+
+    return null;
+  }
 
   @override
   String getRoleIconUrl(Snowflake roleId, String iconHash, String format, int size) => "${Constants.cdnUrl}/role-icons/$roleId/$iconHash.$format?size=$size";


### PR DESCRIPTION
# Description
Add a `@bannerUrl` method on `IUser` class because all properties related to users banners was `bannerHash`.

## Connected issues & other potential problems
Complete #154 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
	- Add `@bannerUrl` method on `IUser`

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
