### PR TITLE
Hotfix: Allow members to be disconnected by IMember.edit()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.4.2
+__22.04.2022__
+
+- bug: Fix setting `channel` to `null` in MemberBuilder causing errors
+
 ## 3.4.1
 __10.04.2022__
 

--- a/lib/src/utils/builders/member_builder.dart
+++ b/lib/src/utils/builders/member_builder.dart
@@ -25,7 +25,7 @@ class MemberBuilder implements Builder {
         if (roles != null) 'roles': roles!.map((e) => e.toString()).toList(),
         if (mute != null) 'mute': mute,
         if (deaf != null) 'deaf': deaf,
-        if (channel != Snowflake.zero()) 'channel_id': channel.toString(),
+        if (channel != Snowflake.zero()) 'channel_id': channel?.toString(),
         if (timeoutUntil?.millisecondsSinceEpoch != 0) 'communication_disabled_until': timeoutUntil?.toIso8601String(),
       };
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx
-version: 3.4.1
+version: 3.4.2
 description: A Discord library for Dart. Simple, robust framework for creating discord bots for Dart language.
 homepage: https://github.com/nyxx-discord/nyxx
 repository: https://github.com/nyxx-discord/nyxx


### PR DESCRIPTION
# Description

Fixes an issue where members could not be disconnected from voice channels due to `"null"` being sent instead of `null` when `MemberBuilder.channel` is set to `null`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
