### PR TITLE
bug: Remove Error from IHttpResponseError

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -138,7 +138,7 @@ export 'src/internal/exceptions/invalid_shard_exception.dart' show InvalidShardE
 export 'src/internal/exceptions/invalid_snowflake_exception.dart' show InvalidSnowflakeException;
 export 'src/internal/exceptions/missing_token_error.dart' show MissingTokenError;
 export 'src/internal/exceptions/unrecoverable_nyxx_error.dart' show UnrecoverableNyxxError;
-export 'src/internal/http/http_response.dart' show IHttpResponse, IHttpResponseError, IHttpResponseSucess;
+export 'src/internal/http/http_response.dart' show IHttpResponse, IHttpResponseError, IHttpResponseSuccess;
 export 'src/internal/interfaces/convertable.dart' show Convertable;
 export 'src/internal/interfaces/disposable.dart' show Disposable;
 export 'src/internal/interfaces/message_author.dart' show IMessageAuthor;

--- a/lib/src/internal/connection_manager.dart
+++ b/lib/src/internal/connection_manager.dart
@@ -30,7 +30,7 @@ class ConnectionManager {
     final httpResponse = await (client.httpEndpoints as HttpEndpoints).getGatewayBot();
 
     if (httpResponse is HttpResponseError) {
-      throw UnrecoverableNyxxError("Cannot get gateway url: [${httpResponse.errorCode}; ${httpResponse.errorMessage}]");
+      throw UnrecoverableNyxxError("Cannot get gateway url: [${httpResponse.code}; ${httpResponse.message}]");
     }
 
     final response = httpResponse as HttpResponseSuccess;

--- a/lib/src/internal/http/http_handler.dart
+++ b/lib/src/internal/http/http_handler.dart
@@ -97,7 +97,7 @@ class HttpHandler {
     await responseError.finalize();
 
     (client.eventsRest as RestEventController).onHttpErrorController.add(HttpErrorEvent(responseError));
-    logger.finer("Got failure http response for endpoint: [${response.request?.url.toString()}]; Response: [${responseError.errorMessage}]");
+    logger.finer("Got failure http response for endpoint: [${response.request?.url.toString()}]; Response: [${responseError.message}]");
 
     return responseError;
   }

--- a/lib/src/internal/http/http_response.dart
+++ b/lib/src/internal/http/http_response.dart
@@ -39,7 +39,7 @@ abstract class HttpResponse implements IHttpResponse {
   }
 }
 
-abstract class IHttpResponseSucess implements IHttpResponse {
+abstract class IHttpResponseSuccess implements IHttpResponse {
   /// Body of response
   List<int> get body;
 
@@ -48,7 +48,7 @@ abstract class IHttpResponseSucess implements IHttpResponse {
 }
 
 /// Returned when http request is successfully executed.
-class HttpResponseSuccess extends HttpResponse implements IHttpResponseSucess {
+class HttpResponseSuccess extends HttpResponse implements IHttpResponseSuccess {
   /// Body of response
   @override
   List<int> get body => _body;
@@ -61,12 +61,12 @@ class HttpResponseSuccess extends HttpResponse implements IHttpResponseSucess {
   HttpResponseSuccess(http.StreamedResponse response) : super(response);
 }
 
-abstract class IHttpResponseError implements IHttpResponse, Error, Exception {
+abstract class IHttpResponseError implements IHttpResponse, Exception {
   /// Message why http request failed
-  String get errorMessage;
+  String get message;
 
   /// Error code of response
-  int get errorCode;
+  int get code;
 }
 
 /// Returned when client fails to execute http request.
@@ -74,20 +74,20 @@ abstract class IHttpResponseError implements IHttpResponse, Error, Exception {
 class HttpResponseError extends HttpResponse implements IHttpResponseError {
   /// Message why http request failed
   @override
-  late String errorMessage;
+  late String message;
 
   /// Error code of response
   @override
-  late int errorCode;
+  late int code;
 
   /// Creates an instance of [HttpResponseError]
   HttpResponseError(http.StreamedResponse response) : super(response) {
     if (response.headers["Content-Type"] == "application/json") {
-      errorCode = _jsonBody["code"] as int;
-      errorMessage = _jsonBody["message"] as String;
+      code = _jsonBody["code"] as int;
+      message = _jsonBody["message"] as String;
     } else {
-      errorMessage = "";
-      errorCode = response.statusCode;
+      message = "";
+      code = response.statusCode;
     }
   }
 
@@ -95,16 +95,13 @@ class HttpResponseError extends HttpResponse implements IHttpResponseError {
   Future<void> finalize() async {
     await super.finalize();
 
-    if (errorMessage.isEmpty) {
+    if (message.isEmpty) {
       try {
-        errorMessage = utf8.decode(_body);
+        message = utf8.decode(_body);
       } on Exception {} // ignore: empty_catches
     }
   }
 
   @override
-  String toString() => "[Code: $errorCode] [Message: $errorMessage]";
-
-  @override
-  StackTrace? get stackTrace => null;
+  String toString() => "[Code: $code] [Message: $message]";
 }

--- a/lib/src/internal/http_endpoints.dart
+++ b/lib/src/internal/http_endpoints.dart
@@ -1596,7 +1596,7 @@ class HttpEndpoints implements IHttpEndpoints {
       return Future.error(result);
     }
 
-    return ThreadMember(client, (result as IHttpResponseSucess).jsonBody as RawApiMap, GuildCacheable(client, guildId));
+    return ThreadMember(client, (result as IHttpResponseSuccess).jsonBody as RawApiMap, GuildCacheable(client, guildId));
   }
 
   @override
@@ -1618,7 +1618,7 @@ class HttpEndpoints implements IHttpEndpoints {
       return Future.error(response);
     }
 
-    return GuildEvent((response as IHttpResponseSucess).jsonBody as RawApiMap, client);
+    return GuildEvent((response as IHttpResponseSuccess).jsonBody as RawApiMap, client);
   }
 
   @override
@@ -1633,7 +1633,7 @@ class HttpEndpoints implements IHttpEndpoints {
       return Future.error(response);
     }
 
-    return GuildEvent((response as IHttpResponseSucess).jsonBody as RawApiMap, client);
+    return GuildEvent((response as IHttpResponseSuccess).jsonBody as RawApiMap, client);
   }
 
   @override
@@ -1644,7 +1644,7 @@ class HttpEndpoints implements IHttpEndpoints {
       return Future.error(response);
     }
 
-    return GuildEvent((response as IHttpResponseSucess).jsonBody as RawApiMap, client);
+    return GuildEvent((response as IHttpResponseSuccess).jsonBody as RawApiMap, client);
   }
 
   @override
@@ -1661,7 +1661,7 @@ class HttpEndpoints implements IHttpEndpoints {
       yield* Stream.error(response);
     }
 
-    for (final rawGuildEventUser in (response as IHttpResponseSucess).jsonBody as RawApiList) {
+    for (final rawGuildEventUser in (response as IHttpResponseSuccess).jsonBody as RawApiList) {
       yield GuildEventUser(rawGuildEventUser as RawApiMap, client, guildId);
     }
   }
@@ -1675,7 +1675,7 @@ class HttpEndpoints implements IHttpEndpoints {
       yield* Stream.error(response);
     }
 
-    for (final rawGuildEvent in (response as IHttpResponseSucess).jsonBody as RawApiList) {
+    for (final rawGuildEvent in (response as IHttpResponseSuccess).jsonBody as RawApiList) {
       yield GuildEvent(rawGuildEvent as RawApiMap, client);
     }
   }


### PR DESCRIPTION
# Description

* Removes `Error` from `IHttpResponseError`
* Fixes name of `HttpResponseSuccess`
* Simplifies names of properties on `IHttpResponseError`

## Connected issues & other potential problems

Fixes #304

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
