### PR TITLE
hasMore is optional for guild.fetchActiveThreads()

### DIFF
--- a/lib/src/internal/response_wrapper/thread_list_result_wrapper.dart
+++ b/lib/src/internal/response_wrapper/thread_list_result_wrapper.dart
@@ -11,7 +11,7 @@ abstract class IThreadListResultWrapper {
   List<IThreadMember> get selfThreadMembers;
 
   /// Whether there are potentially additional threads that could be returned on a subsequent call
-  bool? get hasMore;
+  bool get hasMore;
 }
 
 /// Wrapper of threads listing results.
@@ -26,7 +26,7 @@ class ThreadListResultWrapper implements IThreadListResultWrapper {
 
   /// Whether there are potentially additional threads that could be returned on a subsequent call
   @override
-  late final bool? hasMore;
+  late final bool hasMore;
 
   /// Create an instance of [ThreadListResultWrapper]
   ThreadListResultWrapper(INyxx client, RawApiMap raw) {
@@ -37,6 +37,6 @@ class ThreadListResultWrapper implements IThreadListResultWrapper {
         ThreadMember(client, rawMember as RawApiMap, ChannelCacheable(client, threads.firstWhere((element) => element.id == rawMember["id"]).id))
     ];
 
-    hasMore = raw["has_more"] as bool?;
+    hasMore = (raw["has_more"] as bool?) ?? false;
   }
 }

--- a/lib/src/internal/response_wrapper/thread_list_result_wrapper.dart
+++ b/lib/src/internal/response_wrapper/thread_list_result_wrapper.dart
@@ -11,7 +11,7 @@ abstract class IThreadListResultWrapper {
   List<IThreadMember> get selfThreadMembers;
 
   /// Whether there are potentially additional threads that could be returned on a subsequent call
-  bool get hasMore;
+  bool? get hasMore;
 }
 
 /// Wrapper of threads listing results.
@@ -26,7 +26,7 @@ class ThreadListResultWrapper implements IThreadListResultWrapper {
 
   /// Whether there are potentially additional threads that could be returned on a subsequent call
   @override
-  late final bool hasMore;
+  late final bool? hasMore;
 
   /// Create an instance of [ThreadListResultWrapper]
   ThreadListResultWrapper(INyxx client, RawApiMap raw) {
@@ -37,6 +37,6 @@ class ThreadListResultWrapper implements IThreadListResultWrapper {
         ThreadMember(client, rawMember as RawApiMap, ChannelCacheable(client, threads.firstWhere((element) => element.id == rawMember["id"]).id))
     ];
 
-    hasMore = raw["has_more"] as bool;
+    hasMore = raw["has_more"] as bool?;
   }
 }


### PR DESCRIPTION
# Description

guild.fetchActiveThreads() does not have a `has_more` parameter in [the response](https://discord.com/developers/docs/resources/guild#list-active-guild-threads).

Fixes the issue mentioned here:
https://github.com/nyxx-discord/nyxx/issues/426#issuecomment-1434011164

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
