### PR TITLE
bug: Error when getting IInviteWithMeta from IGuildChannel

### DIFF
--- a/lib/src/internal/http_endpoints.dart
+++ b/lib/src/internal/http_endpoints.dart
@@ -1015,10 +1015,10 @@ class HttpEndpoints implements IHttpEndpoints {
         ..invites(),
     ));
 
-    final bodyValues = response.jsonBody.values.first;
+    final bodyValues = response.jsonBody;
 
-    for (final val in bodyValues as Iterable<RawApiMap>) {
-      yield InviteWithMeta(val, client);
+    for (final val in bodyValues) {
+      yield InviteWithMeta(val as RawApiMap, client);
     }
   }
 


### PR DESCRIPTION
# Description

Previously, an error would be thrown when attempting to get IInviteWithMeta from an IGuildChannel. The updated code resolves this issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues (no new issues created)
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (very minor modifications, no comment required)
- [x] I have made corresponding changes to the documentation (no changes necessary)
- [x] I have checked my changes haven't lowered code coverage
