### PR TITLE
feature: member screening events

### DIFF
--- a/lib/src/internal/event_controller.dart
+++ b/lib/src/internal/event_controller.dart
@@ -127,6 +127,14 @@ abstract class IWebsocketEventController implements IRestEventController {
   /// Emitted when a member joins a guild.
   Stream<IGuildMemberAddEvent> get onGuildMemberAdd;
 
+  /// Emitted when a member joins a guild but is not yet screened by:
+  /// https://support.discord.com/hc/en-us/articles/1500000466882
+  Stream<IGuildMemberAddEvent> get onGuildMemberAddScreening;
+
+  /// Emitted when a member joins a guild but passed member screening
+  /// https://support.discord.com/hc/en-us/articles/1500000466882
+  Stream<IGuildMemberAddEvent> get onGuildMemberAddPassedScreening;
+
   /// Emitted when a member is updated.
   Stream<IGuildMemberUpdateEvent> get onGuildMemberUpdate;
 
@@ -566,6 +574,12 @@ class WebsocketEventController extends RestEventController implements IWebsocket
   @override
   late final Stream<IAutoModerationActionExecutionEvent> onAutoModerationActionExecution;
 
+  @override
+  late final Stream<IGuildMemberAddEvent> onGuildMemberAddScreening;
+
+  @override
+  late final Stream<IGuildMemberAddEvent> onGuildMemberAddPassedScreening;
+
   final INyxxWebsocket _client;
 
   /// Makes a new `EventController`.
@@ -713,6 +727,9 @@ class WebsocketEventController extends RestEventController implements IWebsocket
 
     onAutoModerationActionExecutionController = StreamController.broadcast();
     onAutoModerationActionExecution = onAutoModerationActionExecutionController.stream;
+
+    onGuildMemberAddScreening = onGuildMemberAdd.where((event) => event.member.isPending);
+    onGuildMemberAddPassedScreening = onGuildMemberAdd.where((event) => !event.member.isPending);
   }
 
   @override

--- a/lib/src/internal/event_controller.dart
+++ b/lib/src/internal/event_controller.dart
@@ -133,7 +133,7 @@ abstract class IWebsocketEventController implements IRestEventController {
 
   /// Emitted when a member joins a guild but passed member screening
   /// https://support.discord.com/hc/en-us/articles/1500000466882
-  Stream<IGuildMemberAddEvent> get onGuildMemberAddPassedScreening;
+  Stream<IGuildMemberUpdateEvent> get onGuildMemberAddPassedScreening;
 
   /// Emitted when a member is updated.
   Stream<IGuildMemberUpdateEvent> get onGuildMemberUpdate;
@@ -578,7 +578,7 @@ class WebsocketEventController extends RestEventController implements IWebsocket
   late final Stream<IGuildMemberAddEvent> onGuildMemberAddScreening;
 
   @override
-  late final Stream<IGuildMemberAddEvent> onGuildMemberAddPassedScreening;
+  late final Stream<IGuildMemberUpdateEvent> onGuildMemberAddPassedScreening;
 
   final INyxxWebsocket _client;
 
@@ -729,7 +729,7 @@ class WebsocketEventController extends RestEventController implements IWebsocket
     onAutoModerationActionExecution = onAutoModerationActionExecutionController.stream;
 
     onGuildMemberAddScreening = onGuildMemberAdd.where((event) => event.member.isPending);
-    onGuildMemberAddPassedScreening = onGuildMemberAdd.where((event) => !event.member.isPending);
+    onGuildMemberAddPassedScreening = onGuildMemberUpdate.where((event) => !(event.member.getFromCache()?.isPending ?? true));
   }
 
   @override


### PR DESCRIPTION
# Description

Implements events around `isScreening` fields on `IMember`. Allows easy subscription to changes in member screening. 

## Connected issues & other potential problems

-/-

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
