### PR TITLE
feature: add support for interaction webhooks

### DIFF
--- a/lib/src/core/guild/webhook.dart
+++ b/lib/src/core/guild/webhook.dart
@@ -127,7 +127,7 @@ class Webhook extends SnowflakeEntity implements IWebhook {
   String get username => name.toString();
 
   @override
-  int get discriminator => -1;
+  late final int discriminator;
 
   @override
   bool get bot => true;
@@ -139,11 +139,18 @@ class Webhook extends SnowflakeEntity implements IWebhook {
   @override
   final INyxx client;
 
+  @override
+  bool get isInteractionWebhook => discriminator != -1;
+
+  @override
+  String get formattedDiscriminator => discriminator.toString().padLeft(4, "0");
+
   /// Creates an instance of [Webhook]
   Webhook(RawApiMap raw, this.client) : super(Snowflake(raw["id"] as String)) {
-    name = raw["name"] as String?;
+    name = raw["name"] as String? ?? raw['username'] as String?;
     token = raw["token"] as String? ?? "";
     avatarHash = raw["avatar"] as String?;
+    discriminator = int.tryParse(raw['discriminator'] as String? ?? '-1') ?? -1;
 
     if (raw["type"] != null) {
       type = WebhookType.from(raw["type"] as int);

--- a/lib/src/core/user/user.dart
+++ b/lib/src/core/user/user.dart
@@ -20,9 +20,6 @@ abstract class IUser implements SnowflakeEntity, ISend, Mentionable, IMessageAut
   /// Reference to client
   INyxx get client;
 
-  /// Formatted discriminator with leading zeros if needed
-  String get formattedDiscriminator;
-
   /// The user's avatar hash.
   String? get avatar;
 
@@ -117,6 +114,9 @@ class User extends SnowflakeEntity implements IUser {
   /// Color of the banner
   @override
   late final DiscordColor? accentColor;
+
+  @override
+  bool get isInteractionWebhook => false;
 
   /// Creates an instance of [User]
   User(this.client, RawApiMap raw) : super(Snowflake(raw["id"])) {

--- a/lib/src/internal/interfaces/message_author.dart
+++ b/lib/src/internal/interfaces/message_author.dart
@@ -15,6 +15,12 @@ abstract class IMessageAuthor implements SnowflakeEntity {
   /// User tag: `l7ssha#6712`
   String get tag;
 
+  /// Whether this [IMessageAuthor] is a webhook received by an interaction.
+  bool get isInteractionWebhook;
+
+  /// Formatted discriminator with leading zeros if needed
+  String get formattedDiscriminator;
+
   /// Url to user avatar
   String avatarURL({String format = "webp", int size = 128});
 }


### PR DESCRIPTION
# Description
Add support for interaction webhooks when an interaction is sent.
Because Discord send this as webhooks but it's not really a webhook, rather a mix between an user, and a webhook.

Thanks Discord

## Connected issues & other potential problems
-/-

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
