### PR TITLE
feature: ETF Encoding

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -146,7 +146,7 @@ export 'src/events/typing_event.dart' show ITypingEvent;
 export 'src/events/user_update_event.dart' show IUserUpdateEvent;
 export 'src/events/voice_server_update_event.dart' show IVoiceServerUpdateEvent;
 export 'src/events/voice_state_update_event.dart' show IVoiceStateUpdateEvent;
-export 'src/internal/constants.dart' show Constants, OPCodes;
+export 'src/internal/constants.dart' show Constants, OPCodes, Encoding;
 export 'src/internal/event_controller.dart' show IWebsocketEventController, IRestEventController;
 export 'src/internal/http_endpoints.dart' show IHttpEndpoints;
 export 'src/internal/cache/cache.dart' show SnowflakeCache, ICache, InMemoryCache;

--- a/lib/src/client_options.dart
+++ b/lib/src/client_options.dart
@@ -79,7 +79,6 @@ class ClientOptions {
   /// errors (e.g failed host lookup) which can occur if there is no internet.
   RetryOptions httpRetryOptions;
 
-
   /// The encoding protocol to use when receiving/sending payloads.
   Encoding payloadEncoding;
 

--- a/lib/src/client_options.dart
+++ b/lib/src/client_options.dart
@@ -79,6 +79,15 @@ class ClientOptions {
   /// errors (e.g failed host lookup) which can occur if there is no internet.
   RetryOptions httpRetryOptions;
 
+
+  /// The encoding protocol to use when receiving/sending payloads.
+  Encoding payloadEncoding;
+
+  /// Enable payload compression.
+  /// This cannot be used with the [Encoding.etf] encoding.
+  /// This will also be disabled if [compressedGatewayPayloads] is used.
+  bool payloadCompression;
+
   /// Makes a new `ClientOptions` object.
   ClientOptions({
     this.allowedMentions,
@@ -94,6 +103,8 @@ class ClientOptions {
     this.shardIds,
     this.shardReconnectOptions = const RetryOptions(),
     this.httpRetryOptions = const RetryOptions(),
+    this.payloadEncoding = Encoding.json,
+    this.payloadCompression = false,
   });
 }
 

--- a/lib/src/core/audit_logs/audit_log_options.dart
+++ b/lib/src/core/audit_logs/audit_log_options.dart
@@ -69,12 +69,27 @@ class AuditLogOptions implements IAuditLogOptions {
   late final String? overwrittenType;
 
   AuditLogOptions(RawApiMap raw) {
-    channelId = (raw['channel_id'] as String?)?.toSnowflake();
+    if (raw['channel_id'] != null) {
+      channelId = Snowflake(raw['channel_id']);
+    } else {
+      channelId = null;
+    }
+
     count = raw['count'] != null ? int.parse(raw['count'] as String) : null;
     deleteMemberDuration = (raw['delete_member_days'] as String?) != null ? Duration(days: int.parse(raw['delete_member_days'] as String)) : null;
-    id = (raw['id'] as String?)?.toSnowflake();
+    if (raw['id'] != null) {
+      id = Snowflake(raw['id']);
+    } else {
+      id = null;
+    }
+
     pruneCount = (raw['members_removed'] as String?) != null ? int.parse(raw['members_removed'] as String) : null;
-    messageId = (raw['message_id'] as String?)?.toSnowflake();
+    if (raw['message_id'] != null) {
+      messageId = Snowflake(raw['message_id']);
+    } else {
+      messageId = null;
+    }
+
     roleName = raw['role_name'] as String?;
     switch (raw['type']) {
       case '0':

--- a/lib/src/core/message/attachment.dart
+++ b/lib/src/core/message/attachment.dart
@@ -76,7 +76,7 @@ class Attachment extends SnowflakeEntity implements IAttachment {
   bool get isSpoiler => filename.startsWith("SPOILER_");
 
   /// Creates an instance of [Attachment]
-  Attachment(RawApiMap raw) : super(Snowflake(raw["id"] as String)) {
+  Attachment(RawApiMap raw) : super(Snowflake(raw["id"])) {
     filename = raw["filename"] as String;
     url = raw["url"] as String;
     proxyUrl = raw["proxyUrl"] as String?;

--- a/lib/src/core/permissions/permission_overrides.dart
+++ b/lib/src/core/permissions/permission_overrides.dart
@@ -38,7 +38,7 @@ class PermissionsOverrides extends SnowflakeEntity implements IPermissionsOverri
   late final int deny;
 
   /// Creates an instance of [PermissionsOverrides]
-  PermissionsOverrides(RawApiMap raw) : super(Snowflake(raw["id"] as String)) {
+  PermissionsOverrides(RawApiMap raw) : super(Snowflake(raw["id"])) {
     allow = int.parse(raw["allow"] as String);
     deny = int.parse(raw["deny"] as String);
 

--- a/lib/src/events/guild_events.dart
+++ b/lib/src/events/guild_events.dart
@@ -564,8 +564,8 @@ class WebhookUpdateEvent implements IWebhookUpdateEvent {
   late final Cacheable<Snowflake, IGuild> guild;
 
   WebhookUpdateEvent(RawApiMap raw, INyxx client) {
-    channel = ChannelCacheable(client, Snowflake(raw['d']['channel_id'] as String));
-    guild = GuildCacheable(client, Snowflake(raw['d']['guild_id'] as String));
+    channel = ChannelCacheable(client, Snowflake(raw['d']['channel_id']));
+    guild = GuildCacheable(client, Snowflake(raw['d']['guild_id']));
   }
 }
 
@@ -645,7 +645,7 @@ class AutoModeratioActionExecutionEvent extends SnowflakeEntity implements IAuto
     guild = GuildCacheable(client, Snowflake(raw['guild_id'] as String));
     action = ActionStructure(raw['action'] as RawApiMap, client);
     triggerType = TriggerTypes.fromValue(raw['rule_trigger_type'] as int);
-    member = MemberCacheable(client, Snowflake(raw['user_id'] as String), guild);
+    member = MemberCacheable(client, Snowflake(raw['user_id']), guild);
     channel = raw['channel_id'] != null ? ChannelCacheable(client, Snowflake(raw['channel_id'])) : null;
     message = raw['message_id'] != null && channel != null ? MessageCacheable(client, Snowflake(raw['message_id']), channel!) : null;
     alertSystemMessage = raw['alert_system_message_id'] != null ? Snowflake(raw['alert_system_message_id']) : null;

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -39,8 +39,8 @@ class Constants {
   static const String repoUrl = "https://github.com/nyxx-discord/nyxx";
 
   /// Returns [Uri] to gateway
-  static Uri gatewayUri(String gatewayHost, bool useCompression) {
-    var uriString = "$gatewayHost?v=$apiVersion&encoding=json";
+  static Uri gatewayUri(String gatewayHost, bool useCompression, [Encoding encoding = Encoding.json]) {
+    var uriString = "$gatewayHost?v=$apiVersion&encoding=${encoding.name}";
 
     if (useCompression) {
       uriString += "&compress=zlib-stream";
@@ -48,4 +48,15 @@ class Constants {
 
     return Uri.parse(uriString);
   }
+}
+
+/// The type of encoding to receive/send payloads to discord.
+enum Encoding {
+  /// ETF (External Term Format) encoding
+  /// It's more performant on a ton of servers, use it if you want to optimise your bot scaling.
+  etf,
+
+  /// JSON (JavaScript Object Notation) is an universal data transferring model, 
+  /// it can be used on production too.
+  json
 }

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -56,7 +56,7 @@ enum Encoding {
   /// It's more performant on a ton of servers, use it if you want to optimise your bot scaling.
   etf,
 
-  /// JSON (JavaScript Object Notation) is an universal data transferring model, 
+  /// JSON (JavaScript Object Notation) is an universal data transferring model,
   /// it can be used on production too.
   json
 }

--- a/lib/src/internal/http/http_response.dart
+++ b/lib/src/internal/http/http_response.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
-import 'package:eterl/eterl.dart';
 import 'package:nyxx/nyxx.dart';
 import 'package:nyxx/src/internal/response_wrapper/error_response_wrapper.dart';
 

--- a/lib/src/internal/http/http_response.dart
+++ b/lib/src/internal/http/http_response.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
+import 'package:eterl/eterl.dart';
 import 'package:nyxx/nyxx.dart';
 import 'package:nyxx/src/internal/response_wrapper/error_response_wrapper.dart';
 

--- a/lib/src/internal/shard/message.dart
+++ b/lib/src/internal/shard/message.dart
@@ -63,6 +63,8 @@ enum ManagerToShard {
   ///     The URL on which to connect to the gateway
   /// - `useCompression`: bool
   ///     Whether to use compression on this gateway connection
+  /// - `encoding`: Encoding
+  ///     The encoding type du use to receive/send payloads
   connect,
 
   /// Sent to request the shard to reconnect, closing the current connection if any.

--- a/lib/src/internal/shard/shard.dart
+++ b/lib/src/internal/shard/shard.dart
@@ -405,7 +405,7 @@ class Shard implements IShard {
         "intents": manager.connectionManager.client.intents,
         if (manager.connectionManager.client.options.initialPresence != null) "presence": manager.connectionManager.client.options.initialPresence!.build(),
         "shard": <int>[id, manager.totalNumShards],
-        if (manager.connectionManager.client.options.payloadEncoding == Encoding.json)
+        if (manager.connectionManager.client.options.payloadEncoding == Encoding.json && !manager.connectionManager.client.options.compressedGatewayPayloads)
           "compresstion": manager.connectionManager.client.options.payloadCompression,
       });
 

--- a/lib/src/internal/shard/shard.dart
+++ b/lib/src/internal/shard/shard.dart
@@ -406,7 +406,7 @@ class Shard implements IShard {
         if (manager.connectionManager.client.options.initialPresence != null) "presence": manager.connectionManager.client.options.initialPresence!.build(),
         "shard": <int>[id, manager.totalNumShards],
         if (manager.connectionManager.client.options.payloadEncoding == Encoding.json && !manager.connectionManager.client.options.compressedGatewayPayloads)
-          "compresstion": manager.connectionManager.client.options.payloadCompression,
+          "compression": manager.connectionManager.client.options.payloadCompression,
       });
 
   /// Sends the resume payload to the gateway.

--- a/lib/src/internal/shard/shard.dart
+++ b/lib/src/internal/shard/shard.dart
@@ -406,7 +406,7 @@ class Shard implements IShard {
         if (manager.connectionManager.client.options.initialPresence != null) "presence": manager.connectionManager.client.options.initialPresence!.build(),
         "shard": <int>[id, manager.totalNumShards],
         if (manager.connectionManager.client.options.payloadEncoding == Encoding.json && !manager.connectionManager.client.options.compressedGatewayPayloads)
-          "compression": manager.connectionManager.client.options.payloadCompression,
+          "compression": manager.connectionManager.client.options.compressedGatewayPayloads,
       });
 
   /// Sends the resume payload to the gateway.

--- a/lib/src/internal/shard/shard.dart
+++ b/lib/src/internal/shard/shard.dart
@@ -174,6 +174,7 @@ class Shard implements IShard {
             data: {
               'gatewayHost': shouldResume && canResume ? resumeGatewayUrl : gatewayHost,
               'useCompression': manager.connectionManager.client.options.compressedGatewayPayloads,
+              'encoding': manager.connectionManager.client.options.payloadEncoding,
             },
           ));
 
@@ -231,7 +232,7 @@ class Shard implements IShard {
 
     switch (message.type) {
       case ShardToManager.received:
-        return handlePayload(message.data);
+        return handlePayload(message.data as RawApiMap);
       case ShardToManager.connected:
       case ShardToManager.reconnected:
         return handleConnected();
@@ -313,13 +314,13 @@ class Shard implements IShard {
   }
 
   /// A handler for when a payload from the gateway is received.
-  Future<void> handlePayload(dynamic data) async {
+  Future<void> handlePayload(RawApiMap data) async {
     final opcode = data['op'] as int;
     final d = data['d'];
 
     switch (opcode) {
       case OPCodes.dispatch:
-        dispatch(data['s'] as int, data['t'] as String, data as RawApiMap);
+        dispatch(data['s'] as int, data['t'] as String, data);
         break;
 
       case OPCodes.heartbeat:
@@ -403,7 +404,9 @@ class Shard implements IShard {
         "large_threshold": manager.connectionManager.client.options.largeThreshold,
         "intents": manager.connectionManager.client.intents,
         if (manager.connectionManager.client.options.initialPresence != null) "presence": manager.connectionManager.client.options.initialPresence!.build(),
-        "shard": <int>[id, manager.totalNumShards]
+        "shard": <int>[id, manager.totalNumShards],
+        if (manager.connectionManager.client.options.payloadEncoding == Encoding.json)
+          "compresstion": manager.connectionManager.client.options.payloadCompression,
       });
 
   /// Sends the resume payload to the gateway.

--- a/lib/src/internal/shard/shard_handler.dart
+++ b/lib/src/internal/shard/shard_handler.dart
@@ -134,26 +134,24 @@ class ShardRunner implements Disposable {
       if (useCompression) {
         final filter = RawZLibFilter.inflateFilter();
 
-        final mappedConnection = connection!
-            .cast<List<int>>()
-            .map((rawPayload) {
-              filter.process(rawPayload, 0, rawPayload.length);
+        final mappedConnection = connection!.cast<List<int>>().map((rawPayload) {
+          filter.process(rawPayload, 0, rawPayload.length);
 
-              final buffer = <int>[];
-              for (List<int>? decoded = []; decoded != null; decoded = filter.processed()) {
-                buffer.addAll(decoded);
-              }
+          final buffer = <int>[];
+          for (List<int>? decoded = []; decoded != null; decoded = filter.processed()) {
+            buffer.addAll(decoded);
+          }
 
-              return buffer;
-            });
+          return buffer;
+        });
 
-            Stream<dynamic> stream;
+        Stream<dynamic> stream;
 
-            if (encoding == Encoding.etf) {
-              stream = mappedConnection.transform(eterl.unpacker<RawApiMap>());
-            } else {
-              stream = mappedConnection.transform(utf8.decoder);
-            }
+        if (encoding == Encoding.etf) {
+          stream = mappedConnection.transform(eterl.unpacker<RawApiMap>());
+        } else {
+          stream = mappedConnection.transform(utf8.decoder);
+        }
 
         connectionSubscription = stream.listen(receive);
       } else {

--- a/lib/src/internal/shard/shard_handler.dart
+++ b/lib/src/internal/shard/shard_handler.dart
@@ -4,10 +4,10 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:eterl/eterl.dart';
-import 'package:nyxx/nyxx.dart';
 import 'package:nyxx/src/internal/constants.dart';
 import 'package:nyxx/src/internal/interfaces/disposable.dart';
 import 'package:nyxx/src/internal/shard/message.dart';
+import 'package:nyxx/src/typedefs.dart';
 
 void shardHandler(SendPort sendPort) {
   final runner = ShardRunner(sendPort);

--- a/lib/src/internal/shard/shard_handler.dart
+++ b/lib/src/internal/shard/shard_handler.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
 
+import 'package:eterl/eterl.dart';
+import 'package:nyxx/nyxx.dart';
 import 'package:nyxx/src/internal/constants.dart';
 import 'package:nyxx/src/internal/interfaces/disposable.dart';
 import 'package:nyxx/src/internal/shard/message.dart';
@@ -27,7 +29,7 @@ class ShardRunner implements Disposable {
   WebSocket? connection;
 
   /// The subscription to the current active connection.
-  StreamSubscription<String>? connectionSubscription;
+  StreamSubscription<dynamic>? connectionSubscription;
 
   /// Whether this shard is currently connected to Discord.
   bool get connected => connection?.readyState == WebSocket.open;
@@ -49,6 +51,8 @@ class ShardRunner implements Disposable {
   // Start at -1 and count down to avoid collisions with seq from the shard handler
   int seq = -1;
 
+  late Encoding _encoding;
+
   ShardRunner(this.sendPort) {
     managerMessages.listen(handle);
   }
@@ -59,10 +63,10 @@ class ShardRunner implements Disposable {
   /// Handler for uncompressed messages received from Discord.
   ///
   /// Calls jsonDecode and sends the data back to the manager.
-  void receive(String payload) => execute(ShardMessage(
+  void receive(dynamic payload) => execute(ShardMessage(
         ShardToManager.received,
         seq: seq--,
-        data: jsonDecode(payload),
+        data: payload is String ? jsonDecode(payload) : payload,
       ));
 
   /// Handler for incoming messages from the manager.
@@ -71,9 +75,9 @@ class ShardRunner implements Disposable {
       case ManagerToShard.send:
         return send(message.data, message.seq);
       case ManagerToShard.connect:
-        return connect(message.data['gatewayHost'] as String, message.data['useCompression'] as bool, message.seq);
+        return connect(message.data['gatewayHost'] as String, message.data['useCompression'] as bool, message.seq, message.data['encoding'] as Encoding);
       case ManagerToShard.reconnect:
-        return reconnect(message.data['gatewayHost'] as String, message.data['useCompression'] as bool, message.seq);
+        return reconnect(message.data['gatewayHost'] as String, message.data['useCompression'] as bool, message.seq, message.data['encoding'] as Encoding);
       case ManagerToShard.disconnect:
         return disconnect(message.seq);
       case ManagerToShard.dispose:
@@ -84,7 +88,8 @@ class ShardRunner implements Disposable {
   /// Initiate the connection on this shard.
   ///
   /// Sends [ShardToManager.connected] upon completion.
-  Future<void> connect(String gatewayHost, bool useCompression, int seq) async {
+  Future<void> connect(String gatewayHost, bool useCompression, int seq, Encoding encoding) async {
+    _encoding = encoding;
     if (connected) {
       execute(ShardMessage(
         ShardToManager.error,
@@ -106,7 +111,7 @@ class ShardRunner implements Disposable {
     connecting = true;
 
     try {
-      final gatewayUri = Constants.gatewayUri(gatewayHost, useCompression);
+      final gatewayUri = Constants.gatewayUri(gatewayHost, useCompression, encoding);
 
       connection = await WebSocket.connect(gatewayUri.toString());
       connection!.pingInterval = const Duration(seconds: 20);
@@ -129,7 +134,7 @@ class ShardRunner implements Disposable {
       if (useCompression) {
         final filter = RawZLibFilter.inflateFilter();
 
-        connectionSubscription = connection!
+        final mappedConnection = connection!
             .cast<List<int>>()
             .map((rawPayload) {
               filter.process(rawPayload, 0, rawPayload.length);
@@ -140,9 +145,17 @@ class ShardRunner implements Disposable {
               }
 
               return buffer;
-            })
-            .transform(utf8.decoder)
-            .listen(receive);
+            });
+
+            Stream<dynamic> stream;
+
+            if (encoding == Encoding.etf) {
+              stream = mappedConnection.transform(eterl.unpacker<RawApiMap>());
+            } else {
+              stream = mappedConnection.transform(utf8.decoder);
+            }
+
+        connectionSubscription = stream.listen(receive);
       } else {
         connectionSubscription = connection!.cast<String>().listen(receive);
       }
@@ -160,7 +173,7 @@ class ShardRunner implements Disposable {
   }
 
   /// Reconnect to the server, closing the connection if necessary.
-  Future<void> reconnect(String gatewayHost, bool useCompression, int seq) async {
+  Future<void> reconnect(String gatewayHost, bool useCompression, int seq, Encoding encoding) async {
     if (reconnecting) {
       execute(ShardMessage(
         ShardToManager.error,
@@ -176,7 +189,7 @@ class ShardRunner implements Disposable {
     }
 
     // Sends reconnected instead of connected so we don't have to send it here
-    await connect(gatewayHost, useCompression, seq);
+    await connect(gatewayHost, useCompression, seq, encoding);
     reconnecting = false;
   }
 
@@ -211,7 +224,7 @@ class ShardRunner implements Disposable {
       ));
     }
 
-    connection!.add(jsonEncode(data));
+    connection!.add(_encoding == Encoding.json ? jsonEncode(data) : eterl.pack(data, 1000));
   }
 
   /// Disposes of this shard.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   logging: ^1.0.1
   path: ^1.8.0
   retry: ^3.1.0
-  eterl: ^0.0.2
+  eterl: 0.0.2
 
 dev_dependencies:
   test: ^1.19.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   logging: ^1.0.1
   path: ^1.8.0
   retry: ^3.1.0
+  eterl:
+    git: https://github.com/Rapougnac/eterl.git
 
 dev_dependencies:
   test: ^1.19.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,7 @@ dependencies:
   logging: ^1.0.1
   path: ^1.8.0
   retry: ^3.1.0
-  eterl:
-    git: https://github.com/Rapougnac/eterl.git
+  eterl: ^0.0.2
 
 dev_dependencies:
   test: ^1.19.0


### PR DESCRIPTION
# Description
This adds a way to request etf-encoded payloads and unpack them to get proper payload.


> **Warning**
> Snowflakes are sent as int64 (or String, depends, love discord), and not String, like in json.
> This can be unstable, also

## Connected issues & other potential problems
-/-

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
