### PR TITLE
Mirror fix #352 to multipart request

### DIFF
--- a/lib/src/internal/http/http_request.dart
+++ b/lib/src/internal/http/http_request.dart
@@ -84,7 +84,8 @@ class MultipartRequest extends HttpRequest {
 
   @override
   Future<http.BaseRequest> prepareRequest() async {
-    final request = http.MultipartRequest(method, uri.replace(queryParameters: queryParams))..headers.addAll(genHeaders());
+    final request = http.MultipartRequest(method, uri.replace(queryParameters: queryParams?.map((key, value) => MapEntry(key, value.toString()))))
+      ..headers.addAll(genHeaders());
 
     request.files.addAll(files);
 


### PR DESCRIPTION
# Description

Mirrors https://github.com/nyxx-discord/nyxx/pull/352 to `MultipartRequest`. This issue seems to be present when sending an attachment with a webhook:

```
[SHOUT] [IgnoreExceptions] Unhandled exception was thrown
Error: type 'Null' is not a subtype of type 'bool' in type cast
Stack trace:
#0      new ThreadListResultWrapper (package:nyxx/src/internal/response_wrapper/thread_list_result_wrapper.dart:40:31)
#1      HttpEndpoints.fetchGuildActiveThreads (package:nyxx/src/internal/http_endpoints.dart:1642:12)
<asynchronous suspension>
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
