### PR TITLE
fix: everyone role

### DIFF
--- a/lib/src/core/guild/guild.dart
+++ b/lib/src/core/guild/guild.dart
@@ -441,7 +441,7 @@ class Guild extends SnowflakeEntity implements IGuild {
 
   /// Getter for @everyone role
   @override
-  IRole get everyoneRole => roles.values.firstWhere((r) => r.name == "@everyone");
+  IRole get everyoneRole => roles[id]!;
 
   /// Returns member object for bot user
   @override

--- a/lib/src/core/guild/role.dart
+++ b/lib/src/core/guild/role.dart
@@ -49,7 +49,7 @@ abstract class IRole implements SnowflakeEntity, Mentionable {
 
   /// Mention of role. If role cannot be mentioned it returns name of role (@name)
   @override
-  String get mention => mentionable ? "<@&$id>" : "@$name";
+  String get mention;
 
   /// Returns url to role icon
   String? iconURL({String format = "webp", int size = 128});
@@ -113,7 +113,25 @@ class Role extends SnowflakeEntity implements IRole {
 
   /// Mention of role. If role cannot be mentioned it returns name of role (@name)
   @override
-  String get mention => mentionable ? "<@&$id>" : "@$name";
+  String get mention {
+    String mentionString;
+
+    if (mentionable) {
+      if (id == guild.id) {
+        mentionString = name;
+      } else {
+        mentionString = '<@&$id>';
+      }
+    } else {
+      if (id == guild.id) {
+        mentionString = name;
+      } else {
+        mentionString = '@$name';
+      }
+    }
+
+    return mentionString;
+  }
 
   /// Creates an instance of [Role]
   Role(this.client, RawApiMap raw, Snowflake guildId) : super(Snowflake(raw["id"])) {


### PR DESCRIPTION
# Description
The previous implementation of the `everyoneRole` prop was to find any role that has a name of `@everyone`, while this works most of the time, at any moment, a new role can be created with the name `@everyone` and can cause issues to find the true role.
The id of the everyone role is the guild id, so this will fix that disambiguation.
I also modified the way `mention` works and should display properly an `@everyone` instead of `@@everyone`.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
