### PR TITLE
Correctly dispose all resources on bot stop

### DIFF
--- a/lib/src/internal/http/http_handler.dart
+++ b/lib/src/internal/http/http_handler.dart
@@ -4,13 +4,14 @@ import 'package:logging/logging.dart';
 import 'package:nyxx/src/events/http_events.dart';
 import 'package:nyxx/src/events/ratelimit_event.dart';
 import 'package:nyxx/src/internal/event_controller.dart';
+import 'package:nyxx/src/internal/interfaces/disposable.dart';
 import 'package:nyxx/src/nyxx.dart';
 import 'package:nyxx/src/internal/http/http_bucket.dart';
 import 'package:nyxx/src/internal/http/http_request.dart';
 import 'package:nyxx/src/internal/http/http_response.dart';
 import 'package:nyxx/src/utils/utils.dart';
 
-class HttpHandler {
+class HttpHandler implements Disposable {
   late final http.Client httpClient;
 
   final Logger logger = Logger("Http");
@@ -143,4 +144,7 @@ class HttpHandler {
 
     return responseError;
   }
+
+  @override
+  Future<void> dispose() async => httpClient.close();
 }

--- a/lib/src/internal/shard/shard.dart
+++ b/lib/src/internal/shard/shard.dart
@@ -770,8 +770,9 @@ class Shard implements IShard {
 
   @override
   Future<void> dispose() async {
-    execute(ShardMessage(ManagerToShard.dispose, seq: seq++));
+    heartbeatTimer?.cancel();
 
+    execute(ShardMessage(ManagerToShard.dispose, seq: seq++));
     // Wait for shard to dispose correctly
     await shardMessages.firstWhere((message) => message.type == ShardToManager.disposed);
 

--- a/lib/src/internal/shard/shard_handler.dart
+++ b/lib/src/internal/shard/shard_handler.dart
@@ -219,7 +219,6 @@ class ShardRunner implements Disposable {
     // Closing the connection will trigger the `connection.done` future we listened to when connecting, which will execute the [ShardToManager.disconnected]
     // message.
     await connection!.close(closeCode);
-    await connectionSubscription!.cancel();
 
     connection = null;
     connectionSubscription = null;

--- a/lib/src/nyxx.dart
+++ b/lib/src/nyxx.dart
@@ -236,7 +236,7 @@ class NyxxRest extends INyxxRest {
 
     await eventsRest.dispose();
 
-    onReadyController.close();
+    await onReadyController.close();
 
     await guilds.dispose();
     await users.dispose();

--- a/lib/src/nyxx.dart
+++ b/lib/src/nyxx.dart
@@ -235,6 +235,7 @@ class NyxxRest extends INyxxRest {
     }
 
     await eventsRest.dispose();
+    await httpHandler.dispose();
 
     await onReadyController.close();
 


### PR DESCRIPTION
# Description

This PR fixes two issues: an error that occurred due to the heartbeat timer attempting to reconnect after the bot was closed, and the process remaining alive after the bot was disposed due to the HTTP client not getting closed.

## Connected issues & other potential problems

Closes #450 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
