### PR TITLE
feature: dispatch raw events 

### DIFF
--- a/lib/src/events/raw_event.dart
+++ b/lib/src/events/raw_event.dart
@@ -2,7 +2,6 @@ import 'package:nyxx/src/internal/shard/shard.dart';
 import 'package:nyxx/src/typedefs.dart';
 
 /// Raw gateway event
-/// RawEvent is dispatched ONLY for payload that doesn't match any event built in into Nyxx.
 abstract class IRawEvent {
   /// Shard where event was received
   IShard get shard;
@@ -12,14 +11,11 @@ abstract class IRawEvent {
 }
 
 class RawEvent implements IRawEvent {
-  /// Shard where event was received
   @override
   final IShard shard;
 
-  /// Raw event data as deserialized json
   @override
   final RawApiMap rawData;
 
-  /// Creates an instance of [RawEvent]
   RawEvent(this.shard, this.rawData);
 }

--- a/lib/src/internal/shard/shard.dart
+++ b/lib/src/internal/shard/shard.dart
@@ -674,11 +674,11 @@ class Shard implements IShard {
         break;
 
       default:
-        if (manager.connectionManager.client.options.dispatchRawShardEvent) {
-          manager.onRawEventController.add(RawEvent(this, data));
-        } else {
-          logger.severe("UNKNOWN OPCODE: $data");
-        }
+        logger.severe("UNKNOWN GATEWAY EVENT: $data");
+    }
+
+    if (manager.connectionManager.client.options.dispatchRawShardEvent) {
+      manager.onRawEventController.add(RawEvent(this, data));
     }
   }
 


### PR DESCRIPTION
# Description

Allows to always dispatch raw events from gateway. Raw event are dispatched always last after everything else. Now all unknown event will be logged as severe error.

## Connected issues & other potential problems

Closes #413 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
