### PR TITLE
Rewrite audit logs http api

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -63,6 +63,7 @@ export 'src/http/managers/role_manager.dart' show RoleManager;
 export 'src/http/managers/gateway_manager.dart' show GatewayManager;
 export 'src/http/managers/scheduled_event_manager.dart' show ScheduledEventManager;
 export 'src/http/managers/auto_moderation_manager.dart' show AutoModerationManager;
+export 'src/http/managers/audit_log_manager.dart' show AuditLogManager;
 
 export 'src/gateway/gateway.dart' show Gateway;
 export 'src/gateway/message.dart' show Disconnecting, Dispose, ErrorReceived, EventReceived, GatewayMessage, Send, ShardData, ShardMessage;
@@ -128,6 +129,7 @@ export 'src/models/guild/member.dart' show Member, MemberFlags, PartialMember;
 export 'src/models/guild/onboarding.dart' show Onboarding, OnboardingPrompt, OnboardingPromptOption, OnboardingPromptType;
 export 'src/models/guild/welcome_screen.dart' show WelcomeScreen, WelcomeScreenChannel;
 export 'src/models/guild/scheduled_event.dart' show EntityMetadata, PartialScheduledEvent, ScheduledEvent, ScheduledEventUser, EventStatus, ScheduledEntityType;
+export 'src/models/guild/audit_log.dart' show AuditLogChange, AuditLogEntry, AuditLogEntryInfo, PartialAuditLogEntry, AuditLogEvent;
 export 'src/models/application.dart'
     show Application, ApplicationFlags, InstallationParameters, PartialApplication, ApplicationRoleConnectionMetadata, ConnectionMetadataType;
 export 'src/models/guild/template.dart' show GuildTemplate;

--- a/lib/src/client_options.dart
+++ b/lib/src/client_options.dart
@@ -1,6 +1,7 @@
 import 'package:nyxx/src/cache/cache.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/stage_instance.dart';
+import 'package:nyxx/src/models/guild/audit_log.dart';
 import 'package:nyxx/src/models/guild/auto_moderation.dart';
 import 'package:nyxx/src/models/guild/ban.dart';
 import 'package:nyxx/src/models/guild/guild.dart';
@@ -49,6 +50,8 @@ class RestClientOptions implements ClientOptions {
   /// The [CacheConfig] to use for the [Guild.autoModerationRules] manager.
   final CacheConfig<AutoModerationRule> autoModerationRuleConfig;
 
+  final CacheConfig<AuditLogEntry> auditLogEntryConfig;
+
   /// Create a new [RestClientOptions].
   RestClientOptions({
     this.userCacheConfig = const CacheConfig(),
@@ -62,6 +65,7 @@ class RestClientOptions implements ClientOptions {
     this.stageInstanceCacheConfig = const CacheConfig(),
     this.scheduledEventCacheConfig = const CacheConfig(),
     this.autoModerationRuleConfig = const CacheConfig(),
+    this.auditLogEntryConfig = const CacheConfig(),
   });
 }
 
@@ -79,5 +83,6 @@ class GatewayClientOptions extends RestClientOptions {
     super.stageInstanceCacheConfig,
     super.scheduledEventCacheConfig,
     super.autoModerationRuleConfig,
+    super.auditLogEntryConfig,
   });
 }

--- a/lib/src/client_options.dart
+++ b/lib/src/client_options.dart
@@ -50,6 +50,7 @@ class RestClientOptions implements ClientOptions {
   /// The [CacheConfig] to use for the [Guild.autoModerationRules] manager.
   final CacheConfig<AutoModerationRule> autoModerationRuleConfig;
 
+  /// The [CacheConfig] to use for the [Guild.auditLogs] manager.
   final CacheConfig<AuditLogEntry> auditLogEntryConfig;
 
   /// Create a new [RestClientOptions].

--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -155,6 +155,7 @@ class Gateway extends GatewayManager with EventParser {
           AutoModerationRuleUpdateEvent(:final rule) =>
             client.guilds[rule.guildId].autoModerationRules.cache[rule.id] = rule,
           AutoModerationRuleDeleteEvent(:final rule) => client.guilds[rule.guildId].autoModerationRules.cache.remove(rule.id),
+          GuildAuditLogCreateEvent(:final entry, :final guildId) => client.guilds[guildId].auditLogs.cache[entry.id] = entry,
           _ => null,
         });
   }
@@ -471,7 +472,12 @@ class Gateway extends GatewayManager with EventParser {
   }
 
   GuildAuditLogCreateEvent parseGuildAuditLogCreate(Map<String, Object?> raw) {
-    return GuildAuditLogCreateEvent();
+    final guildId = Snowflake.parse(raw['guild_id'] as String);
+
+    return GuildAuditLogCreateEvent(
+      entry: client.guilds[guildId].auditLogs.parse(raw),
+      guildId: guildId,
+    );
   }
 
   GuildBanAddEvent parseGuildBanAdd(Map<String, Object?> raw) {

--- a/lib/src/http/managers/audit_log_manager.dart
+++ b/lib/src/http/managers/audit_log_manager.dart
@@ -1,0 +1,102 @@
+import 'package:nyxx/src/http/managers/manager.dart';
+import 'package:nyxx/src/http/request.dart';
+import 'package:nyxx/src/http/route.dart';
+import 'package:nyxx/src/models/guild/audit_log.dart';
+import 'package:nyxx/src/models/permission_overwrite.dart';
+import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/utils/parsing_helpers.dart';
+
+class AuditLogManager extends ReadOnlyManager<AuditLogEntry> {
+  final Snowflake guildId;
+
+  AuditLogManager(super.config, super.client, {required this.guildId});
+
+  @override
+  PartialAuditLogEntry operator [](Snowflake id) => PartialAuditLogEntry(id: id, manager: this);
+
+  @override
+  AuditLogEntry parse(Map<String, Object?> raw) {
+    return AuditLogEntry(
+      id: Snowflake.parse(raw['id'] as String),
+      manager: this,
+      targetId: maybeParse(raw['target_id'], Snowflake.parse),
+      changes: maybeParseMany(raw['changes'], parseAuditLogChange),
+      userId: maybeParse(raw['user_id'], Snowflake.parse),
+      actionType: AuditLogEvent.parse(raw['action_type'] as int),
+      options: maybeParse(raw['options'], parseAuditLogEntryInfo),
+      reason: raw['reason'] as String?,
+    );
+  }
+
+  AuditLogChange parseAuditLogChange(Map<String, Object?> raw) {
+    return AuditLogChange(
+      oldValue: raw['old_value'],
+      newValue: raw['new_value'],
+      key: raw['key'] as String,
+    );
+  }
+
+  AuditLogEntryInfo parseAuditLogEntryInfo(Map<String, Object?> raw) {
+    return AuditLogEntryInfo(
+      applicationId: maybeParse(raw['application_id'], Snowflake.parse),
+      autoModerationRuleName: raw['auto_moderation_rule_name'] as String?,
+      autoModerationTriggerType: raw['auto_moderation_rule_trigger_type'] as String?,
+      channelId: maybeParse(raw['channel_id'], Snowflake.parse),
+      count: raw['count'] as String?,
+      deleteMemberDays: raw['delete_member_days'] as String?,
+      id: maybeParse(raw['id'], Snowflake.parse),
+      membersRemoved: raw['members_removed'] as String?,
+      messageId: maybeParse(raw['message_id'], Snowflake.parse),
+      roleName: raw['role_name'] as String?,
+      overwriteType: maybeParse(raw['type'], (String raw) => PermissionOverwriteType.parse(int.parse(raw))),
+    );
+  }
+
+  @override
+  Future<AuditLogEntry> fetch(Snowflake id) async {
+    // TODO: Is before inclusive? If so, we can remove the + duration
+    final entries = await list(before: id + const Duration(milliseconds: 1));
+
+    // TODO: Add an exception when not found
+    return entries.firstWhere(
+      (entry) => entry.id == id,
+    );
+  }
+
+  Future<List<AuditLogEntry>> list({Snowflake? userId, AuditLogEvent? type, Snowflake? before, Snowflake? after, int? limit}) async {
+    final route = HttpRoute()
+      ..guilds(id: guildId.toString())
+      ..auditLogs();
+    final request = BasicRequest(route, queryParameters: {
+      if (userId != null) 'user_id': userId.toString(),
+      if (type != null) 'action_type': type.value.toString(),
+      if (before != null) 'before': before.toString(),
+      if (after != null) 'after': after.toString(),
+      if (limit != null) 'limit': limit.toString(),
+    });
+
+    final response = await client.httpHandler.executeSafe(request);
+    final responseBody = response.jsonBody as Map<String, Object?>;
+    final entries = parseMany(responseBody['audit_log_entries'] as List<Object?>, parse);
+
+    // TODO: application commands
+
+    final autoModerationRules = parseMany(responseBody['auto_moderation_rules'] as List<Object?>, client.guilds[guildId].autoModerationRules.parse);
+    client.guilds[guildId].autoModerationRules.cache.addEntries(autoModerationRules.map((rule) => MapEntry(rule.id, rule)));
+
+    final scheduledEvents = parseMany(responseBody['guild_scheduled_events'] as List<Object?>, client.guilds[guildId].scheduledEvents.parse);
+    client.guilds[guildId].scheduledEvents.cache.addEntries(scheduledEvents.map((event) => MapEntry(event.id, event)));
+
+    final threads = parseMany(responseBody['threads'] as List<Object?>, client.channels.parse);
+    client.channels.cache.addEntries(threads.map((thread) => MapEntry(thread.id, thread)));
+
+    final users = parseMany(responseBody['users'] as List<Object?>, client.users.parse);
+    client.users.cache.addEntries(users.map((user) => MapEntry(user.id, user)));
+
+    final webhooks = parseMany(responseBody['webhooks'] as List<Object?>, client.webhooks.parse);
+    client.webhooks.cache.addEntries(webhooks.map((webhook) => MapEntry(webhook.id, webhook)));
+
+    cache.addEntries(entries.map((entry) => MapEntry(entry.id, entry)));
+    return entries;
+  }
+}

--- a/lib/src/http/route.dart
+++ b/lib/src/http/route.dart
@@ -159,7 +159,7 @@ extension RouteHelpers on HttpRoute {
   void nick() => add(HttpRoutePart("nick"));
 
   /// Adds the [`audit-logs`](https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log) part to this [HttpRoute].
-  void auditlogs() => add(HttpRoutePart("audit-logs"));
+  void auditLogs() => add(HttpRoutePart("audit-logs"));
 
   /// Adds the [`regions`](https://discord.com/developers/docs/resources/voice#list-voice-regions) part to this [HttpRoute].
   void regions() => add(HttpRoutePart("regions"));

--- a/lib/src/models/gateway/events/guild.dart
+++ b/lib/src/models/gateway/events/guild.dart
@@ -1,6 +1,7 @@
 import 'package:nyxx/src/models/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/thread.dart';
 import 'package:nyxx/src/models/gateway/event.dart';
+import 'package:nyxx/src/models/guild/audit_log.dart';
 import 'package:nyxx/src/models/guild/guild.dart';
 import 'package:nyxx/src/models/guild/member.dart';
 import 'package:nyxx/src/models/guild/scheduled_event.dart';
@@ -103,11 +104,14 @@ class GuildDeleteEvent extends DispatchEvent {
 /// Emitted when an audit log entry is created in a guild.
 /// {@endtemplate}
 class GuildAuditLogCreateEvent extends DispatchEvent {
-  // TODO
-  //final AuditLogEntry entry;
+  /// The entry that was created.
+  final AuditLogEntry entry;
+
+  /// The ID of the guild in which the entry was created.
+  final Snowflake guildId;
 
   /// {@macro guild_audit_log_create_event}
-  GuildAuditLogCreateEvent();
+  GuildAuditLogCreateEvent({required this.entry, required this.guildId});
 }
 
 /// {@template guild_ban_add_event}

--- a/lib/src/models/guild/audit_log.dart
+++ b/lib/src/models/guild/audit_log.dart
@@ -1,0 +1,158 @@
+import 'package:nyxx/src/http/managers/audit_log_manager.dart';
+import 'package:nyxx/src/models/permission_overwrite.dart';
+import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/models/snowflake_entity/snowflake_entity.dart';
+import 'package:nyxx/src/utils/to_string_helper/to_string_helper.dart';
+
+class PartialAuditLogEntry extends ManagedSnowflakeEntity<AuditLogEntry> {
+  @override
+  final AuditLogManager manager;
+
+  PartialAuditLogEntry({required super.id, required this.manager});
+}
+
+class AuditLogEntry extends PartialAuditLogEntry {
+  final Snowflake? targetId;
+
+  final List<AuditLogChange>? changes;
+
+  final Snowflake? userId;
+
+  final AuditLogEvent actionType;
+
+  final AuditLogEntryInfo? options;
+
+  final String? reason;
+
+  AuditLogEntry({
+    required super.id,
+    required super.manager,
+    required this.targetId,
+    required this.changes,
+    required this.userId,
+    required this.actionType,
+    required this.options,
+    required this.reason,
+  });
+}
+
+class AuditLogChange with ToStringHelper {
+  final dynamic oldValue;
+
+  final dynamic newValue;
+
+  final String key;
+
+  AuditLogChange({
+    required this.oldValue,
+    required this.newValue,
+    required this.key,
+  });
+}
+
+enum AuditLogEvent {
+  guildUpdate._(1),
+  channelCreate._(10),
+  channelUpdate._(11),
+  channelDelete._(12),
+  channelOverwriteCreate._(13),
+  channelOverwriteUpdate._(14),
+  channelOverwriteDelete._(15),
+  memberKick._(20),
+  memberPrune._(21),
+  memberBanAdd._(22),
+  memberBanRemove._(23),
+  memberUpdate._(24),
+  memberRoleUpdate._(25),
+  memberMove._(26),
+  memberDisconnect._(27),
+  botAdd._(28),
+  roleCreate._(30),
+  roleUpdate._(31),
+  roleDelete._(32),
+  inviteCreate._(40),
+  inviteUpdate._(41),
+  inviteDelete._(42),
+  webhookCreate._(50),
+  webhookUpdate._(51),
+  webhookDelete._(52),
+  emojiCreate._(60),
+  emojiUpdate._(61),
+  emojiDelete._(62),
+  messageDelete._(72),
+  messageBulkDelete._(73),
+  messagePin._(74),
+  messageUnpin._(75),
+  integrationCreate._(80),
+  integrationUpdate._(81),
+  integrationDelete._(82),
+  stageInstanceCreate._(83),
+  stageInstanceUpdate._(84),
+  stageInstanceDelete._(85),
+  stickerCreate._(90),
+  stickerUpdate._(91),
+  stickerDelete._(92),
+  guildScheduledEventCreate._(100),
+  guildScheduledEventUpdate._(101),
+  guildScheduledEventDelete._(102),
+  threadCreate._(110),
+  threadUpdate._(111),
+  threadDelete._(112),
+  applicationCommandPermissionUpdate._(121),
+  autoModerationRuleCreate._(140),
+  autoModerationRuleUpdate._(141),
+  autoModerationRuleDelete._(142),
+  autoModerationBlockMessage._(143),
+  autoModerationFlagToChannel._(144),
+  autoModerationUserCommunicationDisabled._(145);
+
+  final int value;
+
+  const AuditLogEvent._(this.value);
+
+  factory AuditLogEvent.parse(int value) => AuditLogEvent.values.firstWhere(
+        (event) => event.value == value,
+        orElse: () => throw FormatException('Unknown audit log event', value),
+      );
+
+  @override
+  String toString() => 'AuditLogEvent($value)';
+}
+
+class AuditLogEntryInfo with ToStringHelper {
+  final Snowflake? applicationId;
+
+  final String? autoModerationRuleName;
+
+  final String? autoModerationTriggerType;
+
+  final Snowflake? channelId;
+
+  final String? count;
+
+  final String? deleteMemberDays;
+
+  final Snowflake? id;
+
+  final String? membersRemoved;
+
+  final Snowflake? messageId;
+
+  final String? roleName;
+
+  final PermissionOverwriteType? overwriteType;
+
+  AuditLogEntryInfo({
+    required this.applicationId,
+    required this.autoModerationRuleName,
+    required this.autoModerationTriggerType,
+    required this.channelId,
+    required this.count,
+    required this.deleteMemberDays,
+    required this.id,
+    required this.membersRemoved,
+    required this.messageId,
+    required this.roleName,
+    required this.overwriteType,
+  });
+}

--- a/lib/src/models/guild/audit_log.dart
+++ b/lib/src/models/guild/audit_log.dart
@@ -4,26 +4,38 @@ import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/snowflake_entity/snowflake_entity.dart';
 import 'package:nyxx/src/utils/to_string_helper/to_string_helper.dart';
 
+/// A partial [AuditLogEntry].
 class PartialAuditLogEntry extends ManagedSnowflakeEntity<AuditLogEntry> {
   @override
   final AuditLogManager manager;
 
+  /// Create a new [PartialAuditLogEntry].
   PartialAuditLogEntry({required super.id, required this.manager});
 }
 
+/// {@template audit_log_entry}
+/// An entry in a [Guild]'s audit log.
+/// {@endtemplate}
 class AuditLogEntry extends PartialAuditLogEntry {
+  /// The ID of the targeted entity.
   final Snowflake? targetId;
 
+  /// A list of changes made to the entity.
   final List<AuditLogChange>? changes;
 
+  /// The ID of the user that triggered the action.
   final Snowflake? userId;
 
+  /// The type of action taken.
   final AuditLogEvent actionType;
 
+  /// Additional information associated with this entry.
   final AuditLogEntryInfo? options;
 
+  /// The reason for this action.
   final String? reason;
 
+  /// {@macro audit_log_entry}
   AuditLogEntry({
     required super.id,
     required super.manager,
@@ -36,13 +48,20 @@ class AuditLogEntry extends PartialAuditLogEntry {
   });
 }
 
+/// {@template audit_log_change}
+/// A change to an object's field in an [AuditLogEntry].
+/// {@endtemplate}
 class AuditLogChange with ToStringHelper {
+  /// The old, unparsed value of the field.
   final dynamic oldValue;
 
+  /// The new, unparsed value of the field.
   final dynamic newValue;
 
+  /// The name of the affected field.
   final String key;
 
+  /// {@macro audit_log_change}
   AuditLogChange({
     required this.oldValue,
     required this.newValue,
@@ -50,6 +69,7 @@ class AuditLogChange with ToStringHelper {
   });
 }
 
+/// The type of event an [AuditLogEntry] represents.
 enum AuditLogEvent {
   guildUpdate._(1),
   channelCreate._(10),
@@ -106,10 +126,14 @@ enum AuditLogEvent {
   autoModerationFlagToChannel._(144),
   autoModerationUserCommunicationDisabled._(145);
 
+  /// The value of this [AuditLogEvent].
   final int value;
 
   const AuditLogEvent._(this.value);
 
+  /// Parse an [AuditLogEvent] from an [int].
+  ///
+  /// The [value] must be a valid audit log event.
   factory AuditLogEvent.parse(int value) => AuditLogEvent.values.firstWhere(
         (event) => event.value == value,
         orElse: () => throw FormatException('Unknown audit log event', value),
@@ -119,29 +143,44 @@ enum AuditLogEvent {
   String toString() => 'AuditLogEvent($value)';
 }
 
+/// {@template audit_log_entry_info}
+/// Extra information associated with an [AuditLogEntry].
+/// {@endtemplate}
 class AuditLogEntryInfo with ToStringHelper {
+  /// The ID of the application whose permissions were targeted.
   final Snowflake? applicationId;
 
+  /// The name of the Auto Moderation rule that was triggered.
   final String? autoModerationRuleName;
 
+  /// The trigger type of the Auto Moderation rule that was triggered.
   final String? autoModerationTriggerType;
 
+  /// The ID of the channel in which entities were targeted.
   final Snowflake? channelId;
 
+  /// The number of targeted entities.
   final String? count;
 
+  /// The number of days after which inactive members were kicked.
   final String? deleteMemberDays;
 
+  /// The ID of the overwritten entity.
   final Snowflake? id;
 
+  /// The number of members removed by a prune.
   final String? membersRemoved;
 
+  /// The ID of the targeted message.
   final Snowflake? messageId;
 
+  /// The name of the role.
   final String? roleName;
 
+  // The type of overwrite that was targeted.
   final PermissionOverwriteType? overwriteType;
 
+  /// {@macro audit_log_entry_info}
   AuditLogEntryInfo({
     required this.applicationId,
     required this.autoModerationRuleName,

--- a/lib/src/models/guild/guild.dart
+++ b/lib/src/models/guild/guild.dart
@@ -6,6 +6,7 @@ import 'package:nyxx/src/builders/guild/template.dart';
 import 'package:nyxx/src/builders/guild/welcome_screen.dart';
 import 'package:nyxx/src/builders/guild/widget.dart';
 import 'package:nyxx/src/builders/voice.dart';
+import 'package:nyxx/src/http/managers/audit_log_manager.dart';
 import 'package:nyxx/src/http/managers/auto_moderation_manager.dart';
 import 'package:nyxx/src/http/managers/guild_manager.dart';
 import 'package:nyxx/src/http/managers/member_manager.dart';
@@ -44,6 +45,8 @@ class PartialGuild extends WritableSnowflakeEntity<Guild> {
 
   /// An [AutoModerationManager] for the auto moderation rules of this guild.
   AutoModerationManager get autoModerationRules => AutoModerationManager(manager.client.options.autoModerationRuleConfig, manager.client, guildId: id);
+
+  AuditLogManager get auditLogs => AuditLogManager(manager.client.options.auditLogEntryConfig, manager.client, guildId: id);
 
   /// Create a new [PartialGuild].
   PartialGuild({required super.id, required this.manager});

--- a/lib/src/models/guild/guild.dart
+++ b/lib/src/models/guild/guild.dart
@@ -46,6 +46,7 @@ class PartialGuild extends WritableSnowflakeEntity<Guild> {
   /// An [AutoModerationManager] for the auto moderation rules of this guild.
   AutoModerationManager get autoModerationRules => AutoModerationManager(manager.client.options.autoModerationRuleConfig, manager.client, guildId: id);
 
+  /// An [AuditLogManager] for the audit log of this guild.
   AuditLogManager get auditLogs => AuditLogManager(manager.client.options.auditLogEntryConfig, manager.client, guildId: id);
 
   /// Create a new [PartialGuild].

--- a/test/unit/http/managers/audit_log_manager_test.dart
+++ b/test/unit/http/managers/audit_log_manager_test.dart
@@ -1,0 +1,50 @@
+import 'package:matcher/expect.dart';
+import 'package:nyxx/nyxx.dart';
+
+import '../../../test_manager.dart';
+
+final sampleAuditLogEntry = {
+  'target_id': '1',
+  'id': '0',
+  'action_type': 1,
+  'reason': 'Test reason',
+};
+
+void checkAuditLogEntry(AuditLogEntry entry) {}
+
+final sampleAuditLog = {
+  'application_commands': [],
+  'audit_log_entries': [sampleAuditLogEntry],
+  'auto_moderation_rules': [],
+  'guild_scheduled_events': [],
+  'integrations': [],
+  'threads': [],
+  'users': [],
+  'webhooks': [],
+};
+
+void main() {
+  testReadOnlyManager<AuditLogEntry, AuditLogManager>(
+    'AuditLogManager',
+    (config, client) => AuditLogManager(config, client, guildId: Snowflake.zero),
+    // fetch() artificially creates a "before" field
+    '/guilds/0/audit-logs?before=${Snowflake.zero + const Duration(milliseconds: 1)}',
+    sampleObject: sampleAuditLogEntry,
+    sampleMatches: checkAuditLogEntry,
+    // Fetch implementation internally uses `list()`, so we return a full audit log
+    fetchObjectOverride: sampleAuditLog,
+    additionalParsingTests: [],
+    additionalEndpointTests: [
+      EndpointTest<AuditLogManager, List<AuditLogEntry>, Map<String, Object?>>(
+        name: 'list',
+        source: sampleAuditLog,
+        urlMatcher: '/guilds/0/audit-logs',
+        execute: (manager) => manager.list(),
+        check: (list) {
+          expect(list, hasLength(1));
+          checkAuditLogEntry(list.single);
+        },
+      ),
+    ],
+  );
+}


### PR DESCRIPTION
# Description

Rewrite the Audit Logs HTTP API.

This PR uses currently undocumented behaviour, which is being added in [discord/discord-api-docs#6228](https://github.com/discord/discord-api-docs/pull/6228). We should wait for that to be merged before we merge this.

## Connected issues & other potential problems

Closes #455.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
