### PR TITLE
Correct uninitialised fields in events

### DIFF
--- a/lib/src/events/guild_events.dart
+++ b/lib/src/events/guild_events.dart
@@ -405,6 +405,8 @@ class RoleUpdateEvent implements IRoleUpdateEvent {
     if (guildInstance != null) {
       oldRole = guildInstance.roles[role.id];
       guildInstance.roles[role.id] = role;
+    } else {
+      oldRole = null;
     }
   }
 }

--- a/lib/src/events/message_events.dart
+++ b/lib/src/events/message_events.dart
@@ -139,19 +139,19 @@ abstract class IMessageReactionEvent {
   CacheableTextChannel<ITextChannel> get channel;
 
   /// Reference to guild if event happened in guild
-  Cacheable<Snowflake, IGuild> get guild;
+  Cacheable<Snowflake, IGuild>? get guild;
 
   /// Message reference
-  late final IMessage? message;
+  IMessage? get message;
 
   /// Id of message
-  late final Snowflake messageId;
+  Snowflake get messageId;
 
   /// The member who reacted if this happened in a guild
-  late final IMember member;
+  IMember? get member;
 
   /// Emoji object.
-  late final IEmoji emoji;
+  IEmoji get emoji;
 }
 
 /// Emitted when reaction is added or removed from message
@@ -163,7 +163,7 @@ abstract class MessageReactionEvent {
   late final CacheableTextChannel<ITextChannel> channel;
 
   /// Reference to guild if event happened in guild
-  late final Cacheable<Snowflake, IGuild> guild;
+  late final Cacheable<Snowflake, IGuild>? guild;
 
   /// Message reference
   late final IMessage? message;
@@ -172,7 +172,7 @@ abstract class MessageReactionEvent {
   late final Snowflake messageId;
 
   /// The member who reacted if this happened in a guild
-  late final IMember member;
+  late final IMember? member;
 
   /// Emoji object.
   late final IEmoji emoji;
@@ -181,6 +181,13 @@ abstract class MessageReactionEvent {
   MessageReactionEvent(RawApiMap json, INyxx client) {
     user = UserCacheable(client, Snowflake(json["d"]["user_id"]));
     channel = CacheableTextChannel<ITextChannel>(client, Snowflake(json["d"]["channel_id"]));
+    guild = GuildCacheable(client, Snowflake(json["d"]["guild_id"]));
+
+    if (json["d"]["member"] != null) {
+      member = Member(client, json["d"]["member"] as RawApiMap, guild!.id);
+    } else {
+      member = null;
+    }
 
     messageId = Snowflake(json["d"]["message_id"]);
 
@@ -368,12 +375,15 @@ class MessageUpdateEvent implements IMessageUpdateEvent {
 
     final channelInstance = channel.getFromCache();
     if (channelInstance == null) {
+      updatedMessage = null;
+      oldMessage = null;
       return;
     }
 
     oldMessage = channelInstance.messageCache[messageId];
 
     if (oldMessage == null) {
+      updatedMessage = null;
       return;
     }
 

--- a/lib/src/events/presence_update_event.dart
+++ b/lib/src/events/presence_update_event.dart
@@ -35,15 +35,15 @@ class PresenceUpdateEvent implements IPresenceUpdateEvent {
   PresenceUpdateEvent(RawApiMap raw, INyxx client) {
     presences = [for (final rawActivity in raw["d"]["activities"]) Activity(rawActivity as RawApiMap)];
     clientStatus = ClientStatus(raw["d"]["client_status"] as RawApiMap);
-    this.user = UserCacheable(client, Snowflake(raw["d"]["user"]["id"]));
+    user = UserCacheable(client, Snowflake(raw["d"]["user"]["id"]));
 
-    final user = this.user.getFromCache();
-    if (user != null) {
-      if (clientStatus != user.status) {
-        (user as User).status = clientStatus;
+    final cachedUser = user.getFromCache();
+    if (cachedUser != null) {
+      if (clientStatus != cachedUser.status) {
+        (cachedUser as User).status = clientStatus;
       }
 
-      (user as User).presence = presences.isNotEmpty ? presences.first : null;
+      (cachedUser as User).presence = presences.isNotEmpty ? presences.first : null;
     }
   }
 }

--- a/lib/src/events/thread_members_update_event.dart
+++ b/lib/src/events/thread_members_update_event.dart
@@ -53,6 +53,7 @@ class ThreadMembersUpdateEvent implements IThreadMembersUpdateEvent {
 
     thread = CacheableTextChannel(client, Snowflake(data["id"]));
     guild = GuildCacheable(client, Snowflake(data["guild_id"]));
+    approxMemberCount = data["member_count"] as int;
 
     addedMembers = [
       if (data["added_members"] != null)


### PR DESCRIPTION
# Description

Correctly initialises fields that were previously left uninitialised in event classes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
