### PR TITLE
Add avatar decorations to cdn endpoints

### DIFF
--- a/lib/src/core/user/user.dart
+++ b/lib/src/core/user/user.dart
@@ -48,8 +48,14 @@ abstract class IUser implements SnowflakeEntity, ISend, Mentionable, IMessageAut
   /// Gets the [DMChannel] for the user.
   FutureOr<IDMChannel> get dmChannel;
 
+  /// The hash of the user's avatar decoration.
+  String? avatarDecorationHash;
+
   /// The user's banner url.
   String? bannerUrl({String format = 'webp', int? size, bool animated = false});
+
+  /// The user's avatar decoration url, if any.
+  String? avatarDecorationUrl({int size});
 }
 
 /// Represents a single user of Discord, either a human or a bot, outside of any specific guild's context.
@@ -118,6 +124,9 @@ class User extends SnowflakeEntity implements IUser {
   @override
   bool get isInteractionWebhook => false;
 
+  @override
+  late final String? avatarDecorationHash;
+
   /// Creates an instance of [User]
   User(this.client, RawApiMap raw) : super(Snowflake(raw["id"])) {
     username = raw["username"] as String;
@@ -144,6 +153,8 @@ class User extends SnowflakeEntity implements IUser {
     } else {
       accentColor = null;
     }
+
+    avatarDecorationHash = raw['avatar_decoration'] as String?;
   }
 
   /// Gets the [DMChannel] for the user.
@@ -182,5 +193,14 @@ class User extends SnowflakeEntity implements IUser {
   Future<IMessage> sendMessage(MessageBuilder builder) async {
     final channel = await dmChannel;
     return channel.sendMessage(builder);
+  }
+
+  @override
+  String? avatarDecorationUrl({int? size}) {
+    if (avatarDecorationHash == null) {
+      return null;
+    }
+
+    return client.cdnHttpEndpoints.avatarDecoration(id, avatarDecorationHash!, size: size);
   }
 }

--- a/lib/src/internal/cdn_http_endpoints.dart
+++ b/lib/src/internal/cdn_http_endpoints.dart
@@ -31,7 +31,7 @@ abstract class ICdnHttpEndpoints {
 
   /// Returns URL to ``/embed/avatars/[discriminator]``.
   ///
-  /// The [discriminator] is passed as modulo 5 (`% 5`); and will lead to 0,1,2,3,4. (There's 5, but % modulo 5 will never give 5).
+  /// The [discriminator] is passed as modulo 5 (`% 5`); and will lead to 0,1,2,3,4. (There's 5, but 5 modulo 5 will never give 5).
   ///
   /// E.g:
   /// ```dart
@@ -78,6 +78,10 @@ abstract class ICdnHttpEndpoints {
   /// Returns URL to ``/guild-events/[eventId]/[eventCoverHash]``.
   /// With given [format] and [size].
   String guildEventCoverImage(Snowflake eventId, String eventCoverHash, {String format = 'webp', int? size});
+
+  /// Returns URL to ``/avatar-decorations/[userId]/[decorationHash]``.
+  /// With given [size].
+  String avatarDecoration(Snowflake userId, String decorationHash, {int? size});
 }
 
 class CdnHttpEndpoints implements ICdnHttpEndpoints {
@@ -255,6 +259,14 @@ class CdnHttpEndpoints implements ICdnHttpEndpoints {
           ..guildEvents(id: eventId.toString())
           ..addHash(hash: eventCoverHash),
         format: format,
+        size: size,
+      );
+
+  @override
+  String avatarDecoration(Snowflake userId, String decorationHash, {int? size}) => _makeCdnUrl(
+        ICdnHttpRoute()
+          ..avatarDecorations(id: userId.toString())
+          ..addHash(hash: decorationHash),
         size: size,
       );
 }

--- a/lib/src/internal/http/http_route.dart
+++ b/lib/src/internal/http/http_route.dart
@@ -335,6 +335,9 @@ abstract class ICdnHttpRoute implements IHttpRoute {
 
   /// Adds the `guild-events` part to this [ICdnHttpRoute].
   void guildEvents({required String id});
+
+  /// Adds the `avatar-decorations` part to this [ICdnHttpRoute].
+  void avatarDecorations({required String id});
 }
 
 class CdnHttpRoute extends HttpRoute implements ICdnHttpRoute {
@@ -394,4 +397,7 @@ class CdnHttpRoute extends HttpRoute implements ICdnHttpRoute {
 
   @override
   void guildEvents({required String id}) => add(CdnHttpRoutePart('guild-events', [CdnHttpRouteParam(id)]));
+
+  @override
+  void avatarDecorations({required String id}) => add(CdnHttpRoutePart('avatar-decorations', [CdnHttpRouteParam(id)]));
 }

--- a/lib/src/internal/interfaces/message_author.dart
+++ b/lib/src/internal/interfaces/message_author.dart
@@ -23,6 +23,6 @@ abstract class IMessageAuthor implements SnowflakeEntity {
 
   /// The user's avatar, represented as URL.
   /// In case if user does not have avatar, default discord avatar will be returned; [format], [size] and [animated] will no longer affectng this URL.
-  /// If [animated] is set as `true`, if available, the url will be a gif, otherwise the [format] or fallback to "webp".
+  /// If [animated] is set as `true`, if available, the url will be a gif, otherwise the [format].
   String avatarUrl({String format = 'webp', int? size, bool animated = false});
 }


### PR DESCRIPTION
# Description
Add support for avatar decorations

## Connected issues & other potential problems
Relevant:
- https://github.com/discord/discord-api-docs/pull/5723

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
