### PR TITLE
Implement graceful shutdown

### DIFF
--- a/lib/src/internal/shard/shard.dart
+++ b/lib/src/internal/shard/shard.dart
@@ -550,8 +550,10 @@ class Shard implements IShard {
     _sendPort.send({"cmd": "KILL"});
 
     final killFuture = _receiveStream.firstWhere((element) => (element as RawApiMap)["cmd"] == "TERMINATE_OK");
-    _shardIsolate.kill(priority: Isolate.immediate);
     await killFuture;
+
+    _receivePort.close();
+    _heartbeatTimer.cancel();
 
     manager.logger.info("Shard $id disposed.");
   }

--- a/lib/src/internal/shard/shard_manager.dart
+++ b/lib/src/internal/shard/shard_manager.dart
@@ -186,9 +186,9 @@ class ShardManager implements IShardManager {
 
     for (final shard in _shards.values) {
       if (connectionManager.client.options.shutdownShardHook != null) {
-        connectionManager.client.options.shutdownShardHook!(connectionManager.client, shard); // ignore: unawaited_futures
+        await connectionManager.client.options.shutdownShardHook!(connectionManager.client, shard);
       }
-      shard.dispose(); // ignore: unawaited_futures
+      await shard.dispose();
     }
 
     await onConnectController.close();

--- a/lib/src/nyxx.dart
+++ b/lib/src/nyxx.dart
@@ -220,6 +220,10 @@ class NyxxRest extends INyxxRest {
       await plugin.onBotStop(this, _logger);
     }
 
+    await eventsRest.dispose();
+
+    onReadyController.close();
+
     await guilds.dispose();
     await users.dispose();
     await channels.dispose();
@@ -333,7 +337,7 @@ abstract class INyxxWebsocket implements INyxxRest {
 /// ```
 /// or setup `CommandsFramework` and `Voice`.
 class NyxxWebsocket extends NyxxRest implements INyxxWebsocket {
-  late final ConnectionManager ws; // ignore: unused_field
+  late final ConnectionManager ws;
 
   /// Current client"s shard
   @override
@@ -457,14 +461,15 @@ class NyxxWebsocket extends NyxxRest implements INyxxWebsocket {
   Future<void> dispose() async {
     _logger.info("Disposing and closing bot...");
 
+    await super.dispose();
+
     if (options.shutdownHook != null) {
       await options.shutdownHook!(this);
     }
 
     await shardManager.dispose();
-    await eventsRest.dispose();
+    await eventsWs.dispose();
 
-    _logger.info("Exiting...");
-    throw UnrecoverableNyxxError('Exiting nyxx...');
+    _logger.info("Bot disposed.");
   }
 }

--- a/lib/src/plugin/plugins/logging.dart
+++ b/lib/src/plugin/plugins/logging.dart
@@ -1,12 +1,10 @@
-import 'dart:async';
-
 import 'package:logging/logging.dart';
 import 'package:nyxx/src/nyxx.dart';
 import 'package:nyxx/src/plugin/plugin.dart';
 
 class Logging extends BasePlugin {
   @override
-  FutureOr<void> onRegister(INyxx nyxx, Logger logger) {
+  void onRegister(INyxx nyxx, Logger logger) {
     Logger.root.onRecord.listen((LogRecord rec) {
       print("[${rec.time}] [${rec.level.name}] [${rec.loggerName}] ${rec.message}");
     });


### PR DESCRIPTION
# Description

Allows nyxx clients to be disposed gracefully without throwing any errors. Also cleans up the disposing process, fixing resources that weren't disposed previously or weren't themselves disposed gradefully.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
