### PR TITLE
Correct signature of StageVoiceGuildChannel

### DIFF
--- a/lib/src/core/channel/guild/voice_channel.dart
+++ b/lib/src/core/channel/guild/voice_channel.dart
@@ -207,20 +207,24 @@ abstract class IStageVoiceGuildChannel implements IVoiceGuildChannel {
   Future<IStageChannelInstance> updateStageChannelInstance(String topic, {StageChannelInstancePrivacyLevel? privacyLevel});
 }
 
-class StageVoiceGuildChannel extends VoiceGuildChannel {
+class StageVoiceGuildChannel extends VoiceGuildChannel implements IStageVoiceGuildChannel {
   StageVoiceGuildChannel(INyxx client, RawApiMap raw, [Snowflake? guildId]) : super(client, raw, guildId);
 
   /// Gets the stage instance associated with the Stage channel, if it exists.
+  @override
   Future<IStageChannelInstance> getStageChannelInstance() => client.httpEndpoints.getStageChannelInstance(id);
 
   /// Deletes the Stage instance.
+  @override
   Future<void> deleteStageChannelInstance() => client.httpEndpoints.deleteStageChannelInstance(id);
 
   /// Creates a new Stage instance associated to a Stage channel.
+  @override
   Future<IStageChannelInstance> createStageChannelInstance(String topic, {StageChannelInstancePrivacyLevel? privacyLevel}) =>
       client.httpEndpoints.createStageChannelInstance(id, topic, privacyLevel: privacyLevel);
 
   /// Updates fields of an existing Stage instance.
+  @override
   Future<IStageChannelInstance> updateStageChannelInstance(String topic, {StageChannelInstancePrivacyLevel? privacyLevel}) =>
       client.httpEndpoints.updateStageChannelInstance(id, topic, privacyLevel: privacyLevel);
 }


### PR DESCRIPTION
# Description

Small change to correct the signature of the internal StageVoiceGuildChannel class.

## Connected issues & other potential problems

The new `stageVoiceGuildChannelConverter` from nyxx_commands does currently not work due to this issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
