### PR TITLE
Make `animated` nullable for icon/avatar/icon/etc. URL properties and add helper logic

### DIFF
--- a/lib/src/core/guild/guild.dart
+++ b/lib/src/core/guild/guild.dart
@@ -199,7 +199,7 @@ abstract class IGuild implements SnowflakeEntity {
 
   /// The guild's icon, represented as URL.
   /// If guild doesn't have icon it returns null.
-  String? iconUrl({String format = 'webp', int? size, bool animated = false});
+  String? iconUrl({String format = 'webp', int? size, bool? animated});
 
   /// URL to guild's splash.
   /// If guild doesn't have splash it returns null.
@@ -211,7 +211,7 @@ abstract class IGuild implements SnowflakeEntity {
 
   /// URL to guild's banner.
   /// If guild doesn't have banner it returns null.
-  String? bannerUrl({String format = 'webp', int? size, bool animated = false});
+  String? bannerUrl({String format = 'webp', int? size, bool? animated});
 
   /// Allows to download [IGuild] widget aka advert png
   /// Possible options for [style]: shield (default), banner1, banner2, banner3, banner4
@@ -730,10 +730,12 @@ class Guild extends SnowflakeEntity implements IGuild {
   /// The guild's icon, represented as URL.
   /// If guild doesn't have icon it returns null.
   @override
-  String? iconUrl({String format = 'webp', int? size, bool animated = false}) {
+  String? iconUrl({String format = 'webp', int? size, bool? animated}) {
     if (icon == null) {
       return null;
     }
+
+    animated ??= icon?.startsWith("a_") ?? false;
 
     return client.cdnHttpEndpoints.icon(id, icon!, format: format, size: size, animated: animated);
   }
@@ -768,10 +770,12 @@ class Guild extends SnowflakeEntity implements IGuild {
   /// Returns the URL to guild's banner.
   /// If guild doesn't have banner it returns null.
   @override
-  String? bannerUrl({String format = 'webp', int? size, bool animated = false}) {
+  String? bannerUrl({String format = 'webp', int? size, bool? animated}) {
     if (banner == null) {
       return null;
     }
+
+    animated ??= banner?.startsWith("a_") ?? false;
 
     return client.cdnHttpEndpoints.banner(id, banner!, format: format, size: size, animated: animated);
   }

--- a/lib/src/core/guild/guild_preview.dart
+++ b/lib/src/core/guild/guild_preview.dart
@@ -38,7 +38,7 @@ abstract class IGuildPreview implements SnowflakeEntity {
 
   /// The guild's icon, represented as URL.
   /// If guild doesn't have icon it returns null.
-  String? iconUrl({String format = 'webp', int? size, bool animated = false});
+  String? iconUrl({String format = 'webp', int? size, bool? animated});
 
   /// URL to guild's splash.
   /// If guild doesn't have splash it returns null.
@@ -115,10 +115,12 @@ class GuildPreview extends SnowflakeEntity implements IGuildPreview {
   /// The guild's icon, represented as URL.
   /// If guild doesn't have icon it returns null.
   @override
-  String? iconUrl({String format = 'webp', int? size, bool animated = false}) {
+  String? iconUrl({String format = 'webp', int? size, bool? animated}) {
     if (iconHash == null) {
       return null;
     }
+
+    animated ??= iconHash?.startsWith("a_") ?? false;
 
     return client.cdnHttpEndpoints.icon(id, iconHash!, format: format, size: size, animated: animated);
   }

--- a/lib/src/core/guild/webhook.dart
+++ b/lib/src/core/guild/webhook.dart
@@ -79,7 +79,7 @@ abstract class IWebhook implements SnowflakeEntity, IMessageAuthor {
   Future<IMessage?> execute(MessageBuilder builder, {bool wait = true, Snowflake? threadId, String? threadName, String? avatarUrl, String? username});
 
   @override
-  String avatarUrl({String format = 'webp', int? size, bool animated = false});
+  String avatarUrl({String format = 'webp', int? size, bool? animated});
 
   /// Edits the webhook.
   Future<IWebhook> edit({String? name, SnowflakeEntity? channel, AttachmentBuilder? avatarAttachment, String? auditReason});
@@ -187,10 +187,12 @@ class Webhook extends SnowflakeEntity implements IWebhook {
           .executeWebhook(id, builder, token: token, threadId: threadId, username: username, wait: wait, avatarUrl: avatarUrl, threadName: threadName);
 
   @override
-  String avatarUrl({String format = 'webp', int? size, bool animated = false}) {
+  String avatarUrl({String format = 'webp', int? size, bool? animated}) {
     if (avatarHash == null) {
       return client.cdnHttpEndpoints.defaultAvatar(defaultAvatarId);
     }
+
+    animated ??= avatarHash?.startsWith("a_") ?? false;
 
     return client.cdnHttpEndpoints.avatar(id, avatarHash!, format: format, size: size, animated: animated);
   }

--- a/lib/src/core/user/member.dart
+++ b/lib/src/core/user/member.dart
@@ -72,7 +72,7 @@ abstract class IMember implements SnowflakeEntity, Mentionable {
 
   /// The member's avatar, represented as URL. With given [format] and [size].
   /// If [animated] is set as `true`, if available, the url will be a gif, otherwise the [format] or fallback to "webp".
-  String? avatarUrl({String format = 'webp', int? size, bool animated = false});
+  String? avatarUrl({String format = 'webp', int? size, bool? animated});
 
   /// Bans the member and optionally deletes [deleteMessageDays] days worth of messages.
   Future<void> ban({int? deleteMessageDays, String? reason, String? auditReason});
@@ -208,10 +208,12 @@ class Member extends SnowflakeEntity implements IMember {
 
   /// Returns url to member avatar
   @override
-  String? avatarUrl({String format = 'webp', int? size, bool animated = false}) {
+  String? avatarUrl({String format = 'webp', int? size, bool? animated}) {
     if (avatarHash == null) {
       return null;
     }
+
+    animated ??= avatarHash?.startsWith("a_") ?? false;
 
     return client.cdnHttpEndpoints.memberAvatar(guild.id, id, avatarHash!, format: format, size: size, animated: animated);
   }

--- a/lib/src/core/user/user.dart
+++ b/lib/src/core/user/user.dart
@@ -52,7 +52,7 @@ abstract class IUser implements SnowflakeEntity, ISend, Mentionable, IMessageAut
   String? avatarDecorationHash;
 
   /// The user's banner url.
-  String? bannerUrl({String format = 'webp', int? size, bool animated = false});
+  String? bannerUrl({String format = 'webp', int? size, bool? animated});
 
   /// The user's avatar decoration url, if any.
   String? avatarDecorationUrl({int size});
@@ -170,20 +170,24 @@ class User extends SnowflakeEntity implements IUser {
   /// The user's avatar, represented as URL.
   /// In case if user does not have avatar, default discord avatar will be returned with specified size and png format.
   @override
-  String avatarUrl({String format = 'webp', int? size, bool animated = false}) {
+  String avatarUrl({String format = 'webp', int? size, bool? animated}) {
     if (avatar == null) {
       return client.cdnHttpEndpoints.defaultAvatar(discriminator);
     }
+
+    animated ??= avatar?.startsWith("a_") ?? false;
 
     return client.cdnHttpEndpoints.avatar(id, avatar!, format: format, size: size, animated: animated);
   }
 
   /// The user's banner url.
   @override
-  String? bannerUrl({String format = 'webp', int? size, bool animated = false}) {
+  String? bannerUrl({String format = 'webp', int? size, bool? animated}) {
     if (bannerHash == null) {
       return null;
     }
+
+    animated ??= bannerHash?.startsWith("a_") ?? false;
 
     return client.cdnHttpEndpoints.banner(id, bannerHash!, format: format, size: size, animated: animated);
   }

--- a/lib/src/internal/interfaces/message_author.dart
+++ b/lib/src/internal/interfaces/message_author.dart
@@ -24,5 +24,5 @@ abstract class IMessageAuthor implements SnowflakeEntity {
   /// The user's avatar, represented as URL.
   /// In case if user does not have avatar, default discord avatar will be returned; [format], [size] and [animated] will no longer affectng this URL.
   /// If [animated] is set as `true`, if available, the url will be a gif, otherwise the [format].
-  String avatarUrl({String format = 'webp', int? size, bool animated = false});
+  String avatarUrl({String format = 'webp', int? size, bool? animated});
 }


### PR DESCRIPTION
feat: animated icon/avatar/splash URL helpers on null

# Description

Makes the `animated` argument nullable for `iconUrl`, `bannerUrl`, and `avatarUrl` for `MessageAuthor`, `User`, `Member`, `Webhook`, `GuildPreview`, and `Guild`. Adds simple logic that sets the `animated` boolean based on the image hash.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
