### PR TITLE
Add named arguments anywhere we can

### DIFF
--- a/lib/src/core/guild/auto_moderation.dart
+++ b/lib/src/core/guild/auto_moderation.dart
@@ -133,11 +133,11 @@ abstract class ITriggerMetadata {
 
   /// The total number of mentions (either role and user) allowed per message.
   /// (Maximum of 50)
-  /// The associated trigger type is [TriggerTypes.mentionSpam]
+  /// The associated trigger type is [TriggerTypes.mentionSpam].
   int? get mentionLimit;
 
-  /// Regular expression patterns which will be matched against content
-  /// The associated trigger type is [TriggerTypes.keyword]
+  /// Regular expression patterns which will be matched against content.
+  /// The associated trigger type is [TriggerTypes.keyword].
   Iterable<String>? get regexPatterns;
 }
 

--- a/lib/src/core/permissions/permissions.dart
+++ b/lib/src/core/permissions/permissions.dart
@@ -7,122 +7,131 @@ abstract class IPermissions implements Convertable<PermissionsBuilder> {
   /// The raw permission code.
   late final int raw;
 
-  /// True if user can create InstantInvite
+  /// True if user can create InstantInvite.
   bool get createInstantInvite;
 
-  /// True if user can kick members
+  /// True if user can kick members.
   bool get kickMembers;
 
-  /// True if user can ban members
+  /// True if user can ban members.
   bool get banMembers;
 
-  /// True if user is administrator
+  /// True if user is administrator.
   bool get administrator;
 
-  /// True if user can manager channels
+  /// True if user can manager channels.
   bool get manageChannels;
 
-  /// True if user can manager guilds
+  /// True if user can manager guilds.
   bool get manageGuild;
 
-  /// Allows to add reactions
+  /// Allows to add reactions.
   bool get addReactions;
 
-  /// Allows for using priority speaker in a voice channel
+  /// Allow to view audit logs.
+  bool get viewAuditLog;
+
+  /// Allows for using priority speaker in a voice channel.
   bool get prioritySpeaker;
 
-  /// Allow to view audit logs
-  bool get viewAuditLog;
+  /// Allows the user to go live.
+  bool get stream;
 
   /// Allow viewing channels (OLD READ_MESSAGES)
   bool get viewChannel;
 
-  /// True if user can send messages
+  /// True if user can send messages.
   bool get sendMessages;
 
-  /// True if user can send messages in threads
-  bool get sendMessagesInThreads;
-
-  /// True if user can send TTF messages
+  /// True if user can send TTS messages.
   bool get sendTtsMessages;
 
-  /// True if user can manage messages
+  /// True if user can manage messages.
   bool get manageMessages;
 
-  /// True if user can send links in messages
+  /// True if user can send links in messages.
   bool get embedLinks;
 
-  /// True if user can attach files in messages
+  /// True if user can attach files in messages.
   bool get attachFiles;
 
-  /// True if user can read messages history
+  /// True if user can read messages history.
   bool get readMessageHistory;
 
-  /// True if user can mention everyone
+  /// True if user can mention everyone.
   bool get mentionEveryone;
 
-  /// True if user can use external emojis
+  /// True if user can use external emojis.
   bool get useExternalEmojis;
 
-  /// True if user can connect to voice channel
-  bool get connect;
-
-  /// True if user can speak
-  bool get speak;
-
-  /// True if user can mute members
-  bool get muteMembers;
-
-  /// True if user can deafen members
-  bool get deafenMembers;
-
-  /// True if user can move members
-  bool get moveMembers;
-
-  /// Allows for using voice-activity-detection in a voice channel
-  bool get useVad;
-
-  /// True if user can change nick
-  bool get changeNickname;
-
-  /// True if user can manager others nicknames
-  bool get manageNicknames;
-
-  /// True if user can manage server's roles
-  bool get manageRoles;
-
-  /// True if user can manage webhooks
-  bool get manageWebhooks;
-
-  /// Allows management and editing of emojis
-  bool get manageEmojis;
-
-  /// Allows the user to go live
-  bool get stream;
-
-  /// Allows for viewing guild insights
+  /// Allows for viewing guild insights.
   bool get viewGuildInsights;
 
-  /// Allows members to use slash commands in text channels
+  /// True if user can connect to voice channel.
+  bool get connect;
+
+  /// True if user can speak.
+  bool get speak;
+
+  /// True if user can mute members.
+  bool get muteMembers;
+
+  /// True if user can deafen members.
+  bool get deafenMembers;
+
+  /// True if user can move members.
+  bool get moveMembers;
+
+  /// Allows for using voice-activity-detection in a voice channel.
+  bool get useVad;
+
+  /// True if user can change nick.
+  bool get changeNickname;
+
+  /// True if user can manager others nicknames.
+  bool get manageNicknames;
+
+  /// True if user can manage server's roles.
+  bool get manageRoles;
+
+  /// True if user can manage webhooks.
+  bool get manageWebhooks;
+
+  @Deprecated('Use "manageEmojisAndStickers" instead')
+  bool get manageEmojis;
+
+  /// Allows management and editing of emojis and stickers.
+  bool get manageEmojisAndStickers;
+
+  /// Allows for creating, editing, and deleting scheduled events.
+  bool get manageEvents;
+
+  /// Allows members to use slash commands in text channels.
   bool get useSlashCommands;
 
-  /// Allows for requesting to speak in stage channels
+  /// Allows for requesting to speak in stage channels.
   bool get requestToSpeak;
 
-  /// Allows for deleting and archiving threads, and viewing all private threads
+  /// Allows for deleting and archiving threads, and viewing all private threads.
   bool get manageThreads;
 
-  /// Allows for creating and participating in threads
+  /// Allows for creating and participating in threads.
   bool get createPublicThreads;
 
-  /// Allows for creating and participating in private threads
+  /// Allows for creating and participating in private threads.
   bool get createPrivateThreads;
 
-  /// Allows the usage of custom stickers from other servers
+  /// Allows the usage of custom stickers from other servers.
   bool get useExternalStickers;
 
-  /// Allows for launching activities in a voice channel
+  /// True if user can send messages in threads.
+  bool get sendMessagesInThreads;
+
+  /// Allows for launching activities in a voice channel.
   bool get startEmbeddedActivities;
+
+  /// Allows for timing out users to prevent them from sending or reacting to messages in chat and threads, and from speaking in voice and stage channels.
+  bool get moderateMembers;
 
   /// Returns true if this permissions has [permission]
   bool hasPermission(int permission);
@@ -134,39 +143,39 @@ class Permissions implements IPermissions {
   @override
   late final int raw;
 
-  /// True if user can create InstantInvite
+  /// True if user can create InstantInvite.
   @override
   bool get createInstantInvite => PermissionsUtils.isApplied(raw, PermissionsConstants.createInstantInvite);
 
-  /// True if user can kick members
+  /// True if user can kick members.
   @override
   bool get kickMembers => PermissionsUtils.isApplied(raw, PermissionsConstants.kickMembers);
 
-  /// True if user can ban members
+  /// True if user can ban members.
   @override
   bool get banMembers => PermissionsUtils.isApplied(raw, PermissionsConstants.banMembers);
 
-  /// True if user is administrator
+  /// True if user is administrator.
   @override
   bool get administrator => PermissionsUtils.isApplied(raw, PermissionsConstants.administrator);
 
-  /// True if user can manager channels
+  /// True if user can manager channels.
   @override
   bool get manageChannels => PermissionsUtils.isApplied(raw, PermissionsConstants.manageChannels);
 
-  /// True if user can manager guilds
+  /// True if user can manager guilds.
   @override
   bool get manageGuild => PermissionsUtils.isApplied(raw, PermissionsConstants.manageGuild);
 
-  /// Allows to add reactions
+  /// Allows to add reactions.
   @override
   bool get addReactions => PermissionsUtils.isApplied(raw, PermissionsConstants.addReactions);
 
-  /// Allows for using priority speaker in a voice channel
+  /// Allows for using priority speaker in a voice channel.
   @override
   bool get prioritySpeaker => PermissionsUtils.isApplied(raw, PermissionsConstants.prioritySpeaker);
 
-  /// Allow to view audit logs
+  /// Allow to view audit logs.
   @override
   bool get viewAuditLog => PermissionsUtils.isApplied(raw, PermissionsConstants.viewAuditLog);
 
@@ -174,132 +183,141 @@ class Permissions implements IPermissions {
   @override
   bool get viewChannel => PermissionsUtils.isApplied(raw, PermissionsConstants.viewChannel);
 
-  /// True if user can send messages
+  /// True if user can send messages.
   @override
   bool get sendMessages => PermissionsUtils.isApplied(raw, PermissionsConstants.sendMessages);
 
-  /// True if user can send messages in threads
+  /// True if user can send messages in threads.
   @override
-  bool get sendMessagesInThreads => PermissionsUtils.isApplied(raw, PermissionsConstants.sendMessagesInThread);
+  bool get sendMessagesInThreads => PermissionsUtils.isApplied(raw, PermissionsConstants.sendMessagesInThreads);
 
-  /// True if user can send TTF messages
+  /// True if user can send TTF messages.
   @override
   bool get sendTtsMessages => PermissionsUtils.isApplied(raw, PermissionsConstants.sendTtsMessages);
 
-  /// True if user can manage messages
+  /// True if user can manage messages.
   @override
   bool get manageMessages => PermissionsUtils.isApplied(raw, PermissionsConstants.manageMessages);
 
-  /// True if user can send links in messages
+  /// True if user can send links in messages.
   @override
   bool get embedLinks => PermissionsUtils.isApplied(raw, PermissionsConstants.embedLinks);
 
-  /// True if user can attach files in messages
+  /// True if user can attach files in messages.
   @override
   bool get attachFiles => PermissionsUtils.isApplied(raw, PermissionsConstants.attachFiles);
 
-  /// True if user can read messages history
+  /// True if user can read messages history.
   @override
   bool get readMessageHistory => PermissionsUtils.isApplied(raw, PermissionsConstants.readMessageHistory);
 
-  /// True if user can mention everyone
+  /// True if user can mention everyone.
   @override
   bool get mentionEveryone => PermissionsUtils.isApplied(raw, PermissionsConstants.mentionEveryone);
 
-  /// True if user can use external emojis
+  /// True if user can use external emojis.
   @override
-  bool get useExternalEmojis => PermissionsUtils.isApplied(raw, PermissionsConstants.externalEmojis);
+  bool get useExternalEmojis => PermissionsUtils.isApplied(raw, PermissionsConstants.useExternalEmojis);
 
-  /// True if user can connect to voice channel
+  /// True if user can connect to voice channel.
   @override
   bool get connect => PermissionsUtils.isApplied(raw, PermissionsConstants.connect);
 
-  /// True if user can speak
+  /// True if user can speak.
   @override
   bool get speak => PermissionsUtils.isApplied(raw, PermissionsConstants.speak);
 
-  /// True if user can mute members
+  /// True if user can mute members.
   @override
   bool get muteMembers => PermissionsUtils.isApplied(raw, PermissionsConstants.muteMembers);
 
-  /// True if user can deafen members
+  /// True if user can deafen members.
   @override
   bool get deafenMembers => PermissionsUtils.isApplied(raw, PermissionsConstants.deafenMembers);
 
-  /// True if user can move members
+  /// True if user can move members.
   @override
   bool get moveMembers => PermissionsUtils.isApplied(raw, PermissionsConstants.moveMembers);
 
-  /// Allows for using voice-activity-detection in a voice channel
+  /// Allows for using voice-activity-detection in a voice channel.
   @override
   bool get useVad => PermissionsUtils.isApplied(raw, PermissionsConstants.useVad);
 
-  /// True if user can change nick
+  /// True if user can change nick.
   @override
   bool get changeNickname => PermissionsUtils.isApplied(raw, PermissionsConstants.changeNickname);
 
-  /// True if user can manager others nicknames
+  /// True if user can manager others nicknames.
   @override
   bool get manageNicknames => PermissionsUtils.isApplied(raw, PermissionsConstants.manageNicknames);
 
-  /// True if user can manage server's roles
+  /// True if user can manage server's roles.
   @override
-  bool get manageRoles => PermissionsUtils.isApplied(raw, PermissionsConstants.manageRolesOrPermissions);
+  bool get manageRoles => PermissionsUtils.isApplied(raw, PermissionsConstants.manageRoles);
 
-  /// True if user can manage webhooks
+  /// True if user can manage webhooks.
   @override
   bool get manageWebhooks => PermissionsUtils.isApplied(raw, PermissionsConstants.manageWebhooks);
 
-  /// Allows management and editing of emojis
+  @Deprecated('Use "manageEmojisAndStickers" instead')
   @override
-  bool get manageEmojis => PermissionsUtils.isApplied(raw, PermissionsConstants.manageEmojis);
+  bool get manageEmojis => manageEmojisAndStickers;
 
-  /// Allows the user to go live
+  @override
+  bool get manageEmojisAndStickers => PermissionsUtils.isApplied(raw, PermissionsConstants.manageEmojisAndStickers);
+
+  /// Allows the user to go live.
   @override
   bool get stream => PermissionsUtils.isApplied(raw, PermissionsConstants.stream);
 
-  /// Allows for viewing guild insights
+  /// Allows for viewing guild insights.
   @override
   bool get viewGuildInsights => PermissionsUtils.isApplied(raw, PermissionsConstants.viewGuildInsights);
 
-  /// Allows members to use slash commands in text channels
+  /// Allows members to use slash commands in text channels.
   @override
   bool get useSlashCommands => PermissionsUtils.isApplied(raw, PermissionsConstants.useSlashCommands);
 
-  /// Allows for requesting to speak in stage channels
+  /// Allows for requesting to speak in stage channels.
   @override
   bool get requestToSpeak => PermissionsUtils.isApplied(raw, PermissionsConstants.useSlashCommands);
 
-  /// Allows for deleting and archiving threads, and viewing all private threads
+  /// Allows for deleting and archiving threads, and viewing all private threads.
   @override
   bool get manageThreads => PermissionsUtils.isApplied(raw, PermissionsConstants.manageThreads);
 
-  /// Allows for creating and participating in threads
+  /// Allows for creating and participating in threads.
   @override
   bool get createPublicThreads => PermissionsUtils.isApplied(raw, PermissionsConstants.createPublicThreads);
 
-  /// Allows for creating and participating in private threads
+  /// Allows for creating and participating in private threads.
   @override
   bool get createPrivateThreads => PermissionsUtils.isApplied(raw, PermissionsConstants.createPrivateThreads);
 
-  /// Allows the usage of custom stickers from other servers
+  /// Allows the usage of custom stickers from other servers.
   @override
   bool get useExternalStickers => PermissionsUtils.isApplied(raw, PermissionsConstants.useExternalStickers);
 
-  /// Allows for launching activities in a voice channel
+  /// Allows for launching activities in a voice channel.
   @override
   bool get startEmbeddedActivities => PermissionsUtils.isApplied(raw, PermissionsConstants.startEmbeddedActivities);
+
+  @override
+  bool get moderateMembers => PermissionsUtils.isApplied(raw, PermissionsConstants.moderateMembers);
+
+  @override
+  bool get manageEvents => PermissionsUtils.isApplied(raw, PermissionsConstants.manageEvents);
 
   /// Creates an instance of [Permissions]
   Permissions(this.raw);
 
-  /// Permissions with value of 0
+  /// Permissions with value of 0.
   factory Permissions.empty() => Permissions(0);
 
-  /// Permissions with max value
+  /// Permissions with max value.
   factory Permissions.all() => Permissions(PermissionsConstants.allPermissions);
 
-  /// Makes a [Permissions] object from overwrite object
+  /// Makes a [Permissions] object from overwrite object.
   factory Permissions.fromOverwrite(int permissions, int allow, int deny) => Permissions(PermissionsUtils.apply(permissions, allow, deny));
 
   /// Returns true if this permissions has [permission]

--- a/lib/src/core/permissions/permissions_constants.dart
+++ b/lib/src/core/permissions/permissions_constants.dart
@@ -1,122 +1,180 @@
 /// Permissions constants
 class PermissionsConstants {
-  /// Allows to create instant invite
+  /// Allows to create instant invite.
   static const int createInstantInvite = 1 << 0;
 
-  /// Allows to kick members
+  /// Allows to kick members.
   static const int kickMembers = 1 << 1;
 
-  /// Allows to ban members
+  /// Allows to ban members.
   static const int banMembers = 1 << 2;
 
-  /// Given to administrator
+  /// Given to administrator.
   static const int administrator = 1 << 3;
 
   /// Allows to manage channels(renaming, changing permissions)
   static const int manageChannels = 1 << 4;
 
-  /// Allows to manager guild
+  /// Allows to manager guild.
   static const int manageGuild = 1 << 5;
 
-  /// Allows for the addition of reactions to messages
+  /// Allows for the addition of reactions to messages.
   static const int addReactions = 1 << 6;
 
-  /// Allows for viewing of audit logs
+  /// Allows for viewing of audit logs.
   static const int viewAuditLog = 1 << 7;
 
-  /// Allows for using priority speaker in a voice channel
+  /// Allows for using priority speaker in a voice channel.
   static const int prioritySpeaker = 1 << 8;
 
-  /// Allows the user to go live
+  /// Allows the user to go live.
   static const int stream = 1 << 9;
 
-  /// Allows guild members to view a channel, which includes reading messages in text channels
+  /// Allows guild members to view a channel, which includes reading messages in text channels.
   static const int viewChannel = 1 << 10;
 
-  /// Allows to send messages
+  /// Allows to send messages.
   static const int sendMessages = 1 << 11;
 
-  /// Allows to send messages in threads
-  static const int sendMessagesInThread = 1 << 38;
-
-  /// Allows to send TTS messages
+  /// Allows to send TTS messages.
   static const int sendTtsMessages = 1 << 12;
 
-  /// Allows to deletes, edit messages
+  /// Allows to deletes, edit messages.
   static const int manageMessages = 1 << 13;
 
-  /// Links sent by users with this permission will be auto-embedded
+  /// Links sent by users with this permission will be auto-embedded.
   static const int embedLinks = 1 << 14;
 
-  /// Allows for uploading images and files
+  /// Allows for uploading images and files.
   static const int attachFiles = 1 << 15;
 
-  /// Allows for reading of message history
+  /// Allows for reading of message history.
   static const int readMessageHistory = 1 << 16;
 
-  /// Allows for using the @everyone tag to notify all users in a channel, and the @here tag to notify all online users in a channel
+  /// Allows for using the @everyone tag to notify all users in a channel, and the @here tag to notify all online users in a channel.
   static const int mentionEveryone = 1 << 17;
 
-  /// Allows the usage of custom emojis from other servers
-  static const int externalEmojis = 1 << 18;
+  /// Allows the usage of custom emojis from other servers.
+  static const int useExternalEmojis = 1 << 18;
 
-  /// Allows for viewing guild insights
+  @Deprecated('Use "useExternalEMojis" instead')
+  static const int externalEmojis = useExternalEmojis;
+
+  /// Allows for viewing guild insights.
   static const int viewGuildInsights = 1 << 19;
 
-  /// Allows for joining of a voice channel
+  /// Allows for joining of a voice channel.
   static const int connect = 1 << 20;
 
-  /// Allows for speaking in a voice channel
+  /// Allows for speaking in a voice channel.
   static const int speak = 1 << 21;
 
-  /// Allows for muting members in a voice channel
+  /// Allows for muting members in a voice channel.
   static const int muteMembers = 1 << 22;
 
-  /// Allows for deafening of members in a voice channel
+  /// Allows for deafening of members in a voice channel.
   static const int deafenMembers = 1 << 23;
 
-  /// Allows for moving of members between voice channels
+  /// Allows for moving of members between voice channels.
   static const int moveMembers = 1 << 24;
 
-  /// Allows for using voice-activity-detection in a voice channel
+  /// Allows for using voice-activity-detection in a voice channel.
   static const int useVad = 1 << 25;
 
-  /// Allows for modification of own nickname
+  /// Allows for modification of own nickname.
   static const int changeNickname = 1 << 26;
 
-  /// Allows for modification of other users nicknames
+  /// Allows for modification of other users nicknames.
   static const int manageNicknames = 1 << 27;
 
-  /// Allows management and editing of roles
-  static const int manageRolesOrPermissions = 1 << 28;
+  @Deprecated('Use "manageRoles" instead')
+  static const int manageRolesOrPermissions = manageRoles;
 
-  /// Allows management and editing of webhooks
+  /// Allows management and editing of roles.
+  static const int manageRoles = 1 << 28;
+
+  /// Allows management and editing of webhooks.
   static const int manageWebhooks = 1 << 29;
 
-  /// Allows management and editing of emojis
-  static const int manageEmojis = 1 << 30;
+  static const int manageEmojisAndStickers = 1 << 30;
 
-  /// Allows members to use slash commands in text channels
+  @Deprecated('Use "manageEmojisAndStickers" instead')
+  static const int manageEmojis = manageEmojisAndStickers;
+
+  /// Allows members to use slash commands in text channels.
   static const int useSlashCommands = 1 << 31;
 
-  /// Allows for requesting to speak in stage channels
+  /// Allows for requesting to speak in stage channels.
   static const int requestToSpeak = 1 << 32;
 
-  /// Allows for deleting and archiving threads, and viewing all private threads
+  /// Allows for creating, editing, and deleting scheduled events.
+  static const int manageEvents = 1 << 33;
+
+  /// Allows for deleting and archiving threads, and viewing all private threads.
   static const int manageThreads = 1 << 34;
 
-  /// Allows for creating and participating in threads
+  /// Allows for creating and participating in threads.
   static const int createPublicThreads = 1 << 35;
 
-  /// Allows for creating and participating in private threads
+  /// Allows for creating and participating in private threads.
   static const int createPrivateThreads = 1 << 36;
 
-  /// Allows the usage of custom stickers from other servers
+  /// Allows the usage of custom stickers from other servers.
   static const int useExternalStickers = 1 << 37;
 
-  /// Allows for launching activities in a voice channel
+  @Deprecated('Use "sendMessagesInThreads instead')
+  static const int sendMessagesInThread = sendMessagesInThreads;
+
+  /// Allows to send messages in threads.
+  static const int sendMessagesInThreads = 1 << 38;
+
+  /// Allows for launching activities in a voice channel.
   static const int startEmbeddedActivities = 1 << 39;
 
-  /// All of the permissions
-  static int get allPermissions => 1099511627775;
+  /// Allows for timing out users to prevent them from sending or reacting to messages in chat and threads, and from speaking in voice and stage channels.
+  static const int moderateMembers = 1 << 40;
+
+  /// All of the permissions.
+  static int get allPermissions =>
+      createInstantInvite |
+      kickMembers |
+      banMembers |
+      administrator |
+      manageChannels |
+      manageGuild |
+      addReactions |
+      viewAuditLog |
+      prioritySpeaker |
+      stream |
+      viewChannel |
+      sendMessages |
+      sendTtsMessages |
+      manageMessages |
+      embedLinks |
+      attachFiles |
+      readMessageHistory |
+      mentionEveryone |
+      useExternalEmojis |
+      viewGuildInsights |
+      connect |
+      speak |
+      muteMembers |
+      deafenMembers |
+      moveMembers |
+      useVad |
+      changeNickname |
+      manageNicknames |
+      manageRoles |
+      manageWebhooks |
+      manageEmojisAndStickers |
+      useSlashCommands |
+      requestToSpeak |
+      manageEvents |
+      manageThreads |
+      createPublicThreads |
+      createPrivateThreads |
+      useExternalStickers |
+      sendMessagesInThreads |
+      startEmbeddedActivities |
+      moderateMembers;
 }

--- a/lib/src/internal/http_endpoints.dart
+++ b/lib/src/internal/http_endpoints.dart
@@ -978,7 +978,7 @@ class HttpEndpoints implements IHttpEndpoints {
   Future<IUser> fetchUser(Snowflake userId) async {
     final response = await executeSafe(BasicRequest(HttpRoute()..users(id: userId.toString())));
 
-    final user = User(client, (response as HttpResponseSuccess).jsonBody as RawApiMap);
+    final user = User(client, response.jsonBody as RawApiMap);
 
     if (client.cacheOptions.userCachePolicyLocation.http) {
       client.users[user.id] = user;

--- a/lib/src/utils/builders/auto_moderation_builder.dart
+++ b/lib/src/utils/builders/auto_moderation_builder.dart
@@ -30,8 +30,16 @@ class AutoModerationRuleBuilder implements Builder {
   /// The channel ids that should not be affected by the rule. (Maximum of 50).
   List<Snowflake>? ignoredChannels;
 
-  AutoModerationRuleBuilder(this.name,
-      {required this.eventType, required this.triggerType, required this.actions, this.triggerMetadata, this.enabled, this.ignoredChannels, this.ignoredRoles});
+  AutoModerationRuleBuilder(
+    this.name, {
+    required this.eventType,
+    required this.triggerType,
+    required this.actions,
+    this.triggerMetadata,
+    this.enabled,
+    this.ignoredChannels,
+    this.ignoredRoles,
+  });
 
   @override
   RawApiMap build() => {
@@ -74,7 +82,10 @@ class ActionMetadataBuilder implements Builder {
   /// (Works only when it's action type is [ActionTypes.timeout]).
   Duration? duration;
 
-  ActionMetadataBuilder({this.channelId, this.duration});
+  ActionMetadataBuilder({
+    this.channelId,
+    this.duration,
+  });
 
   @override
   RawApiMap build() => {

--- a/lib/src/utils/builders/auto_moderation_builder.dart
+++ b/lib/src/utils/builders/auto_moderation_builder.dart
@@ -108,15 +108,16 @@ class TriggerMetadataBuilder implements Builder {
   /// (Maximum of 50)
   int? mentionLimit;
 
+  /// Regular expression patterns which will be matched against content.
+  ///(Maximum of 10)
+  List<String>? regexPatterns;
+
   TriggerMetadataBuilder({
     this.allowList,
     this.keywordFilter,
     this.mentionLimit,
     this.presets,
   });
-  /// Regular expression patterns which will be matched against content
-  ///(Maximum of 10)
-  List<String>? regexPatterns;
 
   @override
   RawApiMap build() => {

--- a/lib/src/utils/builders/auto_moderation_builder.dart
+++ b/lib/src/utils/builders/auto_moderation_builder.dart
@@ -30,7 +30,8 @@ class AutoModerationRuleBuilder implements Builder {
   /// The channel ids that should not be affected by the rule. (Maximum of 50).
   List<Snowflake>? ignoredChannels;
 
-  AutoModerationRuleBuilder(this.name, {required this.eventType, required this.triggerType, required this.actions});
+  AutoModerationRuleBuilder(this.name,
+      {required this.eventType, required this.triggerType, required this.actions, this.triggerMetadata, this.enabled, this.ignoredChannels, this.ignoredRoles});
 
   @override
   RawApiMap build() => {
@@ -96,6 +97,13 @@ class TriggerMetadataBuilder implements Builder {
   /// (Maximum of 50)
   // Pr still not merged
   int? mentionLimit;
+
+  TriggerMetadataBuilder({
+    this.allowList,
+    this.keywordFilter,
+    this.mentionLimit,
+    this.presets,
+  });
 
   @override
   RawApiMap build() => {

--- a/lib/src/utils/builders/channel_builder.dart
+++ b/lib/src/utils/builders/channel_builder.dart
@@ -22,6 +22,15 @@ abstract class ChannelBuilder implements Builder {
   /// The channel's permission overwrites
   List<PermissionOverrideBuilder>? permissionOverrides;
 
+  ChannelBuilder._({
+    this.id,
+    this.name,
+    this.parentChannel,
+    this.permissionOverrides,
+    this.position,
+    this.type,
+  });
+
   @override
   RawApiMap build() => {
         if (name != null) "name": name,
@@ -52,6 +61,18 @@ class VoiceChannelBuilder extends ChannelBuilder {
   /// Channel voice region id, automatic when set to null
   String? rtcRegion = "";
 
+  VoiceChannelBuilder({
+    super.id,
+    super.name,
+    super.parentChannel,
+    super.permissionOverrides,
+    super.position,
+    this.bitrate,
+    this.rateLimitPerUser,
+    this.rtcRegion,
+    this.userLimit,
+  }) : super._();
+
   @override
   RawApiMap build() => {
         ...super.build(),
@@ -74,7 +95,15 @@ class TextChannelBuilder extends ChannelBuilder {
   /// Whether the channel is nsfw
   bool? nsfw;
 
-  TextChannelBuilder();
+  TextChannelBuilder({
+    super.id,
+    super.name,
+    super.parentChannel,
+    super.permissionOverrides,
+    super.position,
+    this.nsfw,
+    this.topic,
+  }) : super._();
   factory TextChannelBuilder.create(String name) {
     final builder = TextChannelBuilder();
     builder.name = name;

--- a/lib/src/utils/builders/embed_author_builder.dart
+++ b/lib/src/utils/builders/embed_author_builder.dart
@@ -17,7 +17,11 @@ class EmbedAuthorBuilder extends Builder {
   int? get length => name?.length;
 
   /// Create empty [EmbedAuthorBuilder]
-  EmbedAuthorBuilder();
+  EmbedAuthorBuilder({
+    this.iconUrl,
+    this.name,
+    this.url,
+  });
 
   /// Builds object to Map() instance;
   @override

--- a/lib/src/utils/builders/embed_builder.dart
+++ b/lib/src/utils/builders/embed_builder.dart
@@ -42,7 +42,19 @@ class EmbedBuilder extends Builder {
   late List<EmbedFieldBuilder> fields;
 
   /// Creates clean instance [EmbedBuilder]
-  EmbedBuilder() {
+  EmbedBuilder({
+    this.author,
+    this.color,
+    this.description,
+    this.fields = const [],
+    this.footer,
+    this.imageUrl,
+    this.thumbnailUrl,
+    this.timestamp,
+    this.title,
+    this.type,
+    this.url,
+  }) {
     fields = [];
   }
 

--- a/lib/src/utils/builders/embed_field_builder.dart
+++ b/lib/src/utils/builders/embed_field_builder.dart
@@ -5,16 +5,19 @@ import 'package:nyxx/src/utils/builders/builder.dart';
 /// Builder for embed Field.
 class EmbedFieldBuilder extends Builder {
   /// Field name/title
-  dynamic name;
+  Object? name;
 
   /// Field content
-  dynamic content;
+  Object? content;
 
   /// Whether or not this field should display inline
   bool? inline;
 
   /// Constructs new instance of Field
   EmbedFieldBuilder([this.name, this.content, this.inline]);
+
+  /// Constructs new instance of Field
+  EmbedFieldBuilder.named({this.name, this.content, this.inline});
 
   /// Length of current field
   int get length => name.toString().length + content.toString().length;

--- a/lib/src/utils/builders/embed_footer_builder.dart
+++ b/lib/src/utils/builders/embed_footer_builder.dart
@@ -14,7 +14,7 @@ class EmbedFooterBuilder extends Builder {
   int? get length => text?.length;
 
   /// Create empty [EmbedFooterBuilder]
-  EmbedFooterBuilder();
+  EmbedFooterBuilder({this.iconUrl, this.text});
 
   @override
 

--- a/lib/src/utils/builders/forum_thread_builder.dart
+++ b/lib/src/utils/builders/forum_thread_builder.dart
@@ -30,7 +30,13 @@ class ForumThreadBuilder implements Builder {
   /// Set of tags that have been applied to a thread
   Iterable<ForumTagBuilder>? appliedTags;
 
-  ForumThreadBuilder(this.name, this.message);
+  ForumThreadBuilder(
+    this.name,
+    this.message, {
+    this.appliedTags,
+    this.archiveAfter,
+    this.rateLimitPerUser,
+  });
 
   @override
   RawApiMap build() {

--- a/lib/src/utils/builders/guild_builder.dart
+++ b/lib/src/utils/builders/guild_builder.dart
@@ -13,7 +13,7 @@ class GuildBuilder extends Builder {
   final String name;
 
   /// Voice region id
-  @Deprecated('IGuild.region is deprecated, consider using IVoiceChannel.rtcRegion instead')
+  @Deprecated('GuildBuilder.region is deprecated, consider using VoiceChannelBuilder.rtcRegion instead')
   String? region;
 
   /// The 128x128 icon for the guild
@@ -52,7 +52,20 @@ class GuildBuilder extends Builder {
   SystemChannelFlags? systemChannelFlags;
 
   /// Create new instance of [GuildBuilder]
-  GuildBuilder(this.name);
+  GuildBuilder(
+    this.name, {
+    this.afkChannelId,
+    this.afkTimeout,
+    this.channels,
+    this.defaultMessageNotifications,
+    this.explicitContentFilter,
+    this.icon,
+    @Deprecated('GuildBuilder.region is deprecated, consider using VoiceChannelBuilder.rtcRegion instead') this.region,
+    this.roles,
+    this.systemChannelFlags,
+    this.systemChannelId,
+    this.verificationLevel,
+  });
 
   @override
   RawApiMap build() => <String, dynamic>{
@@ -108,7 +121,17 @@ class RoleBuilder extends Builder {
   String? roleIconEmoji;
 
   /// Creates role
-  RoleBuilder(this.name);
+  RoleBuilder(
+    this.name, {
+    this.color,
+    this.hoist,
+    this.id,
+    this.mentionable,
+    this.permission,
+    this.position,
+    this.roleIcon,
+    this.roleIconEmoji,
+  });
 
   @override
   RawApiMap build() => <String, dynamic>{

--- a/lib/src/utils/builders/guild_event_builder.dart
+++ b/lib/src/utils/builders/guild_event_builder.dart
@@ -29,6 +29,18 @@ class GuildEventBuilder implements Builder {
   /// The status of the scheduled event
   GuildEventStatus? status;
 
+  GuildEventBuilder({
+    this.channelId,
+    this.description,
+    this.endDate,
+    this.metadata,
+    this.name,
+    this.privacyLevel,
+    this.startDate,
+    this.status,
+    this.type,
+  });
+
   @override
   RawApiMap build() => {
         if (channelId?.id == 0) "channel_id": channelId.toString(),

--- a/lib/src/utils/builders/member_builder.dart
+++ b/lib/src/utils/builders/member_builder.dart
@@ -19,6 +19,15 @@ class MemberBuilder implements Builder {
   /// When the user's timeout will expire and the user will be able to communicate in the guild again (up to 28 days in the future), set to null to remove timeout
   DateTime? timeoutUntil = DateTime.fromMillisecondsSinceEpoch(0);
 
+  MemberBuilder({
+    this.channel,
+    this.deaf,
+    this.mute,
+    this.nick,
+    this.roles,
+    this.timeoutUntil,
+  });
+
   @override
   RawApiMap build() => {
         if (nick != null) 'nick': nick,

--- a/lib/src/utils/builders/member_builder.dart
+++ b/lib/src/utils/builders/member_builder.dart
@@ -20,13 +20,13 @@ class MemberBuilder implements Builder {
   DateTime? timeoutUntil = DateTime.fromMillisecondsSinceEpoch(0);
 
   MemberBuilder({
-    this.channel,
+    this.channel = const Snowflake.zero(),
     this.deaf,
     this.mute,
     this.nick,
     this.roles,
-    this.timeoutUntil,
-  });
+    DateTime? timeoutUntil,
+  }) : timeoutUntil = timeoutUntil ?? DateTime.fromMicrosecondsSinceEpoch(0);
 
   @override
   RawApiMap build() => {

--- a/lib/src/utils/builders/message_builder.dart
+++ b/lib/src/utils/builders/message_builder.dart
@@ -52,7 +52,7 @@ class MessageBuilder {
 
   /// Generic constructor for [MessageBuilder]
   MessageBuilder({
-    String? content,
+    String? content = '',
     this.allowedMentions,
     this.attachments,
     this.embeds,

--- a/lib/src/utils/builders/message_builder.dart
+++ b/lib/src/utils/builders/message_builder.dart
@@ -42,7 +42,7 @@ class MessageBuilder {
   final _content = StringBuffer();
 
   /// Clears current content of message and sets new
-  set content(Object content) {
+  set content(Object? content) {
     _content.clear();
     _content.write(content);
   }
@@ -51,7 +51,18 @@ class MessageBuilder {
   String get content => _content.toString();
 
   /// Generic constructor for [MessageBuilder]
-  MessageBuilder();
+  MessageBuilder({
+    String? content,
+    this.allowedMentions,
+    this.attachments,
+    this.embeds,
+    this.files,
+    this.nonce,
+    this.replyBuilder,
+    this.tts,
+  }) {
+    this.content = content;
+  }
 
   /// Creates [MessageBuilder] with only content
   factory MessageBuilder.content(String content) => MessageBuilder()..content = content;

--- a/lib/src/utils/builders/permissions_builder.dart
+++ b/lib/src/utils/builders/permissions_builder.dart
@@ -3,10 +3,11 @@ import 'package:nyxx/src/core/guild/role.dart';
 import 'package:nyxx/src/core/permissions/permissions.dart';
 
 /// Set of permissions ints
-class _PermissionsSet {
+class _PermissionsSet extends Builder {
   int allow = 0;
   int deny = 0;
 
+  @override
   RawApiMap build() => {"allow": allow, "deny": deny};
 }
 
@@ -15,13 +16,13 @@ class PermissionOverrideBuilder extends PermissionsBuilder {
   /// Type of permission override either `role` or `member`
   final int type;
 
-  /// Id of entity of permission override
+  /// Id of entity of permission override.
   final Snowflake id;
 
   /// Create builder manually from known data. Id is id of entity. [type] can be either 0 for `role` or 1 for `member`.
   PermissionOverrideBuilder.from(this.type, this.id, Permissions permissions) : super.from(permissions);
 
-  /// Create empty permission builder
+  /// Create empty permission builder.
   PermissionOverrideBuilder(this.type, this.id) : super();
 
   /// Create [PermissionsOverrides] for given [entity]. Entity have to be either [Role] or [Member]
@@ -43,113 +44,173 @@ class PermissionsBuilder extends Builder {
   /// The raw permission code.
   int? raw;
 
-  /// True if user can create InstantInvite
+  /// True if user can create InstantInvite.
   bool? createInstantInvite;
 
-  /// True if user can kick members
+  /// True if user can kick members.
   bool? kickMembers;
 
-  /// True if user can ban members
+  /// True if user can ban members.
   bool? banMembers;
 
-  /// True if user is administrator
+  /// True if user is administrator.
   bool? administrator;
 
-  /// True if user can manager channels
+  /// True if user can manager channels.
   bool? manageChannels;
 
-  /// True if user can manager guilds
+  /// True if user can manager guilds.
   bool? manageGuild;
 
-  /// Allows to add reactions
+  /// Allows to add reactions.
   bool? addReactions;
 
-  /// Allows for using priority speaker in a voice channel
+  /// Allows for using priority speaker in a voice channel.
   bool? prioritySpeaker;
 
-  /// Allow to view audit logs
+  /// Allow to view audit logs.
   bool? viewAuditLog;
 
   /// Allow viewing channels (OLD READ_MESSAGES)
   bool? viewChannel;
 
-  /// True if user can send messages
+  /// True if user can send messages.
   bool? sendMessages;
 
-  /// True if user can send messages in threads
+  /// True if user can send messages in threads.
   bool? sendMessagesInThreads;
 
-  /// True if user can send TTF messages
+  /// True if user can send TTF messages.
   bool? sendTtsMessages;
 
-  /// True if user can manage messages
+  /// True if user can manage messages.
   bool? manageMessages;
 
-  /// True if user can send links in messages
+  /// True if user can send links in messages.
   bool? embedLinks;
 
-  /// True if user can attach files in messages
+  /// True if user can attach files in messages.
   bool? attachFiles;
 
-  /// True if user can read messages history
+  /// True if user can read messages history.
   bool? readMessageHistory;
 
-  /// True if user can mention everyone
+  /// True if user can mention everyone.
   bool? mentionEveryone;
 
-  /// True if user can use external emojis
+  /// True if user can use external emojis.
   bool? useExternalEmojis;
 
-  /// True if user can connect to voice channel
+  /// Allows the usage of custom stickers from other servers.
+  bool? useExternalStickers;
+
+  /// Allows members to use application commands, including slash commands and context menu commands.
+  bool? useSlashCommands;
+
+  /// True if user can connect to voice channel.
   bool? connect;
 
-  /// True if user can speak
+  /// True if user can speak.
   bool? speak;
 
-  /// True if user can mute members
+  /// True if user can mute members.
   bool? muteMembers;
 
-  /// True if user can deafen members
+  /// True if user can deafen members.
   bool? deafenMembers;
 
-  /// True if user can move members
+  /// True if user can move members.
   bool? moveMembers;
 
-  /// Allows for using voice-activity-detection in a voice channel
+  /// Allows for using voice-activity-detection in a voice channel.
   bool? useVad;
 
-  /// True if user can change nick
+  /// True if user can change nick.
   bool? changeNickname;
 
-  /// True if user can manager others nicknames
+  /// True if user can manager others nicknames.
   bool? manageNicknames;
 
-  /// True if user can manage server's roles
+  /// True if user can manage server's roles.
   bool? manageRoles;
 
-  /// True if user can manage webhooks
+  /// True if user can manage webhooks.
   bool? manageWebhooks;
 
-  /// Allows management and editing of emojis
+  /// Allows management and editing of emojis.
+  @Deprecated('Use "manageEmojisAndStickers" instead')
   bool? manageEmojis;
 
-  /// Allows the user to go live
+  /// Allows management and editing of emojis & stickers.
+  bool? manageEmojisAndStickers;
+
+  /// Allows for requesting to speak in stage channels. (This permission is under active development and may be changed or removed.).
+  bool? requestToSpeak;
+
+  /// Allows the user to go live.
   bool? stream;
 
-  /// Allows for viewing guild insights
+  /// Allows for viewing guild insights.
   bool? viewGuildInsights;
 
-  /// Allows for deleting and archiving threads, and viewing all private threads
+  /// Allows for deleting and archiving threads, and viewing all private threads.
   bool? manageThreads;
 
-  /// Allows for creating and participating in threads
+  /// Allows for creating and participating in threads.
   bool? createPublicThreads;
 
-  /// Allows for creating and participating in private threads
+  /// Allows for creating and participating in private threads.
   bool? createPrivateThreads;
 
-  /// Empty permission builder
-  PermissionsBuilder();
+  /// Allows for creating, editing, and deleting scheduled events.
+  bool? manageEvents;
+
+  /// Allows for timing out users to prevent them from sending or reacting to messages in chat and threads, and from speaking in voice and stage channels.
+  bool? moderateMembers;
+
+  PermissionsBuilder({
+    this.addReactions,
+    this.administrator,
+    this.attachFiles,
+    this.banMembers,
+    this.changeNickname,
+    this.connect,
+    this.createInstantInvite,
+    this.createPrivateThreads,
+    this.createPublicThreads,
+    this.deafenMembers,
+    this.embedLinks,
+    this.kickMembers,
+    this.manageChannels,
+    @Deprecated('Use "manageEmojisAndStickers" instead') this.manageEmojis,
+    this.manageEmojisAndStickers,
+    this.manageEvents,
+    this.manageGuild,
+    this.manageMessages,
+    this.manageNicknames,
+    this.manageRoles,
+    this.manageThreads,
+    this.manageWebhooks,
+    this.mentionEveryone,
+    this.moderateMembers,
+    this.moveMembers,
+    this.muteMembers,
+    this.prioritySpeaker,
+    this.readMessageHistory,
+    this.sendMessages,
+    this.requestToSpeak,
+    this.sendMessagesInThreads,
+    this.sendTtsMessages,
+    this.speak,
+    this.stream,
+    this.useExternalEmojis,
+    this.useExternalStickers,
+    this.useSlashCommands,
+    this.useVad,
+    this.viewAuditLog,
+    this.viewChannel,
+    this.viewGuildInsights,
+  });
 
   /// Permission builder from existing [Permissions] object.
   PermissionsBuilder.from(Permissions permissions) {
@@ -183,15 +244,20 @@ class PermissionsBuilder extends Builder {
       ..manageNicknames = permissions.manageNicknames
       ..manageRoles = permissions.manageRoles
       ..manageWebhooks = permissions.manageWebhooks
-      ..manageEmojis = permissions.manageEmojis
+      ..manageEmojisAndStickers = permissions.manageEmojisAndStickers
       ..stream = permissions.stream
       ..viewGuildInsights = permissions.viewGuildInsights
       ..manageThreads = permissions.manageThreads
       ..createPublicThreads = permissions.createPublicThreads
-      ..createPrivateThreads = permissions.createPrivateThreads;
+      ..createPrivateThreads = permissions.createPrivateThreads
+      ..moderateMembers = permissions.moderateMembers
+      ..useSlashCommands = permissions.useSlashCommands
+      ..requestToSpeak = permissions.requestToSpeak
+      ..manageEvents = permissions.manageEvents
+      ..useExternalStickers = permissions.useExternalStickers;
   }
 
-  /// Calculates permission int
+  /// Calculates permission int.
   int calculatePermissionValue() {
     final set = _calculatePermissionSet();
 
@@ -217,7 +283,7 @@ class PermissionsBuilder extends Builder {
     _apply(permissionSet, attachFiles, PermissionsConstants.attachFiles);
     _apply(permissionSet, readMessageHistory, PermissionsConstants.readMessageHistory);
     _apply(permissionSet, mentionEveryone, PermissionsConstants.mentionEveryone);
-    _apply(permissionSet, useExternalEmojis, PermissionsConstants.externalEmojis);
+    _apply(permissionSet, useExternalEmojis, PermissionsConstants.useExternalEmojis);
     _apply(permissionSet, connect, PermissionsConstants.connect);
     _apply(permissionSet, speak, PermissionsConstants.speak);
     _apply(permissionSet, muteMembers, PermissionsConstants.muteMembers);
@@ -226,14 +292,21 @@ class PermissionsBuilder extends Builder {
     _apply(permissionSet, useVad, PermissionsConstants.useVad);
     _apply(permissionSet, changeNickname, PermissionsConstants.changeNickname);
     _apply(permissionSet, manageNicknames, PermissionsConstants.manageNicknames);
-    _apply(permissionSet, manageRoles, PermissionsConstants.manageRolesOrPermissions);
+    _apply(permissionSet, manageRoles, PermissionsConstants.manageRoles);
     _apply(permissionSet, manageWebhooks, PermissionsConstants.manageWebhooks);
     _apply(permissionSet, viewGuildInsights, PermissionsConstants.viewGuildInsights);
     _apply(permissionSet, stream, PermissionsConstants.stream);
-    _apply(permissionSet, manageEmojis, PermissionsConstants.manageEmojis);
+    _apply(permissionSet, manageEmojisAndStickers, PermissionsConstants.manageEmojisAndStickers);
     _apply(permissionSet, manageThreads, PermissionsConstants.manageThreads);
     _apply(permissionSet, createPublicThreads, PermissionsConstants.createPublicThreads);
     _apply(permissionSet, createPrivateThreads, PermissionsConstants.createPrivateThreads);
+    _apply(permissionSet, moderateMembers, PermissionsConstants.moderateMembers);
+    _apply(permissionSet, useExternalStickers, PermissionsConstants.useExternalStickers);
+    _apply(permissionSet, useSlashCommands, PermissionsConstants.useSlashCommands);
+    _apply(permissionSet, manageEvents, PermissionsConstants.manageEvents);
+    _apply(permissionSet, requestToSpeak, PermissionsConstants.requestToSpeak);
+    _apply(permissionSet, prioritySpeaker, PermissionsConstants.prioritySpeaker);
+    _apply(permissionSet, sendMessagesInThreads, PermissionsConstants.sendMessagesInThreads);
 
     return permissionSet;
   }

--- a/lib/src/utils/builders/sticker_builder.dart
+++ b/lib/src/utils/builders/sticker_builder.dart
@@ -16,6 +16,13 @@ class StickerBuilder implements Builder {
   /// File that Sticker should be added to sticker
   late final AttachmentBuilder file;
 
+  StickerBuilder({this.description = '', required this.file, this.name = '', this.tags = ''});
+
   @override
-  RawApiMap build() => {"name": name, "description": description, "tags": tags};
+  RawApiMap build() => {
+        "name": name,
+        "description": description,
+        "tags": tags,
+        'file': file.getBase64(),
+      };
 }

--- a/lib/src/utils/builders/thread_builder.dart
+++ b/lib/src/utils/builders/thread_builder.dart
@@ -26,10 +26,25 @@ class ThreadBuilder extends Builder {
   ThreadArchiveTime? archiveAfter;
 
   /// Create a public thread
-  ThreadBuilder(this.name);
+  ThreadBuilder(
+    this.name, {
+    this.archiveAfter,
+    this.archived,
+    this.invitable,
+    this.locked,
+    this.private,
+    this.rateLimitPerUser,
+  });
 
   /// Create a private thread
-  ThreadBuilder.private(this.name) {
+  ThreadBuilder.private(
+    this.name, {
+    this.archiveAfter,
+    this.archived,
+    this.invitable,
+    this.locked,
+    this.rateLimitPerUser,
+  }) {
     private = true;
   }
 

--- a/test/unit/builders_test.dart
+++ b/test/unit/builders_test.dart
@@ -63,7 +63,7 @@ main() {
 
       final expectedResult = {
         'permission_overwrites': [
-          {'allow': "0", 'deny': "122406567679", 'id': '0', 'type': 0}
+          {'allow': "0", 'deny': "1649267441663", 'id': '0', 'type': 0}
         ],
         'type': 0,
         'name': 'test'
@@ -122,7 +122,7 @@ main() {
     expect(builder.build(), equals({"allow": "0", "deny": "0", 'id': '0', 'type': 0}));
 
     final fromBuilder = PermissionOverrideBuilder.from(0, Snowflake.zero(), Permissions.empty());
-    expect(fromBuilder.build(), equals({"allow": "0", "deny": "122406567679", 'id': '0', 'type': 0}));
+    expect(fromBuilder.build(), equals({"allow": "0", "deny": "1649267441663", 'id': '0', 'type': 0}));
     expect(fromBuilder.calculatePermissionValue(), equals(0));
 
     final ofBuilder = PermissionOverrideBuilder.of(MockMember(Snowflake.zero()))

--- a/test/unit/builders_test.dart
+++ b/test/unit/builders_test.dart
@@ -1,3 +1,4 @@
+import 'package:nyxx/nyxx.dart';
 import 'package:nyxx/src/core/channel/text_channel.dart';
 import 'package:nyxx/src/core/guild/auto_moderation.dart';
 import 'package:nyxx/src/core/guild/status.dart';
@@ -35,12 +36,12 @@ main() {
   });
 
   test('StickerBuilder', () {
-    final builder = StickerBuilder()
+    final builder = StickerBuilder(file: AttachmentBuilder.bytes([], 'foo'))
       ..name = "this is name"
       ..description = "this is description"
       ..tags = "tags";
 
-    expect(builder.build(), equals({"name": "this is name", "description": "this is description", "tags": "tags"}));
+    expect(builder.build(), equals({"name": "this is name", "description": "this is description", "tags": "tags", 'file': 'data:image/png;base64,'}));
   });
 
   test("ReplyBuilder", () {


### PR DESCRIPTION
# Description
When using builders, the previous convention was to use:
```dart
final builder = SomeBuilder()
  ..foo = 'bar'
  ..baz = 'qux';
```
And, imo, this is such a pain when writing long builders.
A more convenient way would be:
```dart
final builder = SomeBuilder(foo: 'bar', baz: 'qux');
```

I also added missing permissions

## Connected issues & other potential problems
-/-

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:
- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
