### PR TITLE
feature: Add `threadName` on `IWebhook#execute()`

### DIFF
--- a/lib/src/core/guild/webhook.dart
+++ b/lib/src/core/guild/webhook.dart
@@ -74,7 +74,9 @@ abstract class IWebhook implements SnowflakeEntity, IMessageAuthor {
   ///
   /// [wait] - waits for server confirmation of message send before response,
   /// and returns the created message body (defaults to false; when false a message that is not save does not return an error)
-  Future<IMessage?> execute(MessageBuilder builder, {bool wait = true, Snowflake? threadId, String? avatarUrl, String? username});
+  /// [threadId] is the id of thread in the channel to send to.
+  /// If [threadName] is specified, this will create a thread in the forum channel with the given name - **this is only available for forum channels.**
+  Future<IMessage?> execute(MessageBuilder builder, {bool wait = true, Snowflake? threadId, String? threadName, String? avatarUrl, String? username});
 
   @override
   String avatarURL({String format = "webp", int size = 128});
@@ -173,8 +175,8 @@ class Webhook extends SnowflakeEntity implements IWebhook {
   /// [wait] - waits for server confirmation of message send before response,
   /// and returns the created message body (defaults to false; when false a message that is not save does not return an error)
   @override
-  Future<IMessage?> execute(MessageBuilder builder, {bool wait = true, Snowflake? threadId, String? avatarUrl, String? username}) =>
-      client.httpEndpoints.executeWebhook(id, builder, token: token, threadId: threadId, username: username, wait: wait, avatarUrl: avatarUrl);
+  Future<IMessage?> execute(MessageBuilder builder, {bool wait = true, Snowflake? threadId, String? threadName, String? avatarUrl, String? username}) =>
+      client.httpEndpoints.executeWebhook(id, builder, token: token, threadId: threadId, username: username, wait: wait, avatarUrl: avatarUrl, threadName: threadName);
 
   @override
   String avatarURL({String format = "webp", int size = 128}) => client.httpEndpoints.userAvatarURL(id, avatarHash, 0, format: format, size: size);

--- a/lib/src/core/guild/webhook.dart
+++ b/lib/src/core/guild/webhook.dart
@@ -176,7 +176,8 @@ class Webhook extends SnowflakeEntity implements IWebhook {
   /// and returns the created message body (defaults to false; when false a message that is not save does not return an error)
   @override
   Future<IMessage?> execute(MessageBuilder builder, {bool wait = true, Snowflake? threadId, String? threadName, String? avatarUrl, String? username}) =>
-      client.httpEndpoints.executeWebhook(id, builder, token: token, threadId: threadId, username: username, wait: wait, avatarUrl: avatarUrl, threadName: threadName);
+      client.httpEndpoints
+          .executeWebhook(id, builder, token: token, threadId: threadId, username: username, wait: wait, avatarUrl: avatarUrl, threadName: threadName);
 
   @override
   String avatarURL({String format = "webp", int size = 128}) => client.httpEndpoints.userAvatarURL(id, avatarHash, 0, format: format, size: size);

--- a/lib/src/internal/http_endpoints.dart
+++ b/lib/src/internal/http_endpoints.dart
@@ -332,7 +332,7 @@ abstract class IHttpEndpoints {
   ///
   /// If [wait] is set to true -- request will return resulting message.
   Future<IMessage?> executeWebhook(Snowflake webhookId, MessageBuilder builder,
-      {String token = "", bool wait = true, String? avatarUrl, String? username, Snowflake? threadId});
+      {String token = "", bool wait = true, String? avatarUrl, String? username, Snowflake? threadId, String? threadName});
 
   /// Fetches webhook using its [id] and optionally [token].
   /// If [token] is specified it will be used to fetch webhook data.
@@ -1585,13 +1585,14 @@ class HttpEndpoints implements IHttpEndpoints {
 
   @override
   Future<IMessage?> executeWebhook(Snowflake webhookId, MessageBuilder builder,
-      {String token = "", bool wait = true, String? avatarUrl, String? username, Snowflake? threadId}) async {
+      {String token = "", bool wait = true, String? avatarUrl, String? username, Snowflake? threadId, String? threadName}) async {
     final queryParams = {"wait": wait, if (threadId != null) "thread_id": threadId};
 
     final body = {
       ...builder.build(client.options.allowedMentions),
       if (avatarUrl != null) "avatar_url": avatarUrl,
       if (username != null) "username": username,
+      if (threadName != null) 'thread_name': threadName,
     };
 
     HttpResponse response;


### PR DESCRIPTION
# Description
Add `threadName` param to create a thread with the given name.

## Connected issues

[#5007 - dapidocs](https://github.com/discord/discord-api-docs/pull/5007)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage