### PR TITLE
Fix null-assert error on shard disposal; don't reconnect shard after disposing

### DIFF
--- a/lib/src/internal/shard/shard_handler.dart
+++ b/lib/src/internal/shard/shard_handler.dart
@@ -37,6 +37,11 @@ class ShardRunner implements Disposable {
   /// [ShardToManager.disconnected] will not be dispatched if this is true.
   bool reconnecting = false;
 
+  /// Whether this shard is currently disposing itself.
+  ///
+  /// [ShardToManager.disconnected] will not be dispatched if this is true.
+  bool disposing = false;
+
   ShardRunner(this.sendPort) {
     managerMessages.listen(handle);
   }
@@ -84,7 +89,7 @@ class ShardRunner implements Disposable {
       connection!.pingInterval = const Duration(seconds: 20);
 
       connection!.done.then((_) {
-        if (reconnecting) {
+        if (reconnecting || disposing) {
           return;
         }
 
@@ -175,6 +180,8 @@ class ShardRunner implements Disposable {
   /// Sends [ShardToManager.disposed] upon completion.
   @override
   Future<void> dispose() async {
+    disposing = true;
+
     if (connected) {
       await disconnect();
     }


### PR DESCRIPTION
# Description

Stops the shard from sending disconnect messages after disposal, which lead to errors obtaining the close code of the connection and attempts to get the shard to reconnect after disposal in the disconnect handler.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
