### PR TITLE
Remove thread archive duration

### DIFF
--- a/lib/src/core/guild/guild_feature.dart
+++ b/lib/src/core/guild/guild_feature.dart
@@ -47,12 +47,6 @@ class GuildFeature extends IEnum<String> {
   /// Guild has increased custom sticker slots
   static const GuildFeature moreStickers = GuildFeature._create("MORE_STICKERS");
 
-  /// Guild has access to the three day archive time for threads
-  static const GuildFeature threeDayThreadArchive = GuildFeature._create("THREE_DAY_THREAD_ARCHIVE");
-
-  /// Guild has access to the seven day archive time for threads
-  static const GuildFeature sevenDayThreadArchive = GuildFeature._create("SEVEN_DAY_THREAD_ARCHIVE");
-
   /// Guild has access to create private threads
   static const GuildFeature privateThreadsEnabled = GuildFeature._create("PRIVATE_THREADS");
 


### PR DESCRIPTION
# Description
3 and 7 days archive duration no longer require boosting the server.
Didn't marked this as deprecated as I'm targeting `next`.

Addresses #339 

Edit: Sorry for the title, seems that Github is doing some weird things

## Connected issues & other potential problems
[#4825 - dapi docs](https://github.com/discord/discord-api-docs/pull/4825)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
