### PR TITLE
Remove redundant argument

### DIFF
--- a/lib/src/core/guild/guild.dart
+++ b/lib/src/core/guild/guild.dart
@@ -290,7 +290,7 @@ abstract class IGuild implements SnowflakeEntity {
   Future<void> kick(SnowflakeEntity user, {String? auditReason});
 
   /// Unbans a user by ID.
-  Future<void> unban(Snowflake id, Snowflake userId);
+  Future<void> unban(Snowflake userId);
 
   /// Edits the guild.
   Future<IGuild> edit(GuildBuilder builder, {String? auditReason});
@@ -828,7 +828,7 @@ class Guild extends SnowflakeEntity implements IGuild {
 
   /// Unbans a user by ID.
   @override
-  Future<void> unban(Snowflake id, Snowflake userId) => client.httpEndpoints.guildUnban(this.id, userId);
+  Future<void> unban(Snowflake userId) => client.httpEndpoints.guildUnban(id, userId);
 
   /// Edits the guild.
   @override


### PR DESCRIPTION
# Description

The `unban(id, userId)` method on `IGuild` takes an ID as its first argument but never uses it. The signature seems to follow the signature of the underlying `unban(guildId, userId)` call, but its first argument is filled by the caller `IGuild`. Since the argument is required and non-nullable, it cannot be easily avoided, therefore I removed it.

## Connected issues & other potential problems

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
