### PR TITLE
Emit bot start to plugins only when ready

### DIFF
--- a/lib/src/nyxx.dart
+++ b/lib/src/nyxx.dart
@@ -207,10 +207,10 @@ class NyxxRest extends INyxxRest {
 
     if (propagateReady) {
       onReadyController.add(ReadyEvent(this));
-    }
 
-    for (final plugin in _plugins) {
-      await plugin.onBotStart(this, _logger);
+      for (final plugin in _plugins) {
+        await plugin.onBotStart(this, _logger);
+      }
     }
   }
 
@@ -372,6 +372,10 @@ class NyxxWebsocket extends NyxxRest implements INyxxWebsocket {
 
     if (propagateReady) {
       onReadyController.add(ReadyEvent(this));
+
+      for (final plugin in _plugins) {
+        await plugin.onBotStart(this, _logger);
+      }
     }
   }
 


### PR DESCRIPTION
# Description

Changes the `onBotStart` plugin hook to act similar to the `onReady` event, to prevent plugins from accessing fields before they are initialised.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
