### PR TITLE
Remove dollar prefix for identify payload

### DIFF
--- a/lib/src/internal/shard/shard.dart
+++ b/lib/src/internal/shard/shard.dart
@@ -314,9 +314,9 @@ class Shard implements IShard {
           final identifyMsg = <String, dynamic>{
             "token": manager.connectionManager.client.token,
             "properties": <String, dynamic>{
-              "\$os": Platform.operatingSystem,
-              "\$browser": "nyxx",
-              "\$device": "nyxx",
+              "os": Platform.operatingSystem,
+              "browser": "nyxx",
+              "device": "nyxx",
             },
             "large_threshold": manager.connectionManager.client.options.largeThreshold,
             "guild_subscriptions": manager.connectionManager.client.options.guildSubscriptions,


### PR DESCRIPTION
# Description

Support for these properties are deprecated and will be dropped in api v11.

See: https://discord.com/developers/docs/change-log#jun-17-2022

## Connected issues & other potential problems
-/-

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] Ran `dart analyze` or `make analyze` and fixed all issues
- [ ] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
