### PR TITLE
Correctly emit connected event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.2
+__30.10.2022__
+
+- bug: Correctly emit connected event in `ShardManager`
+
 ## 4.1.1
 __23.10.2022__
 

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -33,7 +33,7 @@ class Constants {
   static const int apiVersion = 10;
 
   /// Version of Nyxx
-  static const String version = "4.1.1";
+  static const String version = "4.1.2";
 
   /// Url to Nyxx repo
   static const String repoUrl = "https://github.com/nyxx-discord/nyxx";

--- a/lib/src/internal/shard/shard.dart
+++ b/lib/src/internal/shard/shard.dart
@@ -246,6 +246,7 @@ class Shard implements IShard {
   Future<void> handleConnected() async {
     manager.logger.info('Shard $id connected to gateway');
     connected = true;
+    manager.onConnectController.add(this);
 
     // There was no previous heartbeat on a new connection.
     // Setting this to true prevents us from reconnecting upon receiving the first heartbeat due to the previous heartbeat "not being acked".

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx
-version: 4.1.1
+version: 4.1.2
 description: A Discord library for Dart. Simple, robust framework for creating discord bots for Dart language.
 homepage: https://github.com/nyxx-discord/nyxx
 repository: https://github.com/nyxx-discord/nyxx


### PR DESCRIPTION
# Description

Correctly emit `onConnected` when a shard connects to the Gateway.

## Connected issues & other potential problems

#363 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
