### PR TITLE
Initialise guild caches even when guild is not from a create event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.3
+__11.04.2023__
+
+- bug: Always initialize guild caches
+
 ## 5.0.2
 __08.04.2023__
 

--- a/lib/src/core/guild/guild.dart
+++ b/lib/src/core/guild/guild.dart
@@ -678,6 +678,9 @@ class Guild extends SnowflakeEntity implements IGuild {
         for (final rawSticker in raw["stickers"] as RawApiList) GuildSticker(rawSticker as RawApiMap, client)
     ];
 
+    autoModerationRules = SnowflakeCache<IAutoModerationRule>();
+    scheduledEvents = SnowflakeCache<IGuildEvent>();
+
     if (!guildCreate) return;
 
     raw["channels"].forEach((o) {
@@ -722,9 +725,6 @@ class Guild extends SnowflakeEntity implements IGuild {
       if (raw["stage_instances"] != null)
         for (final rawInstance in raw["stage_instances"] as RawApiList) StageChannelInstance(client, rawInstance as RawApiMap)
     ];
-
-    autoModerationRules = SnowflakeCache<IAutoModerationRule>();
-    scheduledEvents = SnowflakeCache<IGuildEvent>();
   }
 
   /// The guild's icon, represented as URL.

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -33,7 +33,7 @@ class Constants {
   static const int apiVersion = 10;
 
   /// Version of Nyxx
-  static const String version = "5.0.2";
+  static const String version = "5.0.3";
 
   /// Url to Nyxx repo
   static const String repoUrl = "https://github.com/nyxx-discord/nyxx";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx
-version: 5.0.2
+version: 5.0.3
 description: A Discord library for Dart. Simple, robust framework for creating discord bots for Dart language.
 homepage: https://github.com/nyxx-discord/nyxx
 repository: https://github.com/nyxx-discord/nyxx


### PR DESCRIPTION
# Description

Hotfix to fix a late initialisation error users encountered concerning the cache of guild scheduled events.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
