### PR TITLE
Cache per client

### DIFF
--- a/lib/src/cache/cache.dart
+++ b/lib/src/cache/cache.dart
@@ -98,9 +98,7 @@ class Cache<T> with MapMixin<Snowflake, T> {
       return null;
     }
 
-    final store = _stores[identifier]!;
-
-    final value = store[key] as T?;
+    final value = _store[key];
     if (value != null) {
       _count.update(key, (value) => value + 1);
     }
@@ -109,8 +107,8 @@ class Cache<T> with MapMixin<Snowflake, T> {
 
   @override
   void clear() {
-    _stores[identifier]!.clear();
-    _counts[identifier]!.clear();
+    _store.clear();
+    _count.clear();
   }
 
   @override
@@ -118,7 +116,7 @@ class Cache<T> with MapMixin<Snowflake, T> {
 
   @override
   T? remove(Object? key) {
-    _counts[identifier]!.remove(key);
-    return _stores[identifier]!.remove(key) as T?;
+    _count.remove(key);
+    return _store.remove(key);
   }
 }

--- a/lib/src/http/managers/auto_moderation_manager.dart
+++ b/lib/src/http/managers/auto_moderation_manager.dart
@@ -11,7 +11,7 @@ import 'package:nyxx/src/utils/parsing_helpers.dart';
 class AutoModerationManager extends Manager<AutoModerationRule> {
   final Snowflake guildId;
 
-  AutoModerationManager(super.config, super.client, {required this.guildId});
+  AutoModerationManager(super.config, super.client, {required this.guildId}) : super(identifier: '$guildId.autoModerationRules');
 
   @override
   PartialAutoModerationRule operator [](Snowflake id) => PartialAutoModerationRule(id: id, manager: this);

--- a/lib/src/http/managers/channel_manager.dart
+++ b/lib/src/http/managers/channel_manager.dart
@@ -40,7 +40,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
 
   /// Create a new [ChannelManager].
   ChannelManager(super.config, super.client, {required CacheConfig<StageInstance> stageInstanceConfig})
-      : stageInstanceCache = Cache((StageInstance).toString(), stageInstanceConfig);
+      : stageInstanceCache = Cache(client, (StageInstance).toString(), stageInstanceConfig);
 
   /// Return a partial instance of the entity with ID [id] containing no data.
   ///

--- a/lib/src/http/managers/channel_manager.dart
+++ b/lib/src/http/managers/channel_manager.dart
@@ -40,7 +40,8 @@ class ChannelManager extends ReadOnlyManager<Channel> {
 
   /// Create a new [ChannelManager].
   ChannelManager(super.config, super.client, {required CacheConfig<StageInstance> stageInstanceConfig})
-      : stageInstanceCache = Cache(client, (StageInstance).toString(), stageInstanceConfig);
+      : stageInstanceCache = Cache(client, 'channels.stageInstances', stageInstanceConfig),
+        super(identifier: 'channels');
 
   /// Return a partial instance of the entity with ID [id] containing no data.
   ///

--- a/lib/src/http/managers/guild_manager.dart
+++ b/lib/src/http/managers/guild_manager.dart
@@ -38,7 +38,9 @@ class GuildManager extends Manager<Guild> {
   final Cache<Ban> banCache;
 
   /// Create a new [GuildManager].
-  GuildManager(super.config, super.client, {required CacheConfig<Ban> banConfig}) : banCache = Cache(client, 'Ban', banConfig);
+  GuildManager(super.config, super.client, {required CacheConfig<Ban> banConfig})
+      : banCache = Cache(client, 'guilds.bans', banConfig),
+        super(identifier: 'guilds');
 
   @override
   PartialGuild operator [](Snowflake id) => PartialGuild(id: id, manager: this);

--- a/lib/src/http/managers/guild_manager.dart
+++ b/lib/src/http/managers/guild_manager.dart
@@ -38,7 +38,7 @@ class GuildManager extends Manager<Guild> {
   final Cache<Ban> banCache;
 
   /// Create a new [GuildManager].
-  GuildManager(super.config, super.client, {required CacheConfig<Ban> banConfig}) : banCache = Cache('Ban', banConfig);
+  GuildManager(super.config, super.client, {required CacheConfig<Ban> banConfig}) : banCache = Cache(client, 'Ban', banConfig);
 
   @override
   PartialGuild operator [](Snowflake id) => PartialGuild(id: id, manager: this);

--- a/lib/src/http/managers/manager.dart
+++ b/lib/src/http/managers/manager.dart
@@ -16,7 +16,7 @@ abstract class ReadOnlyManager<T extends ManagedSnowflakeEntity<T>> {
 
   /// Create a new read-only manager.
   // TODO: Do we really want to use `T.toString()` as the cache identifier?
-  ReadOnlyManager(CacheConfig<T> config, this.client) : cache = Cache(T.toString(), config);
+  ReadOnlyManager(CacheConfig<T> config, this.client) : cache = Cache(client, T.toString(), config);
 
   /// Parse the [raw] data received from the API into an instance of the type of this manager.
   T parse(Map<String, Object?> raw);

--- a/lib/src/http/managers/manager.dart
+++ b/lib/src/http/managers/manager.dart
@@ -15,8 +15,7 @@ abstract class ReadOnlyManager<T extends ManagedSnowflakeEntity<T>> {
   final NyxxRest client;
 
   /// Create a new read-only manager.
-  // TODO: Do we really want to use `T.toString()` as the cache identifier?
-  ReadOnlyManager(CacheConfig<T> config, this.client) : cache = Cache(client, T.toString(), config);
+  ReadOnlyManager(CacheConfig<T> config, this.client, {required String identifier}) : cache = Cache(client, identifier, config);
 
   /// Parse the [raw] data received from the API into an instance of the type of this manager.
   T parse(Map<String, Object?> raw);
@@ -51,7 +50,7 @@ abstract class Manager<T extends WritableSnowflakeEntity<T>> extends ReadOnlyMan
   /// Create a new manager.
   ///
   /// {@macro manager}
-  Manager(super.config, super.client);
+  Manager(super.config, super.client, {required super.identifier});
 
   /// Create a new instance of the type of this manager.
   ///

--- a/lib/src/http/managers/member_manager.dart
+++ b/lib/src/http/managers/member_manager.dart
@@ -14,7 +14,7 @@ class MemberManager extends Manager<Member> {
   /// The ID of the [Guild] this manager is for.
   final Snowflake guildId;
 
-  MemberManager(super.config, super.client, {required this.guildId});
+  MemberManager(super.config, super.client, {required this.guildId}) : super(identifier: '$guildId.members');
 
   @override
   PartialMember operator [](Snowflake id) => PartialMember(id: id, manager: this);

--- a/lib/src/http/managers/message_manager.dart
+++ b/lib/src/http/managers/message_manager.dart
@@ -26,7 +26,7 @@ class MessageManager extends Manager<Message> {
   final Snowflake channelId;
 
   /// Create a new [MessageManager].
-  MessageManager(super.config, super.client, {required this.channelId});
+  MessageManager(super.config, super.client, {required this.channelId}) : super(identifier: '$channelId.messages');
 
   @override
   PartialMessage operator [](Snowflake id) => PartialMessage(id: id, manager: this);

--- a/lib/src/http/managers/role_manager.dart
+++ b/lib/src/http/managers/role_manager.dart
@@ -16,7 +16,7 @@ class RoleManager extends Manager<Role> {
   final Snowflake guildId;
 
   /// Create a new [RoleManager].
-  RoleManager(super.config, super.client, {required this.guildId});
+  RoleManager(super.config, super.client, {required this.guildId}) : super(identifier: '$guildId.roles');
 
   @override
   PartialRole operator [](Snowflake id) => PartialRole(id: id, manager: this);

--- a/lib/src/http/managers/scheduled_event_manager.dart
+++ b/lib/src/http/managers/scheduled_event_manager.dart
@@ -14,7 +14,7 @@ class ScheduledEventManager extends Manager<ScheduledEvent> {
   final Snowflake guildId;
 
   /// Create a new [ScheduledEventManager].
-  ScheduledEventManager(super.config, super.client, {required this.guildId});
+  ScheduledEventManager(super.config, super.client, {required this.guildId}) : super(identifier: '$guildId.scheduledEvents');
 
   @override
   PartialScheduledEvent operator [](Snowflake id) => PartialScheduledEvent(id: id, manager: this);

--- a/lib/src/http/managers/user_manager.dart
+++ b/lib/src/http/managers/user_manager.dart
@@ -14,7 +14,7 @@ import 'package:nyxx/src/models/user/user.dart';
 /// A manager for [User]s.
 class UserManager extends ReadOnlyManager<User> {
   /// Create a new [UserManager].
-  UserManager(super.config, super.client);
+  UserManager(super.config, super.client) : super(identifier: 'users');
 
   @override
   PartialUser operator [](Snowflake id) => PartialUser(id: id, manager: this);

--- a/lib/src/http/managers/webhook_manager.dart
+++ b/lib/src/http/managers/webhook_manager.dart
@@ -19,7 +19,7 @@ import 'package:nyxx/src/utils/parsing_helpers.dart';
 /// A manager for [Webhook]s.
 class WebhookManager extends Manager<Webhook> {
   /// Create a new [WebhookManager].
-  WebhookManager(super.config, super.client);
+  WebhookManager(super.config, super.client) : super(identifier: 'webhooks');
 
   @override
   PartialWebhook operator [](Snowflake id) => PartialWebhook(id: id, manager: this);

--- a/test/test_manager.dart
+++ b/test/test_manager.dart
@@ -73,8 +73,6 @@ Future<void> testReadOnlyManager<T extends ManagedSnowflakeEntity<T>, U extends 
   );
 
   group(name, () {
-    tearDown(() => Cache.testClearAllCaches());
-
     test('parse', () {
       final client = MockNyxx();
       when(() => client.apiOptions).thenReturn(RestApiOptions(token: 'TEST_TOKEN'));

--- a/test/unit/cache/cache_test.dart
+++ b/test/unit/cache/cache_test.dart
@@ -2,16 +2,16 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nyxx/nyxx.dart';
 import 'package:test/test.dart';
 
+import '../../mocks/client.dart';
+
 class MockSnowflakeEntity extends ManagedSnowflakeEntity<MockSnowflakeEntity> with Fake {
   MockSnowflakeEntity({required super.id});
 }
 
 void main() {
   group('Cache', () {
-    tearDown(() => Cache.testClearAllCaches());
-
     test('stores entities', () async {
-      final cache = Cache<MockSnowflakeEntity>('test', CacheConfig());
+      final cache = Cache<MockSnowflakeEntity>(MockNyxx(), 'test', CacheConfig());
 
       final entity = MockSnowflakeEntity(id: Snowflake.zero);
 
@@ -26,7 +26,7 @@ void main() {
     });
 
     test('respects maximum size', () async {
-      final cache = Cache<MockSnowflakeEntity>('test', CacheConfig(maxSize: 3));
+      final cache = Cache<MockSnowflakeEntity>(MockNyxx(), 'test', CacheConfig(maxSize: 3));
 
       final entity1 = MockSnowflakeEntity(id: Snowflake(1));
       final entity2 = MockSnowflakeEntity(id: Snowflake(2));
@@ -44,7 +44,7 @@ void main() {
     });
 
     test('keeps most used items', () async {
-      final cache = Cache<MockSnowflakeEntity>('test', CacheConfig(maxSize: 3));
+      final cache = Cache<MockSnowflakeEntity>(MockNyxx(), 'test', CacheConfig(maxSize: 3));
 
       final entity1 = MockSnowflakeEntity(id: Snowflake(1));
       final entity2 = MockSnowflakeEntity(id: Snowflake(2));
@@ -74,7 +74,7 @@ void main() {
     });
 
     test("doesn't cache items if a filter is provided", () {
-      final cache = Cache<MockSnowflakeEntity>('test', CacheConfig(shouldCache: (e) => e.id.value > 3));
+      final cache = Cache<MockSnowflakeEntity>(MockNyxx(), 'test', CacheConfig(shouldCache: (e) => e.id.value > 3));
 
       final entity1 = MockSnowflakeEntity(id: Snowflake(1));
       final entity2 = MockSnowflakeEntity(id: Snowflake(2));
@@ -95,8 +95,8 @@ void main() {
     });
 
     test('shares resources with the same identifier', () {
-      final cache1 = Cache<MockSnowflakeEntity>('test', CacheConfig());
-      final cache2 = Cache<MockSnowflakeEntity>('test', CacheConfig());
+      final cache1 = Cache<MockSnowflakeEntity>(MockNyxx(), 'test', CacheConfig());
+      final cache2 = Cache<MockSnowflakeEntity>(MockNyxx(), 'test', CacheConfig());
 
       final entity = MockSnowflakeEntity(id: Snowflake.zero);
 

--- a/test/unit/cache/cache_test.dart
+++ b/test/unit/cache/cache_test.dart
@@ -95,8 +95,10 @@ void main() {
     });
 
     test('shares resources with the same identifier', () {
-      final cache1 = Cache<MockSnowflakeEntity>(MockNyxx(), 'test', CacheConfig());
-      final cache2 = Cache<MockSnowflakeEntity>(MockNyxx(), 'test', CacheConfig());
+      final client = MockNyxx();
+
+      final cache1 = Cache<MockSnowflakeEntity>(client, 'test', CacheConfig());
+      final cache2 = Cache<MockSnowflakeEntity>(client, 'test', CacheConfig());
 
       final entity = MockSnowflakeEntity(id: Snowflake.zero);
 

--- a/test/unit/cache/cache_test.dart
+++ b/test/unit/cache/cache_test.dart
@@ -105,5 +105,15 @@ void main() {
       cache1[entity.id] = entity;
       expect(cache2[entity.id], equals(entity));
     });
+
+    test("doesn't share resources across clients", () {
+      final cache1 = Cache<MockSnowflakeEntity>(MockNyxx(), 'test', CacheConfig());
+      final cache2 = Cache<MockSnowflakeEntity>(MockNyxx(), 'test', CacheConfig());
+
+      final entity = MockSnowflakeEntity(id: Snowflake.zero);
+
+      cache1[entity.id] = entity;
+      expect(cache2.containsKey(entity.id), isFalse);
+    });
   });
 }

--- a/test/unit/http/managers/manager_test.dart
+++ b/test/unit/http/managers/manager_test.dart
@@ -7,7 +7,7 @@ import '../../../mocks/client.dart';
 class TestFetchException implements Exception {}
 
 class MockManager extends Manager<MockSnowflakeEntity> with Fake {
-  MockManager(super.config, super.client);
+  MockManager(super.config, super.client) : super(identifier: 'MOCK_IDENTIFIER');
 
   @override
   Future<MockSnowflakeEntity> fetch(Snowflake id) => throw TestFetchException();

--- a/test/unit/http/managers/manager_test.dart
+++ b/test/unit/http/managers/manager_test.dart
@@ -19,8 +19,6 @@ class MockSnowflakeEntity extends WritableSnowflakeEntity<MockSnowflakeEntity> w
 
 void main() {
   group('Manager', () {
-    tearDown(() => Cache.testClearAllCaches());
-
     test('get only calls API when entity is not cached', () {
       final manager = MockManager(CacheConfig(), MockNyxx());
 


### PR DESCRIPTION
# Description

Address the TODOs relating to caching. Caches are now scoped per-client (so a client cannot access another client's cache) and per-resource (so caches that exist on a per-resource basis e.g a channel's messages don't share the cache).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
