### PR TITLE
Add PartialTextChannel

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -68,7 +68,7 @@ export 'src/models/channel/channel.dart' show Channel, ChannelFlags, PartialChan
 export 'src/models/channel/followed_channel.dart' show FollowedChannel;
 export 'src/models/channel/guild_channel.dart' show GuildChannel;
 export 'src/models/channel/has_threads_channel.dart' show HasThreadsChannel;
-export 'src/models/channel/text_channel.dart' show TextChannel;
+export 'src/models/channel/text_channel.dart' show PartialTextChannel, TextChannel;
 export 'src/models/channel/thread_list.dart' show ThreadList;
 export 'src/models/channel/thread.dart' show PartialThreadMember, Thread, ThreadMember;
 export 'src/models/channel/voice_channel.dart' show VoiceChannel, VideoQualityMode;

--- a/lib/src/http/managers/channel_manager.dart
+++ b/lib/src/http/managers/channel_manager.dart
@@ -9,6 +9,7 @@ import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/route.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/followed_channel.dart';
+import 'package:nyxx/src/models/channel/text_channel.dart';
 import 'package:nyxx/src/models/channel/thread.dart';
 import 'package:nyxx/src/models/channel/thread_list.dart';
 import 'package:nyxx/src/models/channel/types/announcement_thread.dart';
@@ -35,8 +36,18 @@ class ChannelManager extends ReadOnlyManager<Channel> {
   /// Create a new [ChannelManager].
   ChannelManager(super.config, super.client);
 
+  /// Return a partial instance of the entity with ID [id] containing no data.
+  ///
+  /// This allows performing API operations without fetching an instance from the API.
+  ///
+  /// Because this method doesn't perform any API checks, there might be no real entity with the
+  /// correct [id]. In this case, the object returned may not work with the API correctly.
+  ///
+  /// While this method's return type is [PartialChannel], a [PartialTextChannel] is always returned.
+  /// If you are sure the channel you are requesting is a text channel, the returned value can safely
+  /// be cast to a [PartialTextChannel] to access the channel's messages.
   @override
-  PartialChannel operator [](Snowflake id) => PartialChannel(id: id, manager: this);
+  PartialChannel operator [](Snowflake id) => PartialTextChannel(id: id, manager: this);
 
   @override
   Channel parse(Map<String, Object?> raw) {

--- a/lib/src/http/managers/webhook_manager.dart
+++ b/lib/src/http/managers/webhook_manager.dart
@@ -6,10 +6,10 @@ import 'package:nyxx/src/builders/message/message.dart';
 import 'package:nyxx/src/builders/sentinels.dart';
 import 'package:nyxx/src/builders/webhook.dart';
 import 'package:nyxx/src/http/managers/manager.dart';
-import 'package:nyxx/src/http/managers/message_manager.dart';
 import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/route.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
+import 'package:nyxx/src/models/channel/text_channel.dart';
 import 'package:nyxx/src/models/guild/guild.dart';
 import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/snowflake.dart';
@@ -187,11 +187,8 @@ class WebhookManager extends Manager<Webhook> {
       return null;
     }
 
-    final messageManager = MessageManager(
-      client.options.messageCacheConfig,
-      client,
-      channelId: Snowflake.parse((response.jsonBody as Map<String, Object?>)['channel_id'] as String),
-    );
+    final channelId = Snowflake.parse((response.jsonBody as Map<String, Object?>)['channel_id'] as String);
+    final messageManager = (client.channels[channelId] as PartialTextChannel).messages;
     final message = messageManager.parse(response.jsonBody as Map<String, Object?>);
 
     messageManager.cache[message.id] = message;
@@ -211,11 +208,8 @@ class WebhookManager extends Manager<Webhook> {
     );
 
     final response = await client.httpHandler.executeSafe(request);
-    final messageManager = MessageManager(
-      client.options.messageCacheConfig,
-      client,
-      channelId: Snowflake.parse((response.jsonBody as Map<String, Object?>)['channel_id'] as String),
-    );
+    final channelId = Snowflake.parse((response.jsonBody as Map<String, Object?>)['channel_id'] as String);
+    final messageManager = (client.channels[channelId] as PartialTextChannel).messages;
     final message = messageManager.parse(response.jsonBody as Map<String, Object?>);
 
     messageManager.cache[message.id] = message;
@@ -271,11 +265,8 @@ class WebhookManager extends Manager<Webhook> {
     }
 
     final response = await client.httpHandler.executeSafe(request);
-    final messageManager = MessageManager(
-      client.options.messageCacheConfig,
-      client,
-      channelId: Snowflake.parse((response.jsonBody as Map<String, Object?>)['channel_id'] as String),
-    );
+    final channelId = Snowflake.parse((response.jsonBody as Map<String, Object?>)['channel_id'] as String);
+    final messageManager = (client.channels[channelId] as PartialTextChannel).messages;
     final message = messageManager.parse(response.jsonBody as Map<String, Object?>);
 
     messageManager.cache[message.id] = message;

--- a/lib/src/models/channel/text_channel.dart
+++ b/lib/src/models/channel/text_channel.dart
@@ -4,11 +4,33 @@ import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 
-//// A text channel
-abstract class TextChannel implements Channel {
+/// A partial [TextChannel].
+class PartialTextChannel extends PartialChannel {
   /// A [Manager] for the [Message]s of this channel.
-  MessageManager get messages;
+  MessageManager get messages => MessageManager(manager.client.options.messageCacheConfig, manager.client, channelId: id);
 
+  /// Create a new [PartialTextChannel].
+  PartialTextChannel({required super.id, required super.manager});
+
+  /// Send a message to this channel.
+  ///
+  /// Returns the created message.
+  ///
+  /// External references:
+  /// * [MessageManager.create]
+  /// * Discord API Reference: https://discord.com/developers/docs/resources/channel#create-message
+  Future<Message> sendMessage(MessageBuilder builder) => messages.create(builder);
+
+  /// Trigger a typing indicator in this channel from the current user.
+  ///
+  /// External references:
+  /// * [ChannelManager.triggerTyping]
+  /// * Discord API Reference: https://discord.com/developers/docs/resources/channel#trigger-typing-indicator
+  Future<void> triggerTyping() => manager.triggerTyping(id);
+}
+
+//// A text channel
+abstract class TextChannel extends PartialTextChannel implements Channel {
   /// The ID of the last [Message] snt in this channel, or `null` if no messages have been sent.
   Snowflake? get lastMessageId;
 
@@ -18,19 +40,5 @@ abstract class TextChannel implements Channel {
   /// The time at which the last message was pinned, or `null` if no messages have been pinned.
   DateTime? get lastPinTimestamp;
 
-  /// Send a message to this channel.
-  ///
-  /// Returns the created message.
-  ///
-  /// External references:
-  /// * [MessageManager.create]
-  /// * Discord API Reference: https://discord.com/developers/docs/resources/channel#create-message
-  Future<Message> sendMessage(MessageBuilder builder);
-
-  /// Trigger a typing indicator in this channel from the current user.
-  ///
-  /// External references:
-  /// * [ChannelManager.triggerTyping]
-  /// * Discord API Reference: https://discord.com/developers/docs/resources/channel#trigger-typing-indicator
-  Future<void> triggerTyping();
+  TextChannel({required super.id, required super.manager});
 }

--- a/lib/src/models/channel/types/announcement_thread.dart
+++ b/lib/src/models/channel/types/announcement_thread.dart
@@ -1,17 +1,12 @@
-import 'package:nyxx/src/builders/message/message.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
-import 'package:nyxx/src/http/managers/message_manager.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
+import 'package:nyxx/src/models/channel/text_channel.dart';
 import 'package:nyxx/src/models/channel/thread.dart';
-import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/permission_overwrite.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/webhook.dart';
 
-class AnnouncementThread extends Channel implements Thread {
-  @override
-  MessageManager get messages => MessageManager(manager.client.options.messageCacheConfig, manager.client, channelId: id);
-
+class AnnouncementThread extends TextChannel implements Thread {
   @override
   final List<Snowflake>? appliedTags;
 
@@ -115,12 +110,6 @@ class AnnouncementThread extends Channel implements Thread {
 
   @override
   Future<void> removeThreadMember(Snowflake memberId) => manager.removeThreadMember(id, memberId);
-
-  @override
-  Future<Message> sendMessage(MessageBuilder builder) => messages.create(builder);
-
-  @override
-  Future<void> triggerTyping() => manager.triggerTyping(id);
 
   @override
   Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);

--- a/lib/src/models/channel/types/dm.dart
+++ b/lib/src/models/channel/types/dm.dart
@@ -1,18 +1,12 @@
-import 'package:nyxx/src/builders/message/message.dart';
-import 'package:nyxx/src/http/managers/message_manager.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/text_channel.dart';
-import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/user/user.dart';
 
 /// {@template dm_channel}
 /// A DM channel.
 /// {@endtemplate}
-class DmChannel extends Channel implements TextChannel {
-  @override
-  MessageManager get messages => MessageManager(manager.client.options.messageCacheConfig, manager.client, channelId: id);
-
+class DmChannel extends TextChannel {
   /// The recipient of this channel.
   final User recipient;
 
@@ -37,10 +31,4 @@ class DmChannel extends Channel implements TextChannel {
     required this.lastPinTimestamp,
     required this.rateLimitPerUser,
   });
-
-  @override
-  Future<Message> sendMessage(MessageBuilder builder) => messages.create(builder);
-
-  @override
-  Future<void> triggerTyping() => manager.triggerTyping(id);
 }

--- a/lib/src/models/channel/types/group_dm.dart
+++ b/lib/src/models/channel/types/group_dm.dart
@@ -1,18 +1,12 @@
-import 'package:nyxx/src/builders/message/message.dart';
-import 'package:nyxx/src/http/managers/message_manager.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/text_channel.dart';
-import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/user/user.dart';
 
 /// {@template group_dm_channel}
 /// A DM channel with multiple recipients.
 /// {@endtemplate}
-class GroupDmChannel extends Channel implements TextChannel {
-  @override
-  MessageManager get messages => MessageManager(manager.client.options.messageCacheConfig, manager.client, channelId: id);
-
+class GroupDmChannel extends TextChannel {
   /// The name of this channel.
   final String name;
 
@@ -57,10 +51,4 @@ class GroupDmChannel extends Channel implements TextChannel {
     required this.lastPinTimestamp,
     required this.rateLimitPerUser,
   });
-
-  @override
-  Future<Message> sendMessage(MessageBuilder builder) => messages.create(builder);
-
-  @override
-  Future<void> triggerTyping() => manager.triggerTyping(id);
 }

--- a/lib/src/models/channel/types/guild_announcement.dart
+++ b/lib/src/models/channel/types/guild_announcement.dart
@@ -1,14 +1,11 @@
 import 'package:nyxx/src/builders/channel/thread.dart';
-import 'package:nyxx/src/builders/message/message.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
-import 'package:nyxx/src/http/managers/message_manager.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/text_channel.dart';
 import 'package:nyxx/src/models/channel/has_threads_channel.dart';
 import 'package:nyxx/src/models/channel/thread.dart';
 import 'package:nyxx/src/models/channel/thread_list.dart';
-import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/permission_overwrite.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/webhook.dart';
@@ -16,10 +13,7 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template guild_announcement_channel}
 /// An announcement channel in a [Guild].
 /// {@endtemplate}
-class GuildAnnouncementChannel extends Channel implements TextChannel, GuildChannel, HasThreadsChannel {
-  @override
-  MessageManager get messages => MessageManager(manager.client.options.messageCacheConfig, manager.client, channelId: id);
-
+class GuildAnnouncementChannel extends TextChannel implements GuildChannel, HasThreadsChannel {
   /// The topic of this channel.
   final String topic;
 
@@ -95,12 +89,6 @@ class GuildAnnouncementChannel extends Channel implements TextChannel, GuildChan
   @override
   Future<ThreadList> listJoinedPrivateArchivedThreads({DateTime? before, int? limit}) =>
       manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit);
-
-  @override
-  Future<Message> sendMessage(MessageBuilder builder) => messages.create(builder);
-
-  @override
-  Future<void> triggerTyping() => manager.triggerTyping(id);
 
   @override
   Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);

--- a/lib/src/models/channel/types/guild_stage.dart
+++ b/lib/src/models/channel/types/guild_stage.dart
@@ -1,11 +1,8 @@
-import 'package:nyxx/src/builders/message/message.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
-import 'package:nyxx/src/http/managers/message_manager.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/text_channel.dart';
 import 'package:nyxx/src/models/channel/voice_channel.dart';
-import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/permission_overwrite.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/webhook.dart';
@@ -13,10 +10,7 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template guild_stage_channel}
 /// A stage channel.
 /// {@endtemplate}
-class GuildStageChannel extends Channel implements TextChannel, VoiceChannel, GuildChannel {
-  @override
-  MessageManager get messages => MessageManager(manager.client.options.messageCacheConfig, manager.client, channelId: id);
-
+class GuildStageChannel extends TextChannel implements VoiceChannel, GuildChannel {
   @override
   final int bitrate;
 
@@ -80,12 +74,6 @@ class GuildStageChannel extends Channel implements TextChannel, VoiceChannel, Gu
 
   @override
   Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
-
-  @override
-  Future<Message> sendMessage(MessageBuilder builder) => messages.create(builder);
-
-  @override
-  Future<void> triggerTyping() => manager.triggerTyping(id);
 
   @override
   Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);

--- a/lib/src/models/channel/types/guild_text.dart
+++ b/lib/src/models/channel/types/guild_text.dart
@@ -1,14 +1,11 @@
 import 'package:nyxx/src/builders/channel/thread.dart';
-import 'package:nyxx/src/builders/message/message.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
-import 'package:nyxx/src/http/managers/message_manager.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/text_channel.dart';
 import 'package:nyxx/src/models/channel/has_threads_channel.dart';
 import 'package:nyxx/src/models/channel/thread.dart';
 import 'package:nyxx/src/models/channel/thread_list.dart';
-import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/permission_overwrite.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/webhook.dart';
@@ -16,10 +13,7 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template guild_text_channel}
 /// A [TextChannel] in a [Guild].
 /// {@endtemplate}
-class GuildTextChannel extends Channel implements TextChannel, GuildChannel, HasThreadsChannel {
-  @override
-  MessageManager get messages => MessageManager(manager.client.options.messageCacheConfig, manager.client, channelId: id);
-
+class GuildTextChannel extends TextChannel implements GuildChannel, HasThreadsChannel {
   /// The topic of this channel.
   final String? topic;
 
@@ -95,12 +89,6 @@ class GuildTextChannel extends Channel implements TextChannel, GuildChannel, Has
   @override
   Future<ThreadList> listJoinedPrivateArchivedThreads({DateTime? before, int? limit}) =>
       manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit);
-
-  @override
-  Future<Message> sendMessage(MessageBuilder builder) => messages.create(builder);
-
-  @override
-  Future<void> triggerTyping() => manager.triggerTyping(id);
 
   @override
   Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);

--- a/lib/src/models/channel/types/guild_voice.dart
+++ b/lib/src/models/channel/types/guild_voice.dart
@@ -1,11 +1,8 @@
-import 'package:nyxx/src/builders/message/message.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
-import 'package:nyxx/src/http/managers/message_manager.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/text_channel.dart';
 import 'package:nyxx/src/models/channel/voice_channel.dart';
-import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/permission_overwrite.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/webhook.dart';
@@ -13,10 +10,7 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template guild_voice_channel}
 /// A [VoiceChannel] in a [Guild].
 /// {@endtemplate}
-class GuildVoiceChannel extends Channel implements TextChannel, GuildChannel, VoiceChannel {
-  @override
-  MessageManager get messages => MessageManager(manager.client.options.messageCacheConfig, manager.client, channelId: id);
-
+class GuildVoiceChannel extends TextChannel implements GuildChannel, VoiceChannel {
   @override
   final int bitrate;
 
@@ -80,12 +74,6 @@ class GuildVoiceChannel extends Channel implements TextChannel, GuildChannel, Vo
 
   @override
   Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
-
-  @override
-  Future<Message> sendMessage(MessageBuilder builder) => messages.create(builder);
-
-  @override
-  Future<void> triggerTyping() => manager.triggerTyping(id);
 
   @override
   Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);

--- a/lib/src/models/channel/types/private_thread.dart
+++ b/lib/src/models/channel/types/private_thread.dart
@@ -1,9 +1,7 @@
-import 'package:nyxx/src/builders/message/message.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
-import 'package:nyxx/src/http/managers/message_manager.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
+import 'package:nyxx/src/models/channel/text_channel.dart';
 import 'package:nyxx/src/models/channel/thread.dart';
-import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/permission_overwrite.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/webhook.dart';
@@ -11,10 +9,7 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template private_thread}
 /// A private [Thread] channel.
 /// {@endtemplate}
-class PrivateThread extends Channel implements Thread {
-  @override
-  MessageManager get messages => MessageManager(manager.client.options.messageCacheConfig, manager.client, channelId: id);
-
+class PrivateThread extends TextChannel implements Thread {
   final bool isInvitable;
 
   @override
@@ -122,12 +117,6 @@ class PrivateThread extends Channel implements Thread {
 
   @override
   Future<void> removeThreadMember(Snowflake memberId) => manager.removeThreadMember(id, memberId);
-
-  @override
-  Future<Message> sendMessage(MessageBuilder builder) => messages.create(builder);
-
-  @override
-  Future<void> triggerTyping() => manager.triggerTyping(id);
 
   @override
   Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);

--- a/lib/src/models/channel/types/public_thread.dart
+++ b/lib/src/models/channel/types/public_thread.dart
@@ -1,9 +1,7 @@
-import 'package:nyxx/src/builders/message/message.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
-import 'package:nyxx/src/http/managers/message_manager.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
+import 'package:nyxx/src/models/channel/text_channel.dart';
 import 'package:nyxx/src/models/channel/thread.dart';
-import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/permission_overwrite.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/webhook.dart';
@@ -11,10 +9,7 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template public_thread}
 /// A public [Thread] channel.
 /// {@endtemplate}
-class PublicThread extends Channel implements Thread {
-  @override
-  MessageManager get messages => MessageManager(manager.client.options.messageCacheConfig, manager.client, channelId: id);
-
+class PublicThread extends TextChannel implements Thread {
   @override
   final List<Snowflake>? appliedTags;
 
@@ -119,12 +114,6 @@ class PublicThread extends Channel implements Thread {
 
   @override
   Future<void> removeThreadMember(Snowflake memberId) => manager.removeThreadMember(id, memberId);
-
-  @override
-  Future<Message> sendMessage(MessageBuilder builder) => messages.create(builder);
-
-  @override
-  Future<void> triggerTyping() => manager.triggerTyping(id);
 
   @override
   Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);

--- a/test/unit/http/managers/channel_manager_test.dart
+++ b/test/unit/http/managers/channel_manager_test.dart
@@ -1,6 +1,7 @@
 import 'package:nyxx/nyxx.dart';
 import 'package:test/test.dart';
 
+import '../../../mocks/client.dart';
 import '../../../test_manager.dart';
 
 final sampleGuildText = {
@@ -629,5 +630,12 @@ void main() {
         check: checkThreadList,
       ),
     ],
+    extraRun: () {
+      test('[] returns PartialTextChannel', () {
+        final manager = ChannelManager(const CacheConfig(), MockNyxx());
+
+        expect(manager[Snowflake.zero], isA<PartialTextChannel>());
+      });
+    },
   );
 }


### PR DESCRIPTION
# Description

Adds a `PartialTextChannel` type which allows users to access a channel's mesages without fetching it or creating the `MessageManager` themselves.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
