### PR TITLE
fix: add message content to client in examples

### DIFF
--- a/example/channel.dart
+++ b/example/channel.dart
@@ -3,7 +3,7 @@ import "package:nyxx/nyxx.dart";
 // Main function
 void main() async {
   // Create new bot instance. Replace string with your token
-  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged)
+  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged | GatewayIntents.messageContent) // Here we use the privilegied intent message content to receive incoming messages.
     ..registerPlugin(Logging()) // Default logging plugin
     ..registerPlugin(CliIntegration()) // Cli integration for nyxx allows stopping application via SIGTERM and SIGKILl
     ..registerPlugin(IgnoreExceptions()) // Plugin that handles uncaught exceptions that may occur

--- a/example/create_add_role.dart
+++ b/example/create_add_role.dart
@@ -3,7 +3,7 @@ import "package:nyxx/nyxx.dart";
 // Main function
 void main() async {
   // Create new bot instance. Replace string with your token
-  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged)
+  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged | GatewayIntents.messageContent) // Here we use the privilegied intent message content to receive incoming messages.
     ..registerPlugin(Logging()) // Default logging plugin
     ..registerPlugin(CliIntegration()) // Cli integration for nyxx allows stopping application via SIGTERM and SIGKILl
     ..registerPlugin(IgnoreExceptions()) // Plugin that handles uncaught exceptions that may occur
@@ -20,7 +20,7 @@ void main() async {
     if (e.message.content == "!role") {
 
       // Make sure that message was sent in guild not im dm, because we cant add roles in dms
-      if(e.message.guild != null) {
+      if (e.message.guild != null) {
         return;
       }
 

--- a/example/embeds.dart
+++ b/example/embeds.dart
@@ -11,11 +11,10 @@ DiscordColor getColorForUserFromMessage(IMessage message) {
 // Main function
 void main() async {
   // Create new bot instance. Replace string with your token
-  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged)
+  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged | GatewayIntents.messageContent) // Here we use the privilegied intent message content to receive incoming messages.
     ..registerPlugin(Logging()) // Default logging plugin
     ..registerPlugin(CliIntegration()) // Cli integration for nyxx allows stopping application via SIGTERM and SIGKILl
     ..registerPlugin(IgnoreExceptions()) // Plugin that handles uncaught exceptions that may occur
-    ..connect();
 
   // Listen to ready event. Invoked when bot is connected to all shards. Note that cache can be empty or not incomplete.
   bot.eventsWs.onReady.listen((IReadyEvent e) {
@@ -23,7 +22,7 @@ void main() async {
   });
 
   // Listen to all incoming messages
-  bot.eventsWs.onMessageReceived.listen((IMessageReceivedEvent e) {
+  bot.eventsWs.onMessageReceived.listen((IMessageReceivedEvent e) async {
     // Check if message content equals "!embed"
     if (e.message.content == "!embed") {
 
@@ -44,7 +43,7 @@ void main() async {
         ..color = getColorForUserFromMessage(e.message);
 
       // Sent an embed to channel where message received was sent
-      e.message.channel.sendMessage(MessageBuilder.embed(embed));
+      await e.message.channel.sendMessage(MessageBuilder.embed(embed));
     }
   });
 

--- a/example/emojis.dart
+++ b/example/emojis.dart
@@ -1,38 +1,40 @@
 import 'package:nyxx/nyxx.dart';
 
 void main(List<String> args) {
-    // Create new bot instance. Replace string with your token
-  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged)
+  // Create new bot instance. Replace string with your token
+  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged | GatewayIntents.messageContent) // Here we use the privilegied intent message content to receive incoming messages.
     ..registerPlugin(Logging()) // Default logging plugin
     ..registerPlugin(CliIntegration()) // Cli integration for nyxx allows stopping application via SIGTERM and SIGKILl
     ..registerPlugin(IgnoreExceptions()) // Plugin that handles uncaught exceptions that may occur
     ..connect();
+
   bot.eventsWs.onReady.listen((_) {
     print('Ready!');
   });
+
   // This event is called when a message is received
   bot.eventsWs.onMessageReceived.listen((event) async {
-    if(event.message.content == '!emoji') {
+    if (event.message.content == '!emoji') {
       final emoji = event.message.guild?.getFromCache()?.emojis.values.firstWhere((emo) => emo.name == 'nyxx');
       final msg = await event.message.channel.sendMessage(MessageBuilder.content('Look at this emoji: $emoji'));
-      msg.createReaction(emoji!);
+      await msg.createReaction(emoji!);
       // For unicode emoji use `UnicodeEmoji` class
-      msg.createReaction(UnicodeEmoji('🤔'));
+      await msg.createReaction(UnicodeEmoji('🤔'));
     }
   });
 
   // This event is called when a reaction has been added to a message
-  bot.eventsWs.onMessageReactionAdded.listen((event) {
+  bot.eventsWs.onMessageReactionAdded.listen((event) async {
     if (event.emoji is UnicodeEmoji) {
-      event.message?.channel.sendMessage(
+      await event.message?.channel.sendMessage(
         MessageBuilder.content(
           'Woah! This is a unicode emoji: ${event.emoji}',
         ),
       );
     } else if (event.emoji is IGuildEmojiPartial) {
-      if(event.emoji is IResolvableGuildEmojiPartial) {
+      if (event.emoji is IResolvableGuildEmojiPartial) {
         final emoji = (event.emoji as IResolvableGuildEmojiPartial).resolve();
-        event.message?.channel.sendMessage(
+        await event.message?.channel.sendMessage(
           MessageBuilder.content(
             'Woah! This is a custom emoji: ${emoji.name}',
           ),

--- a/example/example.dart
+++ b/example/example.dart
@@ -3,7 +3,7 @@ import "package:nyxx/nyxx.dart";
 // Main function
 void main() {
   // Create new bot instance
-  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged)
+  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged | GatewayIntents.messageContent) // Here we use the privilegied intent message content to receive incoming messages.
     ..registerPlugin(Logging()) // Default logging plugin
     ..registerPlugin(CliIntegration()) // Cli integration for nyxx allows stopping application via SIGTERM and SIGKILl
     ..registerPlugin(IgnoreExceptions()) // Plugin that handles uncaught exceptions that may occur

--- a/example/invite.dart
+++ b/example/invite.dart
@@ -3,7 +3,7 @@ import "package:nyxx/nyxx.dart";
 // Main function
 void main() {
   // Create new bot instance. Replace string with your token
-  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged)
+  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged | GatewayIntents.messageContent) // Here we use the privilegied intent message content to receive incoming messages.
     ..registerPlugin(Logging()) // Default logging plugin
     ..registerPlugin(CliIntegration()) // Cli integration for nyxx allows stopping application via SIGTERM and SIGKILl
     ..registerPlugin(IgnoreExceptions()) // Plugin that handles uncaught exceptions that may occur
@@ -16,10 +16,10 @@ void main() {
 
   // Listen to all incoming messages
   bot.eventsWs.onMessageReceived.listen((IMessageReceivedEvent e) async {
-    // Check if message content equals "!embed"
+    // Check if message content equals "!create_channel"
     if (e.message.content == "!create_channel") {
       // Make sure that message was sent in guild not im dm, because we cant add roles in dms
-      if(e.message.guild != null) {
+      if (e.message.guild != null) {
         return;
       }
 

--- a/example/kick_ban.dart
+++ b/example/kick_ban.dart
@@ -1,20 +1,20 @@
 import "package:nyxx/nyxx.dart";
 
 // Returns user that can be banned from message. Parses mention or raw id from message
-SnowflakeEntity getUserToBan(IMessage message) {
+SnowflakeEntity getUserToKickOrBan(IMessage message) {
   // If mentions are not empty return first mention
-  if(message.mentions.isNotEmpty) {
+  if (message.mentions.isNotEmpty) {
     return message.mentions.first.id.toSnowflakeEntity();
   }
 
-  // Otherwise split message by spaces then take lst part and parse it to snowflake and return as Snowflake entity
+  // Otherwise split message by spaces then take last part and parse it to snowflake and return as Snowflake entity
   return SnowflakeEntity(message.content.split(" ").last.toSnowflake());
 }
 
 // Main function
 void main() {
   // Create new bot instance. Replace string with your token
-  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged)
+  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged | GatewayIntents.messageContent) // Here we use the privilegied intent message content to receive incoming messages.
     ..registerPlugin(Logging()) // Default logging plugin
     ..registerPlugin(CliIntegration()) // Cli integration for nyxx allows stopping application via SIGTERM and SIGKILl
     ..registerPlugin(IgnoreExceptions()) // Plugin that handles uncaught exceptions that may occur
@@ -27,16 +27,16 @@ void main() {
 
   // Listen to all incoming messages
   bot.eventsWs.onMessageReceived.listen((IMessageReceivedEvent e) async {
-    // Check if message content equals "!embed"
+    // Check if message content equals "!ban"
     if (e.message.content == "!ban") {
 
       // Make sure that message was sent in guild not im dm, because we cant add roles in dms
-      if(e.message.guild != null) {
+      if (e.message.guild != null) {
         return;
       }
 
       // Get user to ban
-      final userToBan = getUserToBan(e.message);
+      final userToBan = getUserToKickOrBan(e.message);
 
       // Ban user using variable initialized before
       await e.message.guild!.getFromCache()!.ban(userToBan);
@@ -45,15 +45,15 @@ void main() {
       await e.message.channel.sendMessage(MessageBuilder.content("👍"));
     }
 
-    // Check if message content equals "!embed"
-    if (e.message.content == "!ban") {
+    // Check if message content equals "!kick"
+    if (e.message.content == "!kick") {
       // Make sure that message was sent in guild not im dm, because we cant add roles in dms
-      if(e.message.guild != null) {
+      if (e.message.guild != null) {
         return;
       }
 
       // Get user to kick
-      final userToBan = getUserToBan(e.message);
+      final userToBan = getUserToKickOrBan(e.message);
 
       // Kick user
       await e.message.guild!.getFromCache()!.kick(userToBan);

--- a/example/permissions.dart
+++ b/example/permissions.dart
@@ -3,7 +3,7 @@ import "package:nyxx/nyxx.dart";
 // Main function
 void main() {
   // Create new bot instance. Replace string with your token
-  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged)
+  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged | GatewayIntents.messageContent) // Here we use the privilegied intent message content to receive incoming messages.
     ..registerPlugin(Logging()) // Default logging plugin
     ..registerPlugin(CliIntegration()) // Cli integration for nyxx allows stopping application via SIGTERM and SIGKILl
     ..registerPlugin(IgnoreExceptions()) // Plugin that handles uncaught exceptions that may occur

--- a/example/ping_pong.dart
+++ b/example/ping_pong.dart
@@ -3,7 +3,7 @@ import "package:nyxx/nyxx.dart";
 // Main function
 void main() {
   // Create new bot instance
-  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged)
+  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged | GatewayIntents.messageContent) // Here we use the privilegied intent message content to receive incoming messages.
     ..registerPlugin(Logging()) // Default logging plugin
     ..registerPlugin(CliIntegration()) // Cli integration for nyxx allows stopping application via SIGTERM and SIGKILl
     ..registerPlugin(IgnoreExceptions()) // Plugin that handles uncaught exceptions that may occur
@@ -15,11 +15,11 @@ void main() {
   });
 
   // Listen to all incoming messages
-  bot.eventsWs.onMessageReceived.listen((e) {
+  bot.eventsWs.onMessageReceived.listen((e) async {
     // Check if message content equals "!ping"
     if (e.message.content == "!ping") {
       // Send "Pong!" to channel where message was received
-      e.message.channel.sendMessage(MessageBuilder.content("Pong!"));
+      await e.message.channel.sendMessage(MessageBuilder.content("Pong!"));
     }
   });
 }

--- a/example/reply_to_message.dart
+++ b/example/reply_to_message.dart
@@ -3,7 +3,7 @@ import "package:nyxx/nyxx.dart";
 // Main function
 void main() {
   // Create new bot instance. Replace string with your token
-  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged)
+  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged | GatewayIntents.messageContent) // Here we use the privilegied intent message content to receive incoming messages.
     ..registerPlugin(Logging()) // Default logging plugin
     ..registerPlugin(CliIntegration()) // Cli integration for nyxx allows stopping application via SIGTERM and SIGKILl
     ..registerPlugin(IgnoreExceptions()) // Plugin that handles uncaught exceptions that may occur
@@ -24,7 +24,7 @@ void main() {
       final messageBuilder = MessageBuilder.content("This is how replies work")
         ..replyBuilder = replyBuilder;
 
-      // If you dont want to mention user that invoked that command user AllowedMentions
+      // If you dont want to mention user that invoked that command, use AllowedMentions
       final allowedMentionsBuilder = AllowedMentions()
         ..allow(reply: false);
 

--- a/example/sending_file.dart
+++ b/example/sending_file.dart
@@ -5,7 +5,7 @@ import "package:nyxx/nyxx.dart";
 // Main function
 void main() {
   // Create new bot instance
-  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged)
+  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged | GatewayIntents.messageContent) // Here we use the privilegied intent message content to receive incoming messages.
     ..registerPlugin(Logging()) // Default logging plugin
     ..registerPlugin(CliIntegration()) // Cli integration for nyxx allows stopping application via SIGTERM and SIGKILl
     ..registerPlugin(IgnoreExceptions()) // Plugin that handles uncaught exceptions that may occur
@@ -50,7 +50,6 @@ void main() {
         ..thumbnailUrl = attachment.attachUrl;
 
       // Send everything we created before to channel where message was received.
-      // e.message.channel.getFromCache()?.sendMessage(files: [attachment], embed: embed, content: "HEJKA!");
       e.message.channel.sendMessage(
           MessageBuilder.content("HEJKA!")
             ..embeds = [embed]


### PR DESCRIPTION
# Description
Adds missing message content privileged gateway intent.

## Connected issues & other potential problems
-/-

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
