### PR TITLE
Don't use ZlibDecoder to deflate gateway messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.3
+__01.11.2022__
+
+- bug: Combine decompressed gateway payloads before parsing them
+
 ## 4.1.2
 __30.10.2022__
 

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -33,7 +33,7 @@ class Constants {
   static const int apiVersion = 10;
 
   /// Version of Nyxx
-  static const String version = "4.1.2";
+  static const String version = "4.1.3";
 
   /// Url to Nyxx repo
   static const String repoUrl = "https://github.com/nyxx-discord/nyxx";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx
-version: 4.1.2
+version: 4.1.3
 description: A Discord library for Dart. Simple, robust framework for creating discord bots for Dart language.
 homepage: https://github.com/nyxx-discord/nyxx
 repository: https://github.com/nyxx-discord/nyxx


### PR DESCRIPTION
# Description

Using `ZlibDecoder` to deflate Gateway messages resulted in issues as the default implementation of the stream transformer emitted deflated chunks as it received them, resulting in some Gateway messages being chunked and failing JSON parrsing.

This PR changes the deflation method used to accumulate deflated chunks before emitting them for parsing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
