### PR TITLE
Fix deserialize the emoji id of the forum tag

### DIFF
--- a/lib/src/core/channel/guild/forum/forum_tag.dart
+++ b/lib/src/core/channel/guild/forum/forum_tag.dart
@@ -31,7 +31,9 @@ class ForumTag implements IForumTag {
   ForumTag(RawApiMap raw) {
     id = Snowflake(raw['id']);
     name = raw['string'] as String?;
-    emojiId = raw['emoji_id'] != 0 ? Snowflake(raw['emoji_id']) : null;
+    emojiId = (raw['emoji_id'] != 0 && raw['emoji_id'] != null)
+        ? Snowflake(raw['emoji_id'])
+        : null;
     emojiName = raw['emoji_name'] as String?;
   }
 }

--- a/lib/src/core/channel/guild/forum/forum_tag.dart
+++ b/lib/src/core/channel/guild/forum/forum_tag.dart
@@ -31,7 +31,7 @@ class ForumTag implements IForumTag {
   ForumTag(RawApiMap raw) {
     id = Snowflake(raw['id']);
     name = raw['string'] as String?;
-    emojiId = (raw['emoji_id'] != 0 && raw['emoji_id'] != null) ? Snowflake(raw['emoji_id']) : null;
+    emojiId = raw['emoji_id'] != null ? Snowflake(raw['emoji_id']) : null;
     emojiName = raw['emoji_name'] as String?;
   }
 }

--- a/lib/src/core/channel/guild/forum/forum_tag.dart
+++ b/lib/src/core/channel/guild/forum/forum_tag.dart
@@ -31,9 +31,7 @@ class ForumTag implements IForumTag {
   ForumTag(RawApiMap raw) {
     id = Snowflake(raw['id']);
     name = raw['string'] as String?;
-    emojiId = (raw['emoji_id'] != 0 && raw['emoji_id'] != null)
-        ? Snowflake(raw['emoji_id'])
-        : null;
+    emojiId = (raw['emoji_id'] != 0 && raw['emoji_id'] != null) ? Snowflake(raw['emoji_id']) : null;
     emojiName = raw['emoji_name'] as String?;
   }
 }


### PR DESCRIPTION
# Description

Fix deserialize the emoji id of the forum tag.

Because the emoji id of the forum tag maybe is null, so need to check it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
