### PR TITLE
Revert #475

### DIFF
--- a/lib/src/core/application/app_team_user.dart
+++ b/lib/src/core/application/app_team_user.dart
@@ -47,7 +47,7 @@ class AppTeamUser extends SnowflakeEntity implements IAppTeamUser {
   }
 
   @override
-  String avatarUrl({String format = 'webp', int? size, bool animated = false}) {
+  String avatarUrl({String format = 'webp', int? size, bool animated = true}) {
     if (avatar == null) {
       return client.cdnHttpEndpoints.defaultAvatar(int.tryParse(discriminator) ?? 0);
     }

--- a/lib/src/core/guild/guild.dart
+++ b/lib/src/core/guild/guild.dart
@@ -199,7 +199,7 @@ abstract class IGuild implements SnowflakeEntity {
 
   /// The guild's icon, represented as URL.
   /// If guild doesn't have icon it returns null.
-  String? iconUrl({String format = 'webp', int? size, bool animated = false});
+  String? iconUrl({String format = 'webp', int? size, bool animated = true});
 
   /// URL to guild's splash.
   /// If guild doesn't have splash it returns null.
@@ -211,7 +211,7 @@ abstract class IGuild implements SnowflakeEntity {
 
   /// URL to guild's banner.
   /// If guild doesn't have banner it returns null.
-  String? bannerUrl({String format = 'webp', int? size, bool animated = false});
+  String? bannerUrl({String format = 'webp', int? size, bool animated = true});
 
   /// Allows to download [IGuild] widget aka advert png
   /// Possible options for [style]: shield (default), banner1, banner2, banner3, banner4
@@ -730,7 +730,7 @@ class Guild extends SnowflakeEntity implements IGuild {
   /// The guild's icon, represented as URL.
   /// If guild doesn't have icon it returns null.
   @override
-  String? iconUrl({String format = 'webp', int? size, bool animated = false}) {
+  String? iconUrl({String format = 'webp', int? size, bool animated = true}) {
     if (icon == null) {
       return null;
     }
@@ -768,7 +768,7 @@ class Guild extends SnowflakeEntity implements IGuild {
   /// Returns the URL to guild's banner.
   /// If guild doesn't have banner it returns null.
   @override
-  String? bannerUrl({String format = 'webp', int? size, bool animated = false}) {
+  String? bannerUrl({String format = 'webp', int? size, bool animated = true}) {
     if (banner == null) {
       return null;
     }

--- a/lib/src/core/guild/guild.dart
+++ b/lib/src/core/guild/guild.dart
@@ -199,7 +199,7 @@ abstract class IGuild implements SnowflakeEntity {
 
   /// The guild's icon, represented as URL.
   /// If guild doesn't have icon it returns null.
-  String? iconUrl({String format = 'webp', int? size, bool? animated});
+  String? iconUrl({String format = 'webp', int? size, bool animated = false});
 
   /// URL to guild's splash.
   /// If guild doesn't have splash it returns null.
@@ -211,7 +211,7 @@ abstract class IGuild implements SnowflakeEntity {
 
   /// URL to guild's banner.
   /// If guild doesn't have banner it returns null.
-  String? bannerUrl({String format = 'webp', int? size, bool? animated});
+  String? bannerUrl({String format = 'webp', int? size, bool animated = false});
 
   /// Allows to download [IGuild] widget aka advert png
   /// Possible options for [style]: shield (default), banner1, banner2, banner3, banner4
@@ -730,12 +730,10 @@ class Guild extends SnowflakeEntity implements IGuild {
   /// The guild's icon, represented as URL.
   /// If guild doesn't have icon it returns null.
   @override
-  String? iconUrl({String format = 'webp', int? size, bool? animated}) {
+  String? iconUrl({String format = 'webp', int? size, bool animated = false}) {
     if (icon == null) {
       return null;
     }
-
-    animated ??= icon?.startsWith("a_") ?? false;
 
     return client.cdnHttpEndpoints.icon(id, icon!, format: format, size: size, animated: animated);
   }
@@ -770,12 +768,10 @@ class Guild extends SnowflakeEntity implements IGuild {
   /// Returns the URL to guild's banner.
   /// If guild doesn't have banner it returns null.
   @override
-  String? bannerUrl({String format = 'webp', int? size, bool? animated}) {
+  String? bannerUrl({String format = 'webp', int? size, bool animated = false}) {
     if (banner == null) {
       return null;
     }
-
-    animated ??= banner?.startsWith("a_") ?? false;
 
     return client.cdnHttpEndpoints.banner(id, banner!, format: format, size: size, animated: animated);
   }

--- a/lib/src/core/guild/guild_preview.dart
+++ b/lib/src/core/guild/guild_preview.dart
@@ -38,7 +38,7 @@ abstract class IGuildPreview implements SnowflakeEntity {
 
   /// The guild's icon, represented as URL.
   /// If guild doesn't have icon it returns null.
-  String? iconUrl({String format = 'webp', int? size, bool animated = false});
+  String? iconUrl({String format = 'webp', int? size, bool animated = true});
 
   /// URL to guild's splash.
   /// If guild doesn't have splash it returns null.
@@ -115,7 +115,7 @@ class GuildPreview extends SnowflakeEntity implements IGuildPreview {
   /// The guild's icon, represented as URL.
   /// If guild doesn't have icon it returns null.
   @override
-  String? iconUrl({String format = 'webp', int? size, bool animated = false}) {
+  String? iconUrl({String format = 'webp', int? size, bool animated = true}) {
     if (iconHash == null) {
       return null;
     }

--- a/lib/src/core/guild/guild_preview.dart
+++ b/lib/src/core/guild/guild_preview.dart
@@ -38,7 +38,7 @@ abstract class IGuildPreview implements SnowflakeEntity {
 
   /// The guild's icon, represented as URL.
   /// If guild doesn't have icon it returns null.
-  String? iconUrl({String format = 'webp', int? size, bool? animated});
+  String? iconUrl({String format = 'webp', int? size, bool animated = false});
 
   /// URL to guild's splash.
   /// If guild doesn't have splash it returns null.
@@ -115,12 +115,10 @@ class GuildPreview extends SnowflakeEntity implements IGuildPreview {
   /// The guild's icon, represented as URL.
   /// If guild doesn't have icon it returns null.
   @override
-  String? iconUrl({String format = 'webp', int? size, bool? animated}) {
+  String? iconUrl({String format = 'webp', int? size, bool animated = false}) {
     if (iconHash == null) {
       return null;
     }
-
-    animated ??= iconHash?.startsWith("a_") ?? false;
 
     return client.cdnHttpEndpoints.icon(id, iconHash!, format: format, size: size, animated: animated);
   }

--- a/lib/src/core/guild/webhook.dart
+++ b/lib/src/core/guild/webhook.dart
@@ -79,7 +79,7 @@ abstract class IWebhook implements SnowflakeEntity, IMessageAuthor {
   Future<IMessage?> execute(MessageBuilder builder, {bool wait = true, Snowflake? threadId, String? threadName, String? avatarUrl, String? username});
 
   @override
-  String avatarUrl({String format = 'webp', int? size, bool animated = false});
+  String avatarUrl({String format = 'webp', int? size, bool animated = true});
 
   /// Edits the webhook.
   Future<IWebhook> edit({String? name, SnowflakeEntity? channel, AttachmentBuilder? avatarAttachment, String? auditReason});
@@ -187,7 +187,7 @@ class Webhook extends SnowflakeEntity implements IWebhook {
           .executeWebhook(id, builder, token: token, threadId: threadId, username: username, wait: wait, avatarUrl: avatarUrl, threadName: threadName);
 
   @override
-  String avatarUrl({String format = 'webp', int? size, bool animated = false}) {
+  String avatarUrl({String format = 'webp', int? size, bool animated = true}) {
     if (avatarHash == null) {
       return client.cdnHttpEndpoints.defaultAvatar(defaultAvatarId);
     }

--- a/lib/src/core/guild/webhook.dart
+++ b/lib/src/core/guild/webhook.dart
@@ -79,7 +79,7 @@ abstract class IWebhook implements SnowflakeEntity, IMessageAuthor {
   Future<IMessage?> execute(MessageBuilder builder, {bool wait = true, Snowflake? threadId, String? threadName, String? avatarUrl, String? username});
 
   @override
-  String avatarUrl({String format = 'webp', int? size, bool? animated});
+  String avatarUrl({String format = 'webp', int? size, bool animated = false});
 
   /// Edits the webhook.
   Future<IWebhook> edit({String? name, SnowflakeEntity? channel, AttachmentBuilder? avatarAttachment, String? auditReason});
@@ -187,12 +187,10 @@ class Webhook extends SnowflakeEntity implements IWebhook {
           .executeWebhook(id, builder, token: token, threadId: threadId, username: username, wait: wait, avatarUrl: avatarUrl, threadName: threadName);
 
   @override
-  String avatarUrl({String format = 'webp', int? size, bool? animated}) {
+  String avatarUrl({String format = 'webp', int? size, bool animated = false}) {
     if (avatarHash == null) {
       return client.cdnHttpEndpoints.defaultAvatar(defaultAvatarId);
     }
-
-    animated ??= avatarHash?.startsWith("a_") ?? false;
 
     return client.cdnHttpEndpoints.avatar(id, avatarHash!, format: format, size: size, animated: animated);
   }

--- a/lib/src/core/message/guild_emoji.dart
+++ b/lib/src/core/message/guild_emoji.dart
@@ -26,7 +26,7 @@ abstract class IBaseGuildEmoji implements SnowflakeEntity, IEmoji {
 
   /// Returns the CDN URL for this emoji with given [format] and [size].
   /// If [animated] is set as `true`, an animated version of the emoji (if applicable) will be displayed.
-  String cdnUrl({String format = 'webp', int? size, bool animated = false});
+  String cdnUrl({String format = 'webp', int? size, bool animated = true});
 }
 
 abstract class BaseGuildEmoji extends SnowflakeEntity implements IBaseGuildEmoji {
@@ -50,7 +50,7 @@ abstract class BaseGuildEmoji extends SnowflakeEntity implements IBaseGuildEmoji
 
   /// Returns cdn url to emoji
   @override
-  String cdnUrl({String format = 'webp', int? size, bool animated = false}) {
+  String cdnUrl({String format = 'webp', int? size, bool animated = true}) {
     return client.cdnHttpEndpoints.emoji(id, format: this.animated && animated ? 'gif' : format, size: size);
   }
 

--- a/lib/src/core/user/member.dart
+++ b/lib/src/core/user/member.dart
@@ -72,7 +72,7 @@ abstract class IMember implements SnowflakeEntity, Mentionable {
 
   /// The member's avatar, represented as URL. With given [format] and [size].
   /// If [animated] is set as `true`, if available, the url will be a gif, otherwise the [format] or fallback to "webp".
-  String? avatarUrl({String format = 'webp', int? size, bool animated = false});
+  String? avatarUrl({String format = 'webp', int? size, bool animated = true});
 
   /// Bans the member and optionally deletes [deleteMessageDays] days worth of messages.
   Future<void> ban({int? deleteMessageDays, String? reason, String? auditReason});
@@ -208,7 +208,7 @@ class Member extends SnowflakeEntity implements IMember {
 
   /// Returns url to member avatar
   @override
-  String? avatarUrl({String format = 'webp', int? size, bool animated = false}) {
+  String? avatarUrl({String format = 'webp', int? size, bool animated = true}) {
     if (avatarHash == null) {
       return null;
     }

--- a/lib/src/core/user/member.dart
+++ b/lib/src/core/user/member.dart
@@ -72,7 +72,7 @@ abstract class IMember implements SnowflakeEntity, Mentionable {
 
   /// The member's avatar, represented as URL. With given [format] and [size].
   /// If [animated] is set as `true`, if available, the url will be a gif, otherwise the [format] or fallback to "webp".
-  String? avatarUrl({String format = 'webp', int? size, bool? animated});
+  String? avatarUrl({String format = 'webp', int? size, bool animated = false});
 
   /// Bans the member and optionally deletes [deleteMessageDays] days worth of messages.
   Future<void> ban({int? deleteMessageDays, String? reason, String? auditReason});
@@ -208,12 +208,10 @@ class Member extends SnowflakeEntity implements IMember {
 
   /// Returns url to member avatar
   @override
-  String? avatarUrl({String format = 'webp', int? size, bool? animated}) {
+  String? avatarUrl({String format = 'webp', int? size, bool animated = false}) {
     if (avatarHash == null) {
       return null;
     }
-
-    animated ??= avatarHash?.startsWith("a_") ?? false;
 
     return client.cdnHttpEndpoints.memberAvatar(guild.id, id, avatarHash!, format: format, size: size, animated: animated);
   }

--- a/lib/src/core/user/user.dart
+++ b/lib/src/core/user/user.dart
@@ -52,7 +52,7 @@ abstract class IUser implements SnowflakeEntity, ISend, Mentionable, IMessageAut
   String? avatarDecorationHash;
 
   /// The user's banner url.
-  String? bannerUrl({String format = 'webp', int? size, bool animated = false});
+  String? bannerUrl({String format = 'webp', int? size, bool animated = true});
 
   /// The user's avatar decoration url, if any.
   String? avatarDecorationUrl({int size});
@@ -170,7 +170,7 @@ class User extends SnowflakeEntity implements IUser {
   /// The user's avatar, represented as URL.
   /// In case if user does not have avatar, default discord avatar will be returned with specified size and png format.
   @override
-  String avatarUrl({String format = 'webp', int? size, bool animated = false}) {
+  String avatarUrl({String format = 'webp', int? size, bool animated = true}) {
     if (avatar == null) {
       return client.cdnHttpEndpoints.defaultAvatar(discriminator);
     }
@@ -180,7 +180,7 @@ class User extends SnowflakeEntity implements IUser {
 
   /// The user's banner url.
   @override
-  String? bannerUrl({String format = 'webp', int? size, bool animated = false}) {
+  String? bannerUrl({String format = 'webp', int? size, bool animated = true}) {
     if (bannerHash == null) {
       return null;
     }

--- a/lib/src/core/user/user.dart
+++ b/lib/src/core/user/user.dart
@@ -52,7 +52,7 @@ abstract class IUser implements SnowflakeEntity, ISend, Mentionable, IMessageAut
   String? avatarDecorationHash;
 
   /// The user's banner url.
-  String? bannerUrl({String format = 'webp', int? size, bool? animated});
+  String? bannerUrl({String format = 'webp', int? size, bool animated = false});
 
   /// The user's avatar decoration url, if any.
   String? avatarDecorationUrl({int size});
@@ -170,24 +170,20 @@ class User extends SnowflakeEntity implements IUser {
   /// The user's avatar, represented as URL.
   /// In case if user does not have avatar, default discord avatar will be returned with specified size and png format.
   @override
-  String avatarUrl({String format = 'webp', int? size, bool? animated}) {
+  String avatarUrl({String format = 'webp', int? size, bool animated = false}) {
     if (avatar == null) {
       return client.cdnHttpEndpoints.defaultAvatar(discriminator);
     }
-
-    animated ??= avatar?.startsWith("a_") ?? false;
 
     return client.cdnHttpEndpoints.avatar(id, avatar!, format: format, size: size, animated: animated);
   }
 
   /// The user's banner url.
   @override
-  String? bannerUrl({String format = 'webp', int? size, bool? animated}) {
+  String? bannerUrl({String format = 'webp', int? size, bool animated = false}) {
     if (bannerHash == null) {
       return null;
     }
-
-    animated ??= bannerHash?.startsWith("a_") ?? false;
 
     return client.cdnHttpEndpoints.banner(id, bannerHash!, format: format, size: size, animated: animated);
   }

--- a/lib/src/internal/cdn_http_endpoints.dart
+++ b/lib/src/internal/cdn_http_endpoints.dart
@@ -181,8 +181,7 @@ class CdnHttpEndpoints implements ICdnHttpEndpoints {
       );
 
   @override
-  String memberAvatar(Snowflake guildId, Snowflake userId, String avatarHash, {String format = 'webp', int? size, bool animated = true}) =>
-      _makeAnimatedCdnUrl(
+  String memberAvatar(Snowflake guildId, Snowflake userId, String avatarHash, {String format = 'webp', int? size, bool animated = true}) => _makeAnimatedCdnUrl(
         ICdnHttpRoute()
           ..guilds(id: guildId.toString())
           ..users(id: userId.toString())

--- a/lib/src/internal/cdn_http_endpoints.dart
+++ b/lib/src/internal/cdn_http_endpoints.dart
@@ -86,13 +86,9 @@ abstract class ICdnHttpEndpoints {
 
 class CdnHttpEndpoints implements ICdnHttpEndpoints {
   String _makeAnimatedCdnUrl(ICdnHttpRoute fragment, String hash, {String format = 'webp', int? size, bool animated = false}) {
-    if (hash.startsWith('a_') && animated) {
-      animated = true;
-    } else {
-      animated = false;
-    }
+    final isAnimated = animated && hash.startsWith('a_');
 
-    return _makeCdnUrl(fragment, format: format, size: size, animated: animated);
+    return _makeCdnUrl(fragment, format: format, size: size, animated: isAnimated);
   }
 
   String _makeCdnUrl(ICdnHttpRoute fragments, {String format = 'webp', int? size, bool animated = false}) {

--- a/lib/src/internal/cdn_http_endpoints.dart
+++ b/lib/src/internal/cdn_http_endpoints.dart
@@ -19,11 +19,11 @@ abstract class ICdnHttpEndpoints {
 
   /// Returns URL to ``/avatars/[avatarHash]``.
   /// With given [format], [size] and whether or not returns the animated version (if applicable) of this URL with [animated].
-  String avatar(Snowflake id, String avatarHash, {String format = 'webp', int? size, bool animated = false});
+  String avatar(Snowflake id, String avatarHash, {String format = 'webp', int? size, bool animated = true});
 
   /// Returns URL to ``/banners/[bannerHash]``.
   /// With given [format], [size] and whether or not returns the animated version (if applicable) of this URL with [animated].
-  String banner(Snowflake guildOrUserId, String hash, {String format = 'webp', int? size, bool animated = false});
+  String banner(Snowflake guildOrUserId, String hash, {String format = 'webp', int? size, bool animated = true});
 
   /// Returns URL to ``/channel-icons/[iconHash]``.
   /// With given [format] and [size].
@@ -49,11 +49,11 @@ abstract class ICdnHttpEndpoints {
 
   /// Returns URL to ``/guilds/[guildId]/users/[userId]/[avatarHash]``.
   /// With given [format], [size] and whether or not returns the animated version (if applicable) of this URL with [animated].
-  String memberAvatar(Snowflake guildId, Snowflake userId, String avatarHash, {String format = 'webp', int? size, bool animated = false});
+  String memberAvatar(Snowflake guildId, Snowflake userId, String avatarHash, {String format = 'webp', int? size, bool animated = true});
 
   /// Returns URL tp ``/icons/[iconHash]``.
   /// With given [format], [size] and whether or not returns the animated version (if applicable) of this URL with [animated].
-  String icon(Snowflake id, String iconHash, {String format = 'webp', int? size, bool animated = false});
+  String icon(Snowflake id, String iconHash, {String format = 'webp', int? size, bool animated = true});
 
   /// Returns URL to ``/role-icons/[roleIconHash]``.
   /// With given [format] and [size].
@@ -85,13 +85,13 @@ abstract class ICdnHttpEndpoints {
 }
 
 class CdnHttpEndpoints implements ICdnHttpEndpoints {
-  String _makeAnimatedCdnUrl(ICdnHttpRoute fragment, String hash, {String format = 'webp', int? size, bool animated = false}) {
+  String _makeAnimatedCdnUrl(ICdnHttpRoute fragment, String hash, {String format = 'webp', int? size, bool animated = true}) {
     final isAnimated = animated && hash.startsWith('a_');
 
     return _makeCdnUrl(fragment, format: format, size: size, animated: isAnimated);
   }
 
-  String _makeCdnUrl(ICdnHttpRoute fragments, {String format = 'webp', int? size, bool animated = false}) {
+  String _makeCdnUrl(ICdnHttpRoute fragments, {String format = 'webp', int? size, bool animated = true}) {
     if (!CdnConstants.allowedExtensions.contains(format)) {
       throw Exception('Invalid extension provided, must be one of ${CdnConstants.allowedExtensions.and()}; given: $format');
     }
@@ -132,7 +132,7 @@ class CdnHttpEndpoints implements ICdnHttpEndpoints {
       );
 
   @override
-  String avatar(Snowflake id, String avatarHash, {String format = 'webp', int? size, bool animated = false}) => _makeAnimatedCdnUrl(
+  String avatar(Snowflake id, String avatarHash, {String format = 'webp', int? size, bool animated = true}) => _makeAnimatedCdnUrl(
         ICdnHttpRoute()
           ..avatars(id: id.toString())
           ..addHash(hash: avatarHash),
@@ -143,7 +143,7 @@ class CdnHttpEndpoints implements ICdnHttpEndpoints {
       );
 
   @override
-  String banner(Snowflake guildOrUserId, String hash, {String format = 'webp', int? size, bool animated = false}) => _makeAnimatedCdnUrl(
+  String banner(Snowflake guildOrUserId, String hash, {String format = 'webp', int? size, bool animated = true}) => _makeAnimatedCdnUrl(
         ICdnHttpRoute()
           ..banners(id: guildOrUserId.toString())
           ..addHash(hash: hash),
@@ -181,7 +181,7 @@ class CdnHttpEndpoints implements ICdnHttpEndpoints {
       );
 
   @override
-  String memberAvatar(Snowflake guildId, Snowflake userId, String avatarHash, {String format = 'webp', int? size, bool animated = false}) =>
+  String memberAvatar(Snowflake guildId, Snowflake userId, String avatarHash, {String format = 'webp', int? size, bool animated = true}) =>
       _makeAnimatedCdnUrl(
         ICdnHttpRoute()
           ..guilds(id: guildId.toString())
@@ -198,7 +198,7 @@ class CdnHttpEndpoints implements ICdnHttpEndpoints {
       _makeCdnUrl(ICdnHttpRoute()..emojis(id: emojiId.toString()), format: format, size: size);
 
   @override
-  String icon(Snowflake id, String iconHash, {String format = 'webp', int? size, bool animated = false}) => _makeAnimatedCdnUrl(
+  String icon(Snowflake id, String iconHash, {String format = 'webp', int? size, bool animated = true}) => _makeAnimatedCdnUrl(
         ICdnHttpRoute()
           ..icons(id: id.toString())
           ..addHash(hash: iconHash),

--- a/lib/src/internal/interfaces/message_author.dart
+++ b/lib/src/internal/interfaces/message_author.dart
@@ -24,5 +24,5 @@ abstract class IMessageAuthor implements SnowflakeEntity {
   /// The user's avatar, represented as URL.
   /// In case if user does not have avatar, default discord avatar will be returned; [format], [size] and [animated] will no longer affectng this URL.
   /// If [animated] is set as `true`, if available, the url will be a gif, otherwise the [format].
-  String avatarUrl({String format = 'webp', int? size, bool? animated});
+  String avatarUrl({String format = 'webp', int? size, bool animated = false});
 }

--- a/lib/src/internal/interfaces/message_author.dart
+++ b/lib/src/internal/interfaces/message_author.dart
@@ -24,5 +24,5 @@ abstract class IMessageAuthor implements SnowflakeEntity {
   /// The user's avatar, represented as URL.
   /// In case if user does not have avatar, default discord avatar will be returned; [format], [size] and [animated] will no longer affectng this URL.
   /// If [animated] is set as `true`, if available, the url will be a gif, otherwise the [format].
-  String avatarUrl({String format = 'webp', int? size, bool animated = false});
+  String avatarUrl({String format = 'webp', int? size, bool animated = true});
 }


### PR DESCRIPTION
This reverts commit 20c1bc8.

# Description
@l7ssha stated that we don't need nullable parameters for cdns.
I also don't see why it should be nullable, if you have a null value convert it to `false` accordingly.

This also removes operations that are unneeded because it's already handled in cdn endpoints.

## Connected issues & other potential problems
#475 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
