### PR TITLE
feature: Implement newly created and member fields in thread create event

### DIFF
--- a/lib/src/events/thread_create_event.dart
+++ b/lib/src/events/thread_create_event.dart
@@ -5,17 +5,31 @@ import 'package:nyxx/src/typedefs.dart';
 abstract class IThreadCreateEvent {
   /// The thread that was just created
   IThreadChannel get thread;
+
+  /// True if thread is created
+  bool get newlyCreated;
+
+  /// Set when bot joining private thread
+  IThreadMember? get member;
 }
 
-/// Fired when a thread is created
+/// Fired when a thread is created or when bot joins thread
 class ThreadCreateEvent implements IThreadCreateEvent {
   /// The thread that was just created
   @override
   late final IThreadChannel thread;
 
+  @override
+  late final bool newlyCreated;
+
+  @override
+  late final IThreadMember? member;
+
   /// Creates an instance of [ThreadCreateEvent]
   ThreadCreateEvent(RawApiMap raw, INyxx client) {
     thread = ThreadChannel(client, raw["d"] as RawApiMap);
+    newlyCreated = raw['d']['newly_created'] as bool? ?? false;
+    member = raw['d']['member'] != null ? ThreadMember(client, raw['d']['member'] as RawApiMap, thread.guild) : null;
 
     if (client.cacheOptions.channelCachePolicyLocation.event && client.cacheOptions.channelCachePolicy.canCache(thread)) {
       client.channels[thread.id] = thread;

--- a/lib/src/utils/builders/member_builder.dart
+++ b/lib/src/utils/builders/member_builder.dart
@@ -1,7 +1,6 @@
 import 'package:nyxx/src/core/snowflake.dart';
 import 'package:nyxx/src/typedefs.dart';
 import 'package:nyxx/src/utils/builders/builder.dart';
-import 'package:nyxx/src/core/user/member_flags.dart';
 
 class MemberBuilder implements Builder {
   /// Value to set user's nickname to


### PR DESCRIPTION
# Description

Implement newly created and member fields in thread create event

## Connected issues & other potential problems

Fixes  #440 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
