### PR TITLE
Add retry with backoff to network operations (gateway and http)

### DIFF
--- a/lib/src/client_options.dart
+++ b/lib/src/client_options.dart
@@ -1,6 +1,7 @@
 import 'package:nyxx/nyxx.dart';
 import 'package:nyxx/src/nyxx.dart';
 import 'package:nyxx/src/internal/shard/shard.dart';
+import 'package:retry/retry.dart';
 
 /// Options for configuring cache. Allows to specify where and which entities should be cached and preserved in cache
 class CacheOptions {
@@ -69,19 +70,24 @@ class ClientOptions {
   /// Allows to enable receiving raw gateway event
   bool dispatchRawShardEvent;
 
+  /// The [RetryOptions] to use when a shard fails to connect to the gateway.
+  RetryOptions shardReconnectOptions;
+
   /// Makes a new `ClientOptions` object.
-  ClientOptions(
-      {this.allowedMentions,
-      this.shardCount,
-      this.messageCacheSize = 100,
-      this.largeThreshold = 50,
-      this.compressedGatewayPayloads = true,
-      this.guildSubscriptions = true,
-      this.initialPresence,
-      this.shutdownHook,
-      this.shutdownShardHook,
-      this.dispatchRawShardEvent = false,
-      this.shardIds});
+  ClientOptions({
+    this.allowedMentions,
+    this.shardCount,
+    this.messageCacheSize = 100,
+    this.largeThreshold = 50,
+    this.compressedGatewayPayloads = true,
+    this.guildSubscriptions = true,
+    this.initialPresence,
+    this.shutdownHook,
+    this.shutdownShardHook,
+    this.dispatchRawShardEvent = false,
+    this.shardIds,
+    this.shardReconnectOptions = const RetryOptions(maxAttempts: 50), // 50 attempts won't ever reasonably be reached
+  });
 }
 
 /// When identifying to the gateway, you can specify an intents parameter which

--- a/lib/src/client_options.dart
+++ b/lib/src/client_options.dart
@@ -73,6 +73,12 @@ class ClientOptions {
   /// The [RetryOptions] to use when a shard fails to connect to the gateway.
   RetryOptions shardReconnectOptions;
 
+  /// The [RetryOptions] to use when a HTTP request fails.
+  ///
+  /// Note that this will not retry requests that fail because of their HTTP response code (e.g  a 4xx response) but rather requests that fail due to native
+  /// errors (e.g failed host lookup) which can occur if there is no internet.
+  RetryOptions httpRetryOptions;
+
   /// Makes a new `ClientOptions` object.
   ClientOptions({
     this.allowedMentions,
@@ -87,6 +93,7 @@ class ClientOptions {
     this.dispatchRawShardEvent = false,
     this.shardIds,
     this.shardReconnectOptions = const RetryOptions(maxAttempts: 50), // 50 attempts won't ever reasonably be reached
+    this.httpRetryOptions = const RetryOptions(maxAttempts: 50),
   });
 }
 

--- a/lib/src/client_options.dart
+++ b/lib/src/client_options.dart
@@ -92,8 +92,8 @@ class ClientOptions {
     this.shutdownShardHook,
     this.dispatchRawShardEvent = false,
     this.shardIds,
-    this.shardReconnectOptions = const RetryOptions(maxAttempts: 50), // 50 attempts won't ever reasonably be reached
-    this.httpRetryOptions = const RetryOptions(maxAttempts: 50),
+    this.shardReconnectOptions = const RetryOptions(),
+    this.httpRetryOptions = const RetryOptions(),
   });
 }
 

--- a/lib/src/internal/exceptions/http_client_exception.dart
+++ b/lib/src/internal/exceptions/http_client_exception.dart
@@ -1,6 +1,7 @@
 import 'package:http/http.dart' as http;
 
 /// Exception of http client
+@Deprecated('Unused, will be removed in the next major release')
 class HttpClientException extends http.ClientException {
   /// Raw response from server
   final http.BaseResponse? response;

--- a/lib/src/internal/http/http_handler.dart
+++ b/lib/src/internal/http/http_handler.dart
@@ -80,7 +80,10 @@ class HttpHandler {
     // Execute request
     currentBucket?.addInFlightRequest(request);
     final rawRequest = await request.prepareRequest();
-    final response = await client.options.httpRetryOptions.retry(() => httpClient.send(rawRequest));
+    final response = await client.options.httpRetryOptions.retry(
+      () => httpClient.send(rawRequest),
+      onRetry: (ex) => logger.shout('Exception when sending HTTP request (retrying automatically): $ex'),
+    );
     currentBucket?.removeInFlightRequest(request);
     currentBucket = _upsertBucket(request, response);
     return _handle(request, response);

--- a/lib/src/internal/http/http_handler.dart
+++ b/lib/src/internal/http/http_handler.dart
@@ -79,7 +79,8 @@ class HttpHandler {
 
     // Execute request
     currentBucket?.addInFlightRequest(request);
-    final response = await httpClient.send(await request.prepareRequest());
+    final rawRequest = await request.prepareRequest();
+    final response = await client.options.httpRetryOptions.retry(() => httpClient.send(rawRequest));
     currentBucket?.removeInFlightRequest(request);
     currentBucket = _upsertBucket(request, response);
     return _handle(request, response);

--- a/lib/src/internal/http/http_handler.dart
+++ b/lib/src/internal/http/http_handler.dart
@@ -78,25 +78,11 @@ class HttpHandler {
     }
 
     // Execute request
-    try {
-      currentBucket?.addInFlightRequest(request);
-      final response = await httpClient.send(await request.prepareRequest());
-      currentBucket?.removeInFlightRequest(request);
-      currentBucket = _upsertBucket(request, response);
-      return _handle(request, response);
-    } on HttpClientException catch (e) {
-      currentBucket?.removeInFlightRequest(request);
-      if (e.response == null) {
-        logger.warning("Http Error on endpoint: ${request.uri}. Error: [${e.message.toString()}].");
-        rethrow;
-      }
-
-      final response = e.response as http.StreamedResponse;
-      _upsertBucket(request, response);
-
-      // Return http error
-      return _handle(request, response);
-    }
+    currentBucket?.addInFlightRequest(request);
+    final response = await httpClient.send(await request.prepareRequest());
+    currentBucket?.removeInFlightRequest(request);
+    currentBucket = _upsertBucket(request, response);
+    return _handle(request, response);
   }
 
   Future<HttpResponse> _handle(HttpRequest request, http.StreamedResponse response) async {

--- a/lib/src/internal/http/http_handler.dart
+++ b/lib/src/internal/http/http_handler.dart
@@ -79,9 +79,8 @@ class HttpHandler {
 
     // Execute request
     currentBucket?.addInFlightRequest(request);
-    final rawRequest = await request.prepareRequest();
     final response = await client.options.httpRetryOptions.retry(
-      () => httpClient.send(rawRequest),
+      () async => httpClient.send(await request.prepareRequest()),
       onRetry: (ex) => logger.shout('Exception when sending HTTP request (retrying automatically): $ex'),
     );
     currentBucket?.removeInFlightRequest(request);

--- a/lib/src/internal/shard/message.dart
+++ b/lib/src/internal/shard/message.dart
@@ -2,7 +2,9 @@ class ShardMessage<T> {
   final T type;
   final dynamic data;
 
-  const ShardMessage(this.type, {this.data});
+  final int seq;
+
+  const ShardMessage(this.type, {required this.seq, this.data});
 }
 
 enum ShardToManager {
@@ -27,6 +29,9 @@ enum ShardToManager {
 
   /// Sent when the shard is connected
   connected,
+
+  /// Send when the shard successfully reconnects
+  reconnected,
 
   /// Send when the shard is disconnected
   ///

--- a/lib/src/internal/shard/shard.dart
+++ b/lib/src/internal/shard/shard.dart
@@ -123,16 +123,7 @@ class Shard implements IShard {
     readyFuture = spawn();
 
     // Automatically connect once the shard runner is ready.
-    readyFuture.then((_) => execute(
-          ShardMessage(
-            ManagerToShard.connect,
-            seq: seq++,
-            data: {
-              'gatewayHost': gatewayHost,
-              'useCompression': manager.connectionManager.client.options.compressedGatewayPayloads,
-            },
-          ),
-        ));
+    readyFuture.then((_) => connect());
 
     // Start handling messages from the shard.
     readyFuture.then((_) => shardMessages.listen(handle));
@@ -160,6 +151,48 @@ class Shard implements IShard {
     sendPort.send(message);
   }
 
+  Future<void> _connectReconnectHelper(int seq, {required bool isReconnect}) async {
+    // These need to be accessible both in the main callback, in retryIf and in the catch block below
+    bool shouldReconnect = false;
+    late String errorMessage;
+
+    try {
+      await manager.connectionManager.client.options.shardReconnectOptions.retry(
+        retryIf: (_) => shouldReconnect,
+        () async {
+          execute(ShardMessage(
+            isReconnect ? ManagerToShard.reconnect : ManagerToShard.connect,
+            seq: seq,
+            data: {
+              'gatewayHost': shouldResume && canResume ? resumeGatewayUrl : gatewayHost,
+              'useCompression': manager.connectionManager.client.options.compressedGatewayPayloads,
+            },
+          ));
+
+          final message = await shardMessages.firstWhere((element) => element.seq == seq);
+
+          switch (message.type) {
+            case ShardToManager.connected:
+            case ShardToManager.reconnected:
+              return;
+            case ShardToManager.error:
+              shouldReconnect = message.data['shouldReconnect'] as bool? ?? false;
+              errorMessage = message.data['message'] as String;
+              throw Exception();
+            default:
+              assert(false, 'Unreachable');
+              return;
+          }
+        },
+      );
+    } on Exception {
+      // Callback failed too many times, throw an unrecoverable error with the message we were given
+      throw UnrecoverableNyxxError(errorMessage);
+    }
+  }
+
+  Future<void> connect() => _connectReconnectHelper(seq, isReconnect: false);
+
   /// Triggers a reconnection to the shard.
   ///
   /// If the connection is to be resumed, [resumeGatewayUrl] is used as the connection. Otherwise, [gatewayHost] is used.
@@ -167,16 +200,9 @@ class Shard implements IShard {
     manager.logger.info('Reconnecting to gateway on shard $id');
     resetConnectionProperties();
 
-    seq ??= (this.seq++);
+    int realSeq = seq ?? (this.seq++);
 
-    execute(ShardMessage(
-      ManagerToShard.reconnect,
-      seq: seq++,
-      data: {
-        'gatewayHost': shouldResume && canResume ? resumeGatewayUrl : gatewayHost,
-        'useCompression': manager.connectionManager.client.options.compressedGatewayPayloads,
-      },
-    ));
+    await _connectReconnectHelper(realSeq, isReconnect: true);
   }
 
   void resetConnectionProperties() {
@@ -200,7 +226,7 @@ class Shard implements IShard {
       case ShardToManager.disconnected:
         return handleDisconnect(message.data['closeCode'] as int, message.data['closeReason'] as String?, message.seq);
       case ShardToManager.error:
-        return handleError(message.data['message'] as String, message.data['shouldReconnect'] as bool?, message.seq);
+        return handleError(message.data['message'] as String, message.seq);
       case ShardToManager.disposed:
         manager.logger.info("Shard $id disposed.");
         break;
@@ -266,15 +292,11 @@ class Shard implements IShard {
   }
 
   /// A handler for when the shard encounters an error. These can occur if the runner is in an invalid state or fails to open the websocket connection.
-  Future<void> handleError(String message, bool? shouldReconnect, int seq) async {
+  Future<void> handleError(String message, int seq) async {
     manager.logger.shout('Shard $id reported error: $message');
 
     for (final element in manager.connectionManager.client.plugins) {
       element.onConnectionError(manager.connectionManager.client, manager.logger, message);
-    }
-
-    if (shouldReconnect ?? false) {
-      Future.delayed(const Duration(seconds: 10), () => reconnect(seq));
     }
   }
 

--- a/lib/src/internal/shard/shard_handler.dart
+++ b/lib/src/internal/shard/shard_handler.dart
@@ -45,6 +45,10 @@ class ShardRunner implements Disposable {
   /// Whether this shard is currently connecting to the gateway.
   bool connecting = false;
 
+  /// The last sequence number
+  // Start at -1 and count down to avoid collisions with seq from the shard handler
+  int seq = -1;
+
   ShardRunner(this.sendPort) {
     managerMessages.listen(handle);
   }
@@ -57,6 +61,7 @@ class ShardRunner implements Disposable {
   /// Calls jsonDecode and sends the data back to the manager.
   void receive(String payload) => execute(ShardMessage(
         ShardToManager.received,
+        seq: seq--,
         data: jsonDecode(payload),
       ));
 
@@ -64,29 +69,37 @@ class ShardRunner implements Disposable {
   Future<void> handle(ShardMessage<ManagerToShard> message) async {
     switch (message.type) {
       case ManagerToShard.send:
-        return send(message.data);
+        return send(message.data, message.seq);
       case ManagerToShard.connect:
-        return connect(message.data['gatewayHost'] as String, message.data['useCompression'] as bool);
+        return connect(message.data['gatewayHost'] as String, message.data['useCompression'] as bool, message.seq);
       case ManagerToShard.reconnect:
-        return reconnect(message.data['gatewayHost'] as String, message.data['useCompression'] as bool);
+        return reconnect(message.data['gatewayHost'] as String, message.data['useCompression'] as bool, message.seq);
       case ManagerToShard.disconnect:
-        return disconnect();
+        return disconnect(message.seq);
       case ManagerToShard.dispose:
-        return dispose();
+        return dispose(message.seq);
     }
   }
 
   /// Initiate the connection on this shard.
   ///
   /// Sends [ShardToManager.connected] upon completion.
-  Future<void> connect(String gatewayHost, bool useCompression) async {
+  Future<void> connect(String gatewayHost, bool useCompression, int seq) async {
     if (connected) {
-      execute(ShardMessage(ShardToManager.error, data: {'message': 'Shard is already connected'}));
+      execute(ShardMessage(
+        ShardToManager.error,
+        seq: seq,
+        data: {'message': 'Shard is already connected'},
+      ));
       return;
     }
 
     if (connecting) {
-      execute(ShardMessage(ShardToManager.error, data: {'message': 'Shard is already connecting'}));
+      execute(ShardMessage(
+        ShardToManager.error,
+        seq: seq,
+        data: {'message': 'Shard is already connecting'},
+      ));
       return;
     }
 
@@ -105,6 +118,7 @@ class ShardRunner implements Disposable {
 
         execute(ShardMessage(
           ShardToManager.disconnected,
+          seq: seq,
           data: {
             'closeCode': connection!.closeCode!,
             'closeReason': connection!.closeReason,
@@ -133,40 +147,49 @@ class ShardRunner implements Disposable {
         connectionSubscription = connection!.cast<String>().listen(receive);
       }
 
-      execute(ShardMessage(ShardToManager.connected));
+      execute(ShardMessage(reconnecting ? ShardToManager.reconnected : ShardToManager.connected, seq: seq));
     } on WebSocketException catch (err) {
-      execute(ShardMessage(ShardToManager.error, data: {'message': err.message, 'shouldReconnect': true}));
+      execute(ShardMessage(ShardToManager.error, seq: seq, data: {'message': err.message, 'shouldReconnect': true}));
     } on SocketException catch (err) {
-      execute(ShardMessage(ShardToManager.error, data: {'message': err.message, 'shouldReconnect': true}));
+      execute(ShardMessage(ShardToManager.error, seq: seq, data: {'message': err.message, 'shouldReconnect': true}));
     } catch (err) {
-      execute(ShardMessage(ShardToManager.error, data: {'message': 'Unhanded exception $err'}));
+      execute(ShardMessage(ShardToManager.error, seq: seq, data: {'message': 'Unhanded exception $err'}));
     }
 
     connecting = false;
   }
 
   /// Reconnect to the server, closing the connection if necessary.
-  Future<void> reconnect(String gatewayHost, bool useCompression) async {
+  Future<void> reconnect(String gatewayHost, bool useCompression, int seq) async {
     if (reconnecting) {
-      execute(ShardMessage(ShardToManager.error, data: {'message': 'Shard is already reconnecting'}));
+      execute(ShardMessage(
+        ShardToManager.error,
+        seq: seq,
+        data: {'message': 'Shard is already reconnecting'},
+      ));
     }
 
     reconnecting = true;
     if (connected) {
       // Don't send a normal close code so that the bot doesn't appear offline during the reconnect.
-      await disconnect(3001);
+      await disconnect(seq, 3001);
     }
 
-    await connect(gatewayHost, useCompression);
+    // Sends reconnected instead of connected so we don't have to send it here
+    await connect(gatewayHost, useCompression, seq);
     reconnecting = false;
   }
 
   /// Terminate the connection on this shard.
   ///
   /// Sends [ShardToManager.disconnected].
-  Future<void> disconnect([int closeCode = 1000]) async {
+  Future<void> disconnect(int seq, [int closeCode = 1000]) async {
     if (!connected) {
-      execute(ShardMessage(ShardToManager.error, data: {'message': 'Cannot disconnect shard if no connection is active'}));
+      execute(ShardMessage(
+        ShardToManager.error,
+        seq: seq,
+        data: {'message': 'Cannot disconnect shard if no connection is active'},
+      ));
     }
 
     // Closing the connection will trigger the `connection.done` future we listened to when connecting, which will execute the [ShardToManager.disconnected]
@@ -179,9 +202,13 @@ class ShardRunner implements Disposable {
   }
 
   /// Sends data on this shard.
-  Future<void> send(dynamic data) async {
+  Future<void> send(dynamic data, int seq) async {
     if (!connected) {
-      execute(ShardMessage(ShardToManager.error, data: {'message': 'Cannot send data when connection is closed'}));
+      execute(ShardMessage(
+        ShardToManager.error,
+        seq: seq,
+        data: {'message': 'Cannot send data when connection is closed'},
+      ));
     }
 
     connection!.add(jsonEncode(data));
@@ -191,14 +218,15 @@ class ShardRunner implements Disposable {
   ///
   /// Sends [ShardToManager.disposed] upon completion.
   @override
-  Future<void> dispose() async {
+  Future<void> dispose([int? seq]) async {
     disposing = true;
+    seq ??= (this.seq--);
 
     if (connected) {
-      await disconnect();
+      await disconnect(seq);
     }
 
     receivePort.close();
-    execute(ShardMessage(ShardToManager.disposed));
+    execute(ShardMessage(ShardToManager.disposed, seq: seq));
   }
 }

--- a/lib/src/internal/shard/shard_handler.dart
+++ b/lib/src/internal/shard/shard_handler.dart
@@ -42,6 +42,9 @@ class ShardRunner implements Disposable {
   /// [ShardToManager.disconnected] will not be dispatched if this is true.
   bool disposing = false;
 
+  /// Whether this shard is currently connecting to the gateway.
+  bool connecting = false;
+
   ShardRunner(this.sendPort) {
     managerMessages.listen(handle);
   }
@@ -81,6 +84,13 @@ class ShardRunner implements Disposable {
       execute(ShardMessage(ShardToManager.error, data: {'message': 'Shard is already connected'}));
       return;
     }
+
+    if (connecting) {
+      execute(ShardMessage(ShardToManager.error, data: {'message': 'Shard is already connecting'}));
+      return;
+    }
+
+    connecting = true;
 
     try {
       final gatewayUri = Constants.gatewayUri(gatewayHost, useCompression);
@@ -131,6 +141,8 @@ class ShardRunner implements Disposable {
     } catch (err) {
       execute(ShardMessage(ShardToManager.error, data: {'message': 'Unhanded exception $err'}));
     }
+
+    connecting = false;
   }
 
   /// Reconnect to the server, closing the connection if necessary.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   http: ^0.13.3
   logging: ^1.0.1
   path: ^1.8.0
+  retry: ^3.1.0
 
 dev_dependencies:
   test: ^1.19.0


### PR DESCRIPTION
# Description

Ensures that shard connections and http requests retry if they fail due to a native exception (e.g due to a temporary internet outage) and that they do so with exponential backoff.

## Connected issues & other potential problems

Closes #394 and #382.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
