### PR TITLE
(bug) Invalid serialization of query params

### DIFF
--- a/lib/src/internal/http/http_request.dart
+++ b/lib/src/internal/http/http_request.dart
@@ -42,7 +42,12 @@ class BasicRequest extends HttpRequest {
 
   @override
   Future<http.BaseRequest> prepareRequest() async {
-    final request = http.Request(method, uri.replace(queryParameters: queryParams))..headers.addAll(genHeaders());
+    final request = http.Request(
+        method,
+        uri.replace(
+            queryParameters: queryParams?.map((key, value) => MapEntry(key, value.toString()))
+        )
+    )..headers.addAll(genHeaders());
 
     if (body != null && method != "GET") {
       request.headers.addAll(_getJsonContentTypeHeader());

--- a/lib/src/internal/http/http_request.dart
+++ b/lib/src/internal/http/http_request.dart
@@ -42,12 +42,8 @@ class BasicRequest extends HttpRequest {
 
   @override
   Future<http.BaseRequest> prepareRequest() async {
-    final request = http.Request(
-        method,
-        uri.replace(
-            queryParameters: queryParams?.map((key, value) => MapEntry(key, value.toString()))
-        )
-    )..headers.addAll(genHeaders());
+    final request = http.Request(method, uri.replace(queryParameters: queryParams?.map((key, value) => MapEntry(key, value.toString()))))
+      ..headers.addAll(genHeaders());
 
     if (body != null && method != "GET") {
       request.headers.addAll(_getJsonContentTypeHeader());


### PR DESCRIPTION
# Description

Fixes invalid deserialization of query params in built in http request handler

## Connected issues & other potential problems

-/-

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] Ran `dart analyze` or `make analyze` and fixed all issues
- [ ] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
