### PR TITLE
Cache user when fetching

### DIFF
--- a/lib/src/core/user/user.dart
+++ b/lib/src/core/user/user.dart
@@ -140,7 +140,7 @@ class User extends SnowflakeEntity implements IUser {
 
     bannerHash = raw["banner"] as String?;
     if (raw["accent_color"] != null) {
-      accentColor = DiscordColor.fromInt(raw["accent_color"] as int);
+      accentColor = DiscordColor.fromInt(int.parse(raw["accent_color"] as String));
     } else {
       accentColor = null;
     }

--- a/lib/src/core/user/user.dart
+++ b/lib/src/core/user/user.dart
@@ -140,7 +140,7 @@ class User extends SnowflakeEntity implements IUser {
 
     bannerHash = raw["banner"] as String?;
     if (raw["accent_color"] != null) {
-      accentColor = DiscordColor.fromInt(int.parse(raw["accent_color"] as String));
+      accentColor = DiscordColor.fromInt(raw["accent_color"] as int);
     } else {
       accentColor = null;
     }

--- a/lib/src/internal/http_endpoints.dart
+++ b/lib/src/internal/http_endpoints.dart
@@ -1071,7 +1071,13 @@ class HttpEndpoints implements IHttpEndpoints {
       return Future.error(response);
     }
 
-    return User(client, (response as HttpResponseSuccess).jsonBody as RawApiMap);
+    final user = User(client, (response as HttpResponseSuccess).jsonBody as RawApiMap);
+
+    if (client.cacheOptions.userCachePolicyLocation.http) {
+      client.users[user.id] = user;
+    }
+
+    return user;
   }
 
   @override

--- a/lib/src/internal/http_endpoints.dart
+++ b/lib/src/internal/http_endpoints.dart
@@ -1071,13 +1071,7 @@ class HttpEndpoints implements IHttpEndpoints {
       return Future.error(response);
     }
 
-    final user = User(client, (response as HttpResponseSuccess).jsonBody as RawApiMap);
-
-    if (client.cacheOptions.userCachePolicyLocation.http) {
-      client.users[user.id] = user;
-    }
-
-    return user;
+    return User(client, (response as HttpResponseSuccess).jsonBody as RawApiMap);
   }
 
   @override


### PR DESCRIPTION
# Description
Fix `accentColor` parsing on `IUser`s.
This PR also caches users when fetching them from the api.

## Connected issues & other potential problems
-/-
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
