### PR TITLE
Change Flags & Snowflake to use BigInts

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -20,7 +20,7 @@ void main() async {
   // Support for partial objects (at minimum with only an ID). These can be accessed for an
   // arbitrary id on a manager with the `[]` operator and allow API operations without fetching the
   // entire object from the API.
-  const abitofevrythingId = Snowflake(506759329068613643);
+  final abitofevrythingId = Snowflake(506759329068613643);
   final partialAbitofevrything = client.users[abitofevrythingId];
 
   // There are no API operations for arbitrary users other then fetch so... this is our demo. But

--- a/lib/src/builders/channel/guild_channel.dart
+++ b/lib/src/builders/channel/guild_channel.dart
@@ -290,7 +290,7 @@ class ForumChannelUpdateBuilder extends GuildChannelUpdateBuilder<ForumChannel> 
         if (!identical(rateLimitPerUser, sentinelDuration)) 'rate_limit_per_user': rateLimitPerUser?.inSeconds,
         if (!identical(parentId, sentinelSnowflake)) 'parent_id': parentId?.toString(),
         if (!identical(defaultAutoArchiveDuration, sentinelDuration)) 'default_auto_archive_duration': defaultAutoArchiveDuration?.inMinutes,
-        if (flags != null) 'flags': flags!.value,
+        if (flags != null) 'flags': flags!.value.toInt(),
         if (tags != null) 'available_tags': tags!.map((e) => e.build()).toList(),
         if (!identical(defaultReaction, sentinelDefaultReaction))
           'default_reaction_emoji': defaultReaction == null

--- a/lib/src/builders/channel/thread.dart
+++ b/lib/src/builders/channel/thread.dart
@@ -110,7 +110,7 @@ class ThreadUpdateBuilder extends UpdateBuilder<Thread> {
         if (isLocked != null) 'locked': isLocked,
         if (isInvitable != null) 'invitable': isInvitable,
         if (!identical(rateLimitPerUser, sentinelDuration)) 'rate_limit_per_user': rateLimitPerUser?.inSeconds,
-        if (flags != null) 'flags': flags!.value,
+        if (flags != null) 'flags': flags!.value.toInt(),
         if (appliedTags != null) 'applied_tags': appliedTags!.map((e) => e.toString()).toList(),
       };
 }

--- a/lib/src/builders/message/message.dart
+++ b/lib/src/builders/message/message.dart
@@ -125,8 +125,8 @@ class MessageBuilder extends CreateBuilder<Message> {
       if (stickerIds != null) 'sticker_ids': stickerIds!.map((e) => e.toString()).toList(),
       if (attachments != null) 'attachments': attachments!.map((e) => e.build()).toList(),
       if (suppressEmbeds != null || suppressNotifications != null)
-        'flags':
-            (suppressEmbeds == true ? MessageFlags.suppressEmbeds.value : 0) | (suppressNotifications == true ? MessageFlags.suppressNotifications.value : 0),
+        'flags': (suppressEmbeds == true ? MessageFlags.suppressEmbeds.value.toInt() : 0) |
+            (suppressNotifications == true ? MessageFlags.suppressNotifications.value.toInt() : 0),
     };
   }
 }
@@ -226,7 +226,7 @@ class MessageUpdateBuilder extends UpdateBuilder<Message> {
       if (!identical(embeds, sentinelList)) 'embeds': embeds,
       if (allowedMentions != null) 'allowed_mentions': allowedMentions!.build(),
       if (!identical(attachments, sentinelList)) 'attachments': attachments!.map((e) => e.build()).toList(),
-      if (suppressEmbeds != null) 'flags': (suppressEmbeds == true ? MessageFlags.suppressEmbeds.value : 0),
+      if (suppressEmbeds != null) 'flags': (suppressEmbeds == true ? MessageFlags.suppressEmbeds.value.toInt() : 0),
     };
   }
 }

--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -206,7 +206,7 @@ class Gateway extends GatewayManager with EventParser {
   }
 
   /// Compute the ID of the shard that handles events for [guildId].
-  int shardIdFor(Snowflake guildId) => (guildId.value >> 22) % totalShards;
+  int shardIdFor(Snowflake guildId) => ((guildId.value >> 22) % BigInt.from(totalShards)).toInt();
 
   /// Return the shard that handles events for [guildId].
   ///

--- a/lib/src/gateway/shard_runner.dart
+++ b/lib/src/gateway/shard_runner.dart
@@ -218,7 +218,7 @@ class ShardRunner {
         'shard': [data.id, data.totalShards],
         // TODO
         //'presence': ...,
-        'intents': data.apiOptions.intents.value,
+        'intents': data.apiOptions.intents.value.toInt(),
       },
     ));
   }

--- a/lib/src/http/managers/application_manager.dart
+++ b/lib/src/http/managers/application_manager.dart
@@ -47,7 +47,7 @@ class ApplicationManager {
       primarySkuId: maybeParse(raw['primary_sku_id'], Snowflake.parse),
       slug: raw['slug'] as String?,
       coverImageHash: raw['cover_image'] as String?,
-      flags: ApplicationFlags(raw['flags'] as int? ?? 0),
+      flags: ApplicationFlags(BigInt.from(raw['flags'] as int? ?? 0)),
       tags: maybeParseMany(raw['tags']),
       installationParameters: maybeParse(raw['install_params'], parseInstallationParameters),
       customInstallUrl: maybeParse(raw['custom_install_url'], Uri.parse),
@@ -76,7 +76,7 @@ class ApplicationManager {
   InstallationParameters parseInstallationParameters(Map<String, Object?> raw) {
     return InstallationParameters(
       scopes: parseMany(raw['scopes'] as List),
-      permissions: Permissions(int.parse(raw['permissions'] as String)),
+      permissions: Permissions(BigInt.parse(raw['permissions'] as String)),
     );
   }
 

--- a/lib/src/http/managers/channel_manager.dart
+++ b/lib/src/http/managers/channel_manager.dart
@@ -216,7 +216,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
       position: -1,
       rateLimitPerUser: maybeParse<Duration?, int>(raw['rate_limit_per_user'], (value) => value == 0 ? null : Duration(seconds: value)),
       totalMessagesSent: raw['total_message_sent'] as int,
-      flags: maybeParse(raw['flags'], ChannelFlags.new),
+      flags: maybeParse(raw['flags'], (int value) => ChannelFlags(BigInt.from(value))),
     );
   }
 
@@ -245,7 +245,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
       position: -1,
       rateLimitPerUser: maybeParse<Duration?, int>(raw['rate_limit_per_user'], (value) => value == 0 ? null : Duration(seconds: value)),
       totalMessagesSent: raw['total_message_sent'] as int,
-      flags: maybeParse(raw['flags'], ChannelFlags.new),
+      flags: maybeParse(raw['flags'], (int value) => ChannelFlags(BigInt.from(value))),
     );
   }
 
@@ -275,7 +275,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
       position: -1,
       rateLimitPerUser: maybeParse<Duration?, int>(raw['rate_limit_per_user'], (value) => value == 0 ? null : Duration(seconds: value)),
       totalMessagesSent: raw['total_message_sent'] as int,
-      flags: maybeParse(raw['flags'], ChannelFlags.new),
+      flags: maybeParse(raw['flags'], (int value) => ChannelFlags(BigInt.from(value))),
     );
   }
 
@@ -319,7 +319,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
       topic: raw['topic'] as String?,
       lastThreadId: maybeParse(raw['last_message_id'], Snowflake.parse),
       lastPinTimestamp: maybeParse(raw['last_pin_timestamp'], DateTime.parse),
-      flags: ChannelFlags(raw['flags'] as int),
+      flags: ChannelFlags(BigInt.from(raw['flags'] as int)),
       availableTags: parseMany(raw['available_tags'] as List, parseForumTag),
       defaultReaction: maybeParse(raw['default_reaction_emoji'], parseDefaultReaction),
       // Discord doesn't seem to include this field if the default 3 day expiration is used (3 days = 4320 minutes)
@@ -339,8 +339,8 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     return PermissionOverwrite(
       id: Snowflake.parse(raw['id'] as String),
       type: PermissionOverwriteType.parse(raw['type'] as int),
-      allow: Permissions(int.parse(raw['allow'] as String)),
-      deny: Permissions(int.parse(raw['deny'] as String)),
+      allow: Permissions(BigInt.parse(raw['allow'] as String)),
+      deny: Permissions(BigInt.parse(raw['deny'] as String)),
     );
   }
 
@@ -371,7 +371,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
   ThreadMember parseThreadMember(Map<String, Object?> raw) {
     return ThreadMember(
       joinTimestamp: DateTime.parse(raw['join_timestamp'] as String),
-      flags: Flags<Never>(raw['flags'] as int),
+      flags: Flags<Never>(BigInt.from(raw['flags'] as int)),
       threadId: Snowflake.parse(raw['id'] as String),
       userId: Snowflake.parse(raw['user_id'] as String),
       member: maybeParse(raw['member'], client.guilds[Snowflake.zero].members.parse),

--- a/lib/src/http/managers/guild_manager.dart
+++ b/lib/src/http/managers/guild_manager.dart
@@ -54,7 +54,7 @@ class GuildManager extends Manager<Guild> {
       discoverySplashHash: raw['discovery_splash'] as String?,
       isOwnedByCurrentUser: raw['owner'] as bool?,
       ownerId: Snowflake.parse(raw['owner_id'] as String),
-      currentUserPermissions: maybeParse(raw['permissions'], (String permissions) => Permissions(int.parse(permissions))),
+      currentUserPermissions: maybeParse(raw['permissions'], (String permissions) => Permissions(BigInt.parse(permissions))),
       afkChannelId: maybeParse(raw['afk_channel_id'], Snowflake.parse),
       afkTimeout: Duration(seconds: raw['afk_timeout'] as int),
       isWidgetEnabled: raw['widget_enabled'] as bool? ?? false,
@@ -67,7 +67,7 @@ class GuildManager extends Manager<Guild> {
       mfaLevel: MfaLevel.parse(raw['mfa_level'] as int),
       applicationId: maybeParse(raw['application_id'], Snowflake.parse),
       systemChannelId: maybeParse(raw['system_channel_id'], Snowflake.parse),
-      systemChannelFlags: SystemChannelFlags(raw['system_channel_flags'] as int),
+      systemChannelFlags: SystemChannelFlags(BigInt.from(raw['system_channel_flags'] as int)),
       rulesChannelId: maybeParse(raw['rules_channel_id'], Snowflake.parse),
       maxPresences: raw['max_presences'] as int?,
       maxMembers: raw['max_members'] as int?,
@@ -126,7 +126,7 @@ class GuildManager extends Manager<Guild> {
   GuildFeatures parseGuildFeatures(List<Object?> raw) {
     final featureFlags = parseMany(raw, parseGuildFeature);
 
-    return GuildFeatures(featureFlags.fold(0, (value, element) => value | element.value));
+    return GuildFeatures(featureFlags.fold(BigInt.zero, (value, element) => value | element.value));
   }
 
   /// Parse a [Flag]<GuildFeature> from [raw].

--- a/lib/src/http/managers/member_manager.dart
+++ b/lib/src/http/managers/member_manager.dart
@@ -32,9 +32,9 @@ class MemberManager extends Manager<Member> {
       premiumSince: maybeParse(raw['premium_since'], DateTime.parse),
       isDeaf: raw['deaf'] as bool,
       isMute: raw['mute'] as bool,
-      flags: MemberFlags(raw['flags'] as int),
+      flags: MemberFlags(BigInt.from(raw['flags'] as int)),
       isPending: raw['pending'] as bool? ?? false,
-      permissions: maybeParse(raw['permissions'], (String raw) => Permissions(int.parse(raw))),
+      permissions: maybeParse(raw['permissions'], (String raw) => Permissions(BigInt.parse(raw))),
       communicationDisabledUntil: maybeParse(raw['communication_disabled_until'], DateTime.parse),
     );
   }

--- a/lib/src/http/managers/message_manager.dart
+++ b/lib/src/http/managers/message_manager.dart
@@ -56,7 +56,7 @@ class MessageManager extends Manager<Message> {
       activity: maybeParse(raw['activity'], parseMessageActivity),
       applicationId: maybeParse(raw['application_id'], Snowflake.parse),
       reference: maybeParse(raw['message_reference'], parseMessageReference),
-      flags: MessageFlags(raw['flags'] as int? ?? 0),
+      flags: MessageFlags(BigInt.from(raw['flags'] as int? ?? 0)),
       referencedMessage: maybeParse(raw['referenced_message'], parse),
       thread: maybeParse(raw['thread'], client.channels.parse) as Thread?,
       position: raw['position'] as int?,

--- a/lib/src/http/managers/role_manager.dart
+++ b/lib/src/http/managers/role_manager.dart
@@ -32,7 +32,7 @@ class RoleManager extends Manager<Role> {
       iconHash: raw['icon'] as String?,
       unicodeEmoji: raw['unicode_emoji'] as String?,
       position: raw['position'] as int,
-      permissions: Permissions(int.parse(raw['permissions'] as String)),
+      permissions: Permissions(BigInt.parse(raw['permissions'] as String)),
       isMentionable: raw['mentionable'] as bool,
       tags: maybeParse(raw['tags'], parseRoleTags),
     );

--- a/lib/src/http/managers/user_manager.dart
+++ b/lib/src/http/managers/user_manager.dart
@@ -39,9 +39,9 @@ class UserManager extends ReadOnlyManager<User> {
       bannerHash: raw['banner'] as String?,
       accentColor: hasAccentColor ? DiscordColor(raw['accent_color'] as int) : null,
       locale: hasLocale ? Locale.parse(raw['locale'] as String) : null,
-      flags: hasFlags ? UserFlags(raw['flags'] as int) : null,
+      flags: hasFlags ? UserFlags(BigInt.from(raw['flags'] as int)) : null,
       nitroType: hasPremiumType ? NitroType.parse(raw['premium_type'] as int) : NitroType.none,
-      publicFlags: hasPublicFlags ? UserFlags(raw['public_flags'] as int) : null,
+      publicFlags: hasPublicFlags ? UserFlags(BigInt.from(raw['public_flags'] as int)) : null,
     );
   }
 

--- a/lib/src/intents.dart
+++ b/lib/src/intents.dart
@@ -2,38 +2,38 @@ import 'package:nyxx/src/utils/flags.dart';
 
 /// Flags used to set the intents when opening a Gateway session.
 class GatewayIntents extends Flags<GatewayIntents> {
-  static const guilds = Flag<GatewayIntents>.fromOffset(0);
-  static const guildMembers = Flag<GatewayIntents>.fromOffset(1);
-  static const guildModeration = Flag<GatewayIntents>.fromOffset(2);
-  static const guildEmojisAndStickers = Flag<GatewayIntents>.fromOffset(3);
-  static const guildIntegrations = Flag<GatewayIntents>.fromOffset(4);
-  static const guildWebhooks = Flag<GatewayIntents>.fromOffset(5);
-  static const guildInvites = Flag<GatewayIntents>.fromOffset(6);
-  static const guildVoiceStates = Flag<GatewayIntents>.fromOffset(7);
-  static const guildPresences = Flag<GatewayIntents>.fromOffset(8);
-  static const guildMessages = Flag<GatewayIntents>.fromOffset(9);
-  static const guildMessageReactions = Flag<GatewayIntents>.fromOffset(10);
-  static const guildMessageTyping = Flag<GatewayIntents>.fromOffset(11);
-  static const directMessages = Flag<GatewayIntents>.fromOffset(12);
-  static const directMessageReactions = Flag<GatewayIntents>.fromOffset(13);
-  static const directMessageTyping = Flag<GatewayIntents>.fromOffset(14);
-  static const messageContent = Flag<GatewayIntents>.fromOffset(15);
-  static const guildScheduledEvents = Flag<GatewayIntents>.fromOffset(16);
-  static const autoModerationConfiguration = Flag<GatewayIntents>.fromOffset(20);
-  static const autoModerationExecution = Flag<GatewayIntents>.fromOffset(21);
+  static final guilds = Flag<GatewayIntents>.fromOffset(0);
+  static final guildMembers = Flag<GatewayIntents>.fromOffset(1);
+  static final guildModeration = Flag<GatewayIntents>.fromOffset(2);
+  static final guildEmojisAndStickers = Flag<GatewayIntents>.fromOffset(3);
+  static final guildIntegrations = Flag<GatewayIntents>.fromOffset(4);
+  static final guildWebhooks = Flag<GatewayIntents>.fromOffset(5);
+  static final guildInvites = Flag<GatewayIntents>.fromOffset(6);
+  static final guildVoiceStates = Flag<GatewayIntents>.fromOffset(7);
+  static final guildPresences = Flag<GatewayIntents>.fromOffset(8);
+  static final guildMessages = Flag<GatewayIntents>.fromOffset(9);
+  static final guildMessageReactions = Flag<GatewayIntents>.fromOffset(10);
+  static final guildMessageTyping = Flag<GatewayIntents>.fromOffset(11);
+  static final directMessages = Flag<GatewayIntents>.fromOffset(12);
+  static final directMessageReactions = Flag<GatewayIntents>.fromOffset(13);
+  static final directMessageTyping = Flag<GatewayIntents>.fromOffset(14);
+  static final messageContent = Flag<GatewayIntents>.fromOffset(15);
+  static final guildScheduledEvents = Flag<GatewayIntents>.fromOffset(16);
+  static final autoModerationConfiguration = Flag<GatewayIntents>.fromOffset(20);
+  static final autoModerationExecution = Flag<GatewayIntents>.fromOffset(21);
 
   /// A [GatewayIntents] with all intents enabled.
-  static const all = GatewayIntents(0x1fffff);
+  static final all = GatewayIntents(BigInt.from(0x1fffff));
 
   /// A [GatewayIntents] with all unprivileged intents enabled.
-  static const allUnprivileged = GatewayIntents(0x317efd);
+  static final allUnprivileged = GatewayIntents(BigInt.from(0x317efd));
 
   /// A [GatewayIntents] with all privileged intents enabled.
-  static const allPrivileged = GatewayIntents(0x8102);
+  static final allPrivileged = GatewayIntents(BigInt.from(0x8102));
 
   /// A [GatewayIntents] with no intents enabled.
-  static const none = GatewayIntents(0);
+  static final none = GatewayIntents(BigInt.zero);
 
   /// Create a new [GatewayIntents].
-  const GatewayIntents(super.value);
+  GatewayIntents(super.value);
 }

--- a/lib/src/models/application.dart
+++ b/lib/src/models/application.dart
@@ -123,34 +123,34 @@ class Application extends PartialApplication {
 /// Flags for an [Application].
 class ApplicationFlags extends Flags<ApplicationFlags> {
   /// Indicates if an app uses the Auto Moderation API.
-  static const applicationAutoModerationRuleCreateBadge = Flag<ApplicationFlags>.fromOffset(6);
+  static final applicationAutoModerationRuleCreateBadge = Flag<ApplicationFlags>.fromOffset(6);
 
   /// Intent required for bots in 100 or more servers to receive presence_update events.
-  static const gatewayPresence = Flag<ApplicationFlags>.fromOffset(12);
+  static final gatewayPresence = Flag<ApplicationFlags>.fromOffset(12);
 
   /// Intent required for bots in under 100 servers to receive presence_update events, found on the Bot page in your app's settings.
-  static const gatewayPresenceLimited = Flag<ApplicationFlags>.fromOffset(13);
+  static final gatewayPresenceLimited = Flag<ApplicationFlags>.fromOffset(13);
 
   /// Intent required for bots in 100 or more servers to receive member-related events like guild_member_add. See the list of member-related events under GUILD_MEMBERS.
-  static const gatewayGuildMembers = Flag<ApplicationFlags>.fromOffset(14);
+  static final gatewayGuildMembers = Flag<ApplicationFlags>.fromOffset(14);
 
   /// Intent required for bots in under 100 servers to receive member-related events like guild_member_add, found on the Bot page in your app's settings. See the list of member-related events under GUILD_MEMBERS.
-  static const gatewayGuildMembersLimited = Flag<ApplicationFlags>.fromOffset(15);
+  static final gatewayGuildMembersLimited = Flag<ApplicationFlags>.fromOffset(15);
 
   /// Indicates unusual growth of an app that prevents verification.
-  static const verificationPendingGuildLimit = Flag<ApplicationFlags>.fromOffset(16);
+  static final verificationPendingGuildLimit = Flag<ApplicationFlags>.fromOffset(16);
 
   /// Indicates if an app is embedded within the Discord client (currently unavailable publicly).
-  static const embedded = Flag<ApplicationFlags>.fromOffset(17);
+  static final embedded = Flag<ApplicationFlags>.fromOffset(17);
 
   /// Intent required for bots in 100 or more servers to receive message content.
-  static const gatewayMessageContent = Flag<ApplicationFlags>.fromOffset(18);
+  static final gatewayMessageContent = Flag<ApplicationFlags>.fromOffset(18);
 
   /// Intent required for bots in under 100 servers to receive message content, found on the Bot page in your app's settings.
-  static const gatewayMessageContentLimited = Flag<ApplicationFlags>.fromOffset(19);
+  static final gatewayMessageContentLimited = Flag<ApplicationFlags>.fromOffset(19);
 
   /// Indicates if an app has registered global application commands.
-  static const applicationCommandBadge = Flag<ApplicationFlags>.fromOffset(23);
+  static final applicationCommandBadge = Flag<ApplicationFlags>.fromOffset(23);
 
   /// Whether this application has the [applicationAutoModerationRuleCreateBadge] flag set.
   bool get usesApplicationAutoModerationRuleCreateBadge => has(applicationAutoModerationRuleCreateBadge);

--- a/lib/src/models/channel/channel.dart
+++ b/lib/src/models/channel/channel.dart
@@ -104,10 +104,10 @@ enum ChannelType {
 // Currently only used in forum channels and threads
 class ChannelFlags extends Flags<ChannelFlags> {
   /// The channel is pinned in a forum channel.
-  static const pinned = Flag<ChannelFlags>.fromOffset(1);
+  static final pinned = Flag<ChannelFlags>.fromOffset(1);
 
   /// The forum channel requires threads to have tags.
-  static const requireTag = Flag<ChannelFlags>.fromOffset(4);
+  static final requireTag = Flag<ChannelFlags>.fromOffset(4);
 
   /// Whether this channel has the [pinned] flag set.
   bool get isPinned => has(pinned);
@@ -116,5 +116,5 @@ class ChannelFlags extends Flags<ChannelFlags> {
   bool get requiresTag => has(requireTag);
 
   /// Create a new [ChannelFlags].
-  const ChannelFlags(super.value);
+  ChannelFlags(super.value);
 }

--- a/lib/src/models/guild/guild.dart
+++ b/lib/src/models/guild/guild.dart
@@ -404,88 +404,88 @@ enum ExplicitContentFilterLevel {
 // Artificial flags for guild features. The values are arbitrary, and are associated with the strings from the API in [GuildManager].
 class GuildFeatures extends Flags<GuildFeatures> {
   /// The guild has an animated banner.
-  static const animatedBanner = Flag<GuildFeatures>.fromOffset(0);
+  static final animatedBanner = Flag<GuildFeatures>.fromOffset(0);
 
   /// The guild has an animated icon.
-  static const animatedIcon = Flag<GuildFeatures>.fromOffset(1);
+  static final animatedIcon = Flag<GuildFeatures>.fromOffset(1);
 
   /// The guild has the Application Command Permissions V2.
-  static const applicationCommandPermissionsV2 = Flag<GuildFeatures>.fromOffset(2);
+  static final applicationCommandPermissionsV2 = Flag<GuildFeatures>.fromOffset(2);
 
   /// The guild has auto moderation.
-  static const autoModeration = Flag<GuildFeatures>.fromOffset(3);
+  static final autoModeration = Flag<GuildFeatures>.fromOffset(3);
 
   /// The guild has a banner.
-  static const banner = Flag<GuildFeatures>.fromOffset(4);
+  static final banner = Flag<GuildFeatures>.fromOffset(4);
 
   /// The guild is a community guild.
-  static const community = Flag<GuildFeatures>.fromOffset(5);
+  static final community = Flag<GuildFeatures>.fromOffset(5);
 
   /// The guild has enabled monetization.
-  static const creatorMonetizableProvisional = Flag<GuildFeatures>.fromOffset(6);
+  static final creatorMonetizableProvisional = Flag<GuildFeatures>.fromOffset(6);
 
   /// The guild has enabled the role subscription promo page.
-  static const creatorStorePage = Flag<GuildFeatures>.fromOffset(7);
+  static final creatorStorePage = Flag<GuildFeatures>.fromOffset(7);
 
   /// The guild has been set as a support server on the App Directory.
-  static const developerSupportServer = Flag<GuildFeatures>.fromOffset(8);
+  static final developerSupportServer = Flag<GuildFeatures>.fromOffset(8);
 
   /// The guild is able to be discovered in the directory.
-  static const discoverable = Flag<GuildFeatures>.fromOffset(9);
+  static final discoverable = Flag<GuildFeatures>.fromOffset(9);
 
   /// The guild is able to be featured in the directory.
-  static const featurable = Flag<GuildFeatures>.fromOffset(10);
+  static final featurable = Flag<GuildFeatures>.fromOffset(10);
 
   /// The guild has paused invites, preventing new users from joining.
-  static const invitesDisabled = Flag<GuildFeatures>.fromOffset(11);
+  static final invitesDisabled = Flag<GuildFeatures>.fromOffset(11);
 
   /// The guild has access to set an invite splash background.
-  static const inviteSplash = Flag<GuildFeatures>.fromOffset(12);
+  static final inviteSplash = Flag<GuildFeatures>.fromOffset(12);
 
   /// The guild has enabled Membership Screening.
-  static const memberVerificationGateEnabled = Flag<GuildFeatures>.fromOffset(13);
+  static final memberVerificationGateEnabled = Flag<GuildFeatures>.fromOffset(13);
 
   /// The guild has increased custom sticker slots.
-  static const moreStickers = Flag<GuildFeatures>.fromOffset(14);
+  static final moreStickers = Flag<GuildFeatures>.fromOffset(14);
 
   /// The guild has access to create announcement channels.
-  static const news = Flag<GuildFeatures>.fromOffset(15);
+  static final news = Flag<GuildFeatures>.fromOffset(15);
 
   /// The guild is partnered.
-  static const partnered = Flag<GuildFeatures>.fromOffset(16);
+  static final partnered = Flag<GuildFeatures>.fromOffset(16);
 
   /// The guild can be previewed before joining via Membership Screening or the directory.
-  static const previewEnabled = Flag<GuildFeatures>.fromOffset(17);
+  static final previewEnabled = Flag<GuildFeatures>.fromOffset(17);
 
   /// The guild has disabled alerts for join raids in the configured safety alerts channel.
-  static const raidAlertsDisabled = Flag<GuildFeatures>.fromOffset(18);
+  static final raidAlertsDisabled = Flag<GuildFeatures>.fromOffset(18);
 
   /// The guild is able to set role icons.
-  static const roleIcons = Flag<GuildFeatures>.fromOffset(19);
+  static final roleIcons = Flag<GuildFeatures>.fromOffset(19);
 
   /// The guild has role subscriptions that can be purchased.
-  static const roleSubscriptionsAvailableForPurchase = Flag<GuildFeatures>.fromOffset(20);
+  static final roleSubscriptionsAvailableForPurchase = Flag<GuildFeatures>.fromOffset(20);
 
   /// The guild has enabled role subscriptions.
-  static const roleSubscriptionsEnabled = Flag<GuildFeatures>.fromOffset(21);
+  static final roleSubscriptionsEnabled = Flag<GuildFeatures>.fromOffset(21);
 
   /// The guild has enabled ticketed events.
-  static const ticketedEventsEnabled = Flag<GuildFeatures>.fromOffset(22);
+  static final ticketedEventsEnabled = Flag<GuildFeatures>.fromOffset(22);
 
   /// The guild has access to set a vanity URL.
-  static const vanityUrl = Flag<GuildFeatures>.fromOffset(23);
+  static final vanityUrl = Flag<GuildFeatures>.fromOffset(23);
 
   /// The guild is verified.
-  static const verified = Flag<GuildFeatures>.fromOffset(24);
+  static final verified = Flag<GuildFeatures>.fromOffset(24);
 
   /// The guild has access to set 384kbps bitrate in voice (previously VIP voice servers).
-  static const vipRegions = Flag<GuildFeatures>.fromOffset(25);
+  static final vipRegions = Flag<GuildFeatures>.fromOffset(25);
 
   /// The guild has enabled the welcome screen.
-  static const welcomeScreenEnabled = Flag<GuildFeatures>.fromOffset(26);
+  static final welcomeScreenEnabled = Flag<GuildFeatures>.fromOffset(26);
 
   /// Create a new [GuildFeatures].
-  const GuildFeatures(super.value);
+  GuildFeatures(super.value);
 
   /// Whether this guild has the [animatedBanner] feature.
   bool get hasAnimatedBanner => has(animatedBanner);
@@ -594,25 +594,25 @@ enum MfaLevel {
 /// The configuration of a guild's system channel.
 class SystemChannelFlags extends Flags<SystemChannelFlags> {
   /// Suppress member join notifications.
-  static const suppressJoinNotifications = Flag<SystemChannelFlags>.fromOffset(0);
+  static final suppressJoinNotifications = Flag<SystemChannelFlags>.fromOffset(0);
 
   /// Suppress server boost notifications.
-  static const suppressPremiumSubscriptions = Flag<SystemChannelFlags>.fromOffset(1);
+  static final suppressPremiumSubscriptions = Flag<SystemChannelFlags>.fromOffset(1);
 
   /// Suppress server setup tips.
-  static const suppressGuildReminderNotifications = Flag<SystemChannelFlags>.fromOffset(2);
+  static final suppressGuildReminderNotifications = Flag<SystemChannelFlags>.fromOffset(2);
 
   /// Hide member join sticker reply buttons.
-  static const suppressJoinNotificationReplies = Flag<SystemChannelFlags>.fromOffset(3);
+  static final suppressJoinNotificationReplies = Flag<SystemChannelFlags>.fromOffset(3);
 
   /// Suppress role subscription purchase and renewal notifications.
-  static const suppressRoleSubscriptionPurchaseNotifications = Flag<SystemChannelFlags>.fromOffset(4);
+  static final suppressRoleSubscriptionPurchaseNotifications = Flag<SystemChannelFlags>.fromOffset(4);
 
   /// Hide role subscription sticker reply buttons.
-  static const suppressRoleSubscriptionPurchaseNotificationReplies = Flag<SystemChannelFlags>.fromOffset(5);
+  static final suppressRoleSubscriptionPurchaseNotificationReplies = Flag<SystemChannelFlags>.fromOffset(5);
 
   /// Create a new [SystemChannelFlags].
-  const SystemChannelFlags(super.value);
+  SystemChannelFlags(super.value);
 
   /// Whether this configuration has the [suppressJoinNotifications] flag.
   bool get shouldSuppressJoinNotifications => has(suppressJoinNotifications);

--- a/lib/src/models/guild/member.dart
+++ b/lib/src/models/guild/member.dart
@@ -88,16 +88,16 @@ class Member extends PartialMember {
 /// Flags that can be applied to a [Member].
 class MemberFlags extends Flags<MemberFlags> {
   /// This member has left and rejoined the guild.
-  static const didRejoin = Flag<MemberFlags>.fromOffset(0);
+  static final didRejoin = Flag<MemberFlags>.fromOffset(0);
 
   /// This member completed the guild's onboarding process.
-  static const completedOnboarding = Flag<MemberFlags>.fromOffset(1);
+  static final completedOnboarding = Flag<MemberFlags>.fromOffset(1);
 
   /// This member is exempt from guild verification requirements.
-  static const bypassesVerification = Flag<MemberFlags>.fromOffset(2);
+  static final bypassesVerification = Flag<MemberFlags>.fromOffset(2);
 
   /// This member has started the guild's onboarding process.
-  static const startedOnboarding = Flag<MemberFlags>.fromOffset(3);
+  static final startedOnboarding = Flag<MemberFlags>.fromOffset(3);
 
   /// Whether this member has the [didRejoin] flag.
   bool get hasRejoined => has(didRejoin);
@@ -112,5 +112,5 @@ class MemberFlags extends Flags<MemberFlags> {
   bool get didStartOnboarding => has(startedOnboarding);
 
   /// Create a new [MemberFlags].
-  const MemberFlags(super.value);
+  MemberFlags(super.value);
 }

--- a/lib/src/models/message/message.dart
+++ b/lib/src/models/message/message.dart
@@ -239,34 +239,34 @@ enum MessageType {
 /// * Discord API Reference: https://discord.com/developers/docs/resources/channel#message-object-message-flags
 class MessageFlags extends Flags<MessageFlags> {
   /// This message has been published to subscribed channels (via Channel Following).
-  static const crossposted = Flag<MessageFlags>.fromOffset(0);
+  static final crossposted = Flag<MessageFlags>.fromOffset(0);
 
   /// This message originated from a message in another channel (via Channel Following).
-  static const isCrosspost = Flag<MessageFlags>.fromOffset(1);
+  static final isCrosspost = Flag<MessageFlags>.fromOffset(1);
 
   /// Do not include any embeds when serializing this message.
-  static const suppressEmbeds = Flag<MessageFlags>.fromOffset(2);
+  static final suppressEmbeds = Flag<MessageFlags>.fromOffset(2);
 
   /// The source message for this crosspost has been deleted (via Channel Following).
-  static const sourceMessageDeleted = Flag<MessageFlags>.fromOffset(3);
+  static final sourceMessageDeleted = Flag<MessageFlags>.fromOffset(3);
 
   /// This message came from the urgent message system.
-  static const urgent = Flag<MessageFlags>.fromOffset(4);
+  static final urgent = Flag<MessageFlags>.fromOffset(4);
 
   /// This message has an associated thread, with the same id as the message.
-  static const hasThread = Flag<MessageFlags>.fromOffset(5);
+  static final hasThread = Flag<MessageFlags>.fromOffset(5);
 
   /// This message is only visible to the user who invoked the Interaction.
-  static const ephemeral = Flag<MessageFlags>.fromOffset(6);
+  static final ephemeral = Flag<MessageFlags>.fromOffset(6);
 
   /// This message is an Interaction Response and the bot is "thinking".
-  static const loading = Flag<MessageFlags>.fromOffset(7);
+  static final loading = Flag<MessageFlags>.fromOffset(7);
 
   /// This message failed to mention some roles and add their members to the thread.
-  static const failedToMentionSomeRolesInThread = Flag<MessageFlags>.fromOffset(8);
+  static final failedToMentionSomeRolesInThread = Flag<MessageFlags>.fromOffset(8);
 
   /// This message will not trigger push and desktop notifications.
-  static const suppressNotifications = Flag<MessageFlags>.fromOffset(12);
+  static final suppressNotifications = Flag<MessageFlags>.fromOffset(12);
 
   /// Whether this set of flags has the [crossposted] flag set.
   bool get wasCrossposted => has(crossposted);
@@ -299,5 +299,5 @@ class MessageFlags extends Flags<MessageFlags> {
   bool get suppressesNotifications => has(suppressNotifications);
 
   /// Create a new [MessageFlags].
-  const MessageFlags(super.value);
+  MessageFlags(super.value);
 }

--- a/lib/src/models/permissions.dart
+++ b/lib/src/models/permissions.dart
@@ -6,133 +6,133 @@ import 'package:nyxx/src/utils/flags.dart';
 /// * Discord API Reference: https://discord.com/developers/docs/topics/permissions
 class Permissions extends Flags<Permissions> {
   /// Allows creation of instant invites.
-  static const createInstantInvite = Flag<Permissions>.fromOffset(0);
+  static final createInstantInvite = Flag<Permissions>.fromOffset(0);
 
   /// Allows kicking members.
-  static const kickMembers = Flag<Permissions>.fromOffset(1);
+  static final kickMembers = Flag<Permissions>.fromOffset(1);
 
   /// Allows banning members.
-  static const banMembers = Flag<Permissions>.fromOffset(2);
+  static final banMembers = Flag<Permissions>.fromOffset(2);
 
   /// Allows all permissions and bypasses channel permission overwrites.
-  static const administrator = Flag<Permissions>.fromOffset(3);
+  static final administrator = Flag<Permissions>.fromOffset(3);
 
   /// Allows management and editing of channels.
-  static const manageChannels = Flag<Permissions>.fromOffset(4);
+  static final manageChannels = Flag<Permissions>.fromOffset(4);
 
   /// Allows management and editing of the guild.
-  static const manageGuild = Flag<Permissions>.fromOffset(5);
+  static final manageGuild = Flag<Permissions>.fromOffset(5);
 
   /// Allows for the addition of reactions to messages.
-  static const addReactions = Flag<Permissions>.fromOffset(6);
+  static final addReactions = Flag<Permissions>.fromOffset(6);
 
   /// Allows for viewing of audit logs.
-  static const viewAuditLog = Flag<Permissions>.fromOffset(7);
+  static final viewAuditLog = Flag<Permissions>.fromOffset(7);
 
   /// Allows for using priority speaker in a voice channel.
-  static const prioritySpeaker = Flag<Permissions>.fromOffset(8);
+  static final prioritySpeaker = Flag<Permissions>.fromOffset(8);
 
   /// Allows the user to go live.
-  static const stream = Flag<Permissions>.fromOffset(9);
+  static final stream = Flag<Permissions>.fromOffset(9);
 
   /// Allows guild members to view a channel, which includes reading messages in text channels and joining voice channels.
-  static const viewChannel = Flag<Permissions>.fromOffset(10);
+  static final viewChannel = Flag<Permissions>.fromOffset(10);
 
   /// Allows for sending messages in a channel and creating threads in a forum (does not allow sending messages in threads).
-  static const sendMessages = Flag<Permissions>.fromOffset(11);
+  static final sendMessages = Flag<Permissions>.fromOffset(11);
 
   /// Allows for sending of /tts messages.
-  static const sendTtsMessages = Flag<Permissions>.fromOffset(12);
+  static final sendTtsMessages = Flag<Permissions>.fromOffset(12);
 
   /// Allows for deletion of other users messages.
-  static const manageMessages = Flag<Permissions>.fromOffset(13);
+  static final manageMessages = Flag<Permissions>.fromOffset(13);
 
   /// Links sent by users with this permission will be auto-embedded.
-  static const embedLinks = Flag<Permissions>.fromOffset(14);
+  static final embedLinks = Flag<Permissions>.fromOffset(14);
 
   /// Allows for uploading images and files.
-  static const attachFiles = Flag<Permissions>.fromOffset(15);
+  static final attachFiles = Flag<Permissions>.fromOffset(15);
 
   /// Allows for reading of message history.
-  static const readMessageHistory = Flag<Permissions>.fromOffset(16);
+  static final readMessageHistory = Flag<Permissions>.fromOffset(16);
 
   /// Allows for using the @everyone tag to notify all users in a channel, and the @here tag to notify all online users in a channel.
-  static const mentionEveryone = Flag<Permissions>.fromOffset(17);
+  static final mentionEveryone = Flag<Permissions>.fromOffset(17);
 
   /// Allows the usage of custom emojis from other servers.
-  static const useExternalEmojis = Flag<Permissions>.fromOffset(18);
+  static final useExternalEmojis = Flag<Permissions>.fromOffset(18);
 
   /// Allows for viewing guild insights.
-  static const viewGuildInsights = Flag<Permissions>.fromOffset(19);
+  static final viewGuildInsights = Flag<Permissions>.fromOffset(19);
 
   /// Allows for joining of a voice channel.
-  static const connect = Flag<Permissions>.fromOffset(20);
+  static final connect = Flag<Permissions>.fromOffset(20);
 
   /// Allows for speaking in a voice channel.
-  static const speak = Flag<Permissions>.fromOffset(21);
+  static final speak = Flag<Permissions>.fromOffset(21);
 
   /// Allows for muting members in a voice channel.
-  static const muteMembers = Flag<Permissions>.fromOffset(22);
+  static final muteMembers = Flag<Permissions>.fromOffset(22);
 
   /// Allows for deafening of members in a voice channel.
-  static const deafenMembers = Flag<Permissions>.fromOffset(23);
+  static final deafenMembers = Flag<Permissions>.fromOffset(23);
 
   /// Allows for moving of members between voice channels.
-  static const moveMembers = Flag<Permissions>.fromOffset(24);
+  static final moveMembers = Flag<Permissions>.fromOffset(24);
 
   /// Allows for using voice-activity-detection in a voice channel.
-  static const useVad = Flag<Permissions>.fromOffset(25);
+  static final useVad = Flag<Permissions>.fromOffset(25);
 
   /// Allows for modification of own nickname.
-  static const changeNickname = Flag<Permissions>.fromOffset(26);
+  static final changeNickname = Flag<Permissions>.fromOffset(26);
 
   /// Allows for modification of other users nicknames.
-  static const manageNicknames = Flag<Permissions>.fromOffset(27);
+  static final manageNicknames = Flag<Permissions>.fromOffset(27);
 
   /// Allows management and editing of roles.
-  static const manageRoles = Flag<Permissions>.fromOffset(28);
+  static final manageRoles = Flag<Permissions>.fromOffset(28);
 
   /// Allows management and editing of webhooks.
-  static const manageWebhooks = Flag<Permissions>.fromOffset(29);
+  static final manageWebhooks = Flag<Permissions>.fromOffset(29);
 
   /// Allows management and editing of emojis, stickers, and soundboard sounds.
-  static const manageEmojisAndStickers = Flag<Permissions>.fromOffset(30);
+  static final manageEmojisAndStickers = Flag<Permissions>.fromOffset(30);
 
   /// Allows members to use application commands, including slash commands and context menu commands..
-  static const useApplicationCommands = Flag<Permissions>.fromOffset(31);
+  static final useApplicationCommands = Flag<Permissions>.fromOffset(31);
 
   /// Allows for requesting to speak in stage channels. (This permission is under active development and may be changed or removed.).
-  static const requestToSpeak = Flag<Permissions>.fromOffset(32);
+  static final requestToSpeak = Flag<Permissions>.fromOffset(32);
 
   /// Allows for creating, editing, and deleting scheduled events.
-  static const manageEvents = Flag<Permissions>.fromOffset(33);
+  static final manageEvents = Flag<Permissions>.fromOffset(33);
 
   /// Allows for deleting and archiving threads, and viewing all private threads.
-  static const manageThreads = Flag<Permissions>.fromOffset(34);
+  static final manageThreads = Flag<Permissions>.fromOffset(34);
 
   /// Allows for creating public and announcement threads.
-  static const createPublicThreads = Flag<Permissions>.fromOffset(35);
+  static final createPublicThreads = Flag<Permissions>.fromOffset(35);
 
   /// Allows for creating private threads.
-  static const createPrivateThreads = Flag<Permissions>.fromOffset(36);
+  static final createPrivateThreads = Flag<Permissions>.fromOffset(36);
 
   /// Allows the usage of custom stickers from other servers.
-  static const useExternalStickers = Flag<Permissions>.fromOffset(37);
+  static final useExternalStickers = Flag<Permissions>.fromOffset(37);
 
   /// Allows for sending messages in threads.
-  static const sendMessagesInThreads = Flag<Permissions>.fromOffset(38);
+  static final sendMessagesInThreads = Flag<Permissions>.fromOffset(38);
 
   /// Allows for using Activities (applications with the EMBEDDED flag) in a voice channel.
-  static const useEmbeddedActivities = Flag<Permissions>.fromOffset(39);
+  static final useEmbeddedActivities = Flag<Permissions>.fromOffset(39);
 
   /// Allows for timing out users to prevent them from sending or reacting to messages in chat and threads, and from speaking in voice and stage channels.
-  static const moderateMembers = Flag<Permissions>.fromOffset(40);
+  static final moderateMembers = Flag<Permissions>.fromOffset(40);
 
   /// Allows for viewing role subscription insights.
-  static const viewCreatorMonetizationAnalytics = Flag<Permissions>.fromOffset(41);
+  static final viewCreatorMonetizationAnalytics = Flag<Permissions>.fromOffset(41);
 
   /// Allows for using soundboard in a voice channel.
-  static const useSoundboard = Flag<Permissions>.fromOffset(42);
+  static final useSoundboard = Flag<Permissions>.fromOffset(42);
 
   /// Whether this set of permissions has the [createInstantInvite] permission.
   bool get canCreateInstantInvite => has(createInstantInvite);
@@ -264,5 +264,5 @@ class Permissions extends Flags<Permissions> {
   bool get canUseSoundboard => has(useSoundboard);
 
   /// Create a new [Permissions] from a permissions value.
-  const Permissions(super.value);
+  Permissions(super.value);
 }

--- a/lib/src/models/presence.dart
+++ b/lib/src/models/presence.dart
@@ -215,21 +215,21 @@ class ActivitySecrets with ToStringHelper {
 /// Information about the data in an [Activity] instance.
 class ActivityFlags extends Flags<ActivityFlags> {
   /// The activity is an instanced game session.
-  static const instance = Flag<ActivityFlags>.fromOffset(0);
+  static final instance = Flag<ActivityFlags>.fromOffset(0);
 
   /// The activity can be joined.
-  static const canJoin = Flag<ActivityFlags>.fromOffset(1);
+  static final canJoin = Flag<ActivityFlags>.fromOffset(1);
 
   /// The activity can be spectated.
-  static const spectate = Flag<ActivityFlags>.fromOffset(2);
+  static final spectate = Flag<ActivityFlags>.fromOffset(2);
 
   /// The client can request to join the activity.
-  static const joinRequest = Flag<ActivityFlags>.fromOffset(3);
-  static const sync = Flag<ActivityFlags>.fromOffset(4);
-  static const play = Flag<ActivityFlags>.fromOffset(5);
-  static const partyPrivacyFriends = Flag<ActivityFlags>.fromOffset(6);
-  static const partyPrivacyVoiceChannel = Flag<ActivityFlags>.fromOffset(7);
-  static const embedded = Flag<ActivityFlags>.fromOffset(8);
+  static final joinRequest = Flag<ActivityFlags>.fromOffset(3);
+  static final sync = Flag<ActivityFlags>.fromOffset(4);
+  static final play = Flag<ActivityFlags>.fromOffset(5);
+  static final partyPrivacyFriends = Flag<ActivityFlags>.fromOffset(6);
+  static final partyPrivacyVoiceChannel = Flag<ActivityFlags>.fromOffset(7);
+  static final embedded = Flag<ActivityFlags>.fromOffset(8);
 
   /// Create a new [ActivityFlags].
   ActivityFlags(super.value);

--- a/lib/src/models/user/user.dart
+++ b/lib/src/models/user/user.dart
@@ -84,50 +84,50 @@ class User extends PartialUser implements MessageAuthor {
 /// A set of [Flags] a user can have.
 class UserFlags extends Flags<UserFlags> {
   /// The user is a Discord employee.
-  static const staff = Flag<UserFlags>.fromOffset(0);
+  static final staff = Flag<UserFlags>.fromOffset(0);
 
   /// The user is a Partnered Server Owner.
-  static const partner = Flag<UserFlags>.fromOffset(1);
+  static final partner = Flag<UserFlags>.fromOffset(1);
 
   /// The user is a Hypesquad Events Member.
-  static const hypesquad = Flag<UserFlags>.fromOffset(2);
+  static final hypesquad = Flag<UserFlags>.fromOffset(2);
 
   /// The user has the Bug Hunter level 1 badge.
-  static const bugHunter1 = Flag<UserFlags>.fromOffset(3);
+  static final bugHunter1 = Flag<UserFlags>.fromOffset(3);
 
   /// The user is a House of Bravery Member.
-  static const hypesquadHouse1 = Flag<UserFlags>.fromOffset(6);
+  static final hypesquadHouse1 = Flag<UserFlags>.fromOffset(6);
 
   /// The user is a House of Brilliance Member.
-  static const hypesquadHouse2 = Flag<UserFlags>.fromOffset(7);
+  static final hypesquadHouse2 = Flag<UserFlags>.fromOffset(7);
 
   /// The user is a House of Balance Member.
-  static const hypesquadHouse3 = Flag<UserFlags>.fromOffset(8);
+  static final hypesquadHouse3 = Flag<UserFlags>.fromOffset(8);
 
   /// The user is an Early Nitro Supporter.
-  static const earlySupporter = Flag<UserFlags>.fromOffset(9);
+  static final earlySupporter = Flag<UserFlags>.fromOffset(9);
 
   /// The user is a pseudo-user for a [Team].
-  static const teamUser = Flag<UserFlags>.fromOffset(10);
+  static final teamUser = Flag<UserFlags>.fromOffset(10);
 
   /// The user has the Bug Hunter level 2 badge.
-  static const bugHunter2 = Flag<UserFlags>.fromOffset(14);
+  static final bugHunter2 = Flag<UserFlags>.fromOffset(14);
 
   /// The user is a verified bot.
-  static const verifiedBot = Flag<UserFlags>.fromOffset(16);
+  static final verifiedBot = Flag<UserFlags>.fromOffset(16);
 
   /// The user is an Early Verified Bot Developer.
-  static const verifiedDeveloper = Flag<UserFlags>.fromOffset(17);
+  static final verifiedDeveloper = Flag<UserFlags>.fromOffset(17);
 
   /// The user is a Moderator Programs Alumni.
-  static const certifierModerator = Flag<UserFlags>.fromOffset(18);
+  static final certifierModerator = Flag<UserFlags>.fromOffset(18);
 
   /// The user is a bot which uses only HTTP interactions, and as such is shown as online in the
   /// member list.
-  static const botHttpInteractions = Flag<UserFlags>.fromOffset(19);
+  static final botHttpInteractions = Flag<UserFlags>.fromOffset(19);
 
   /// The user is an Active Developer.
-  static const activeDeveloper = Flag<UserFlags>.fromOffset(22);
+  static final activeDeveloper = Flag<UserFlags>.fromOffset(22);
 
   /// Whether the user is a Discord employee.
   bool get isStaff => has(staff);
@@ -175,7 +175,7 @@ class UserFlags extends Flags<UserFlags> {
   bool get isActiveDeveloper => has(activeDeveloper);
 
   /// Create a new [UserFlags].
-  const UserFlags(super.value);
+  UserFlags(super.value);
 }
 
 /// The types of Discord Nitro subscription a user can have.

--- a/lib/src/utils/flags.dart
+++ b/lib/src/utils/flags.dart
@@ -49,9 +49,6 @@ class _FlagIterator<T extends Flags<T>> implements Iterator<Flag<T>> {
 
   _FlagIterator(this.source);
 
-  // TODO: Rewrite this to avoid hardcoding a max offset.
-  static const maxOffset = 64;
-
   int? offset;
 
   @override
@@ -63,7 +60,7 @@ class _FlagIterator<T extends Flags<T>> implements Iterator<Flag<T>> {
         offset = offset! + 1;
       }
 
-      if (offset! > maxOffset) {
+      if (source.value >> offset! == BigInt.zero) {
         return false;
       }
     } while (!source.has(current));

--- a/lib/src/utils/flags.dart
+++ b/lib/src/utils/flags.dart
@@ -5,13 +5,13 @@ import 'package:nyxx/src/utils/to_string_helper/to_string_helper.dart';
 /// A set of flags that can be either enabled or disabled.
 class Flags<T extends Flags<T>> extends IterableBase<Flag<T>> with ToStringHelper {
   /// The integer value encoding the flags as a bitfield.
-  final int value;
+  final BigInt value;
 
   /// Create a new [Flags].
-  const Flags(this.value);
+  Flags(this.value);
 
   /// Returns `true` if this [Flags] has the [flag] enabled, `false` otherwise.
-  bool has(Flag<T> flag) => value & flag.value != 0;
+  bool has(Flag<T> flag) => value & flag.value != BigInt.zero;
 
   @override
   Iterator<Flag<T>> get iterator => _FlagIterator(this);
@@ -35,10 +35,10 @@ class Flags<T extends Flags<T>> extends IterableBase<Flag<T>> with ToStringHelpe
 /// A flag within a set of [Flags].
 class Flag<T extends Flags<T>> extends Flags<T> {
   /// Create a new [Flag].
-  const Flag(super.value);
+  Flag(super.value);
 
   /// Create a new [Flag] from an offset into the bitfield.
-  const Flag.fromOffset(int offset) : super(1 << offset);
+  Flag.fromOffset(int offset) : super(BigInt.one << offset);
 
   @override
   String toString() => 'Flag<$T>($value)';

--- a/test/unit/cache/cache_test.dart
+++ b/test/unit/cache/cache_test.dart
@@ -74,7 +74,7 @@ void main() {
     });
 
     test("doesn't cache items if a filter is provided", () {
-      final cache = Cache<MockSnowflakeEntity>('test', CacheConfig(shouldCache: (e) => e.id.value > 3));
+      final cache = Cache<MockSnowflakeEntity>('test', CacheConfig(shouldCache: (e) => e.id.value > BigInt.from(3)));
 
       final entity1 = MockSnowflakeEntity(id: Snowflake(1));
       final entity2 = MockSnowflakeEntity(id: Snowflake(2));

--- a/test/unit/http/managers/application_manager_test.dart
+++ b/test/unit/http/managers/application_manager_test.dart
@@ -55,7 +55,7 @@ void checkApplication(Application application) {
   expect(application.primarySkuId, equals(Snowflake(172150183260323840)));
   expect(application.slug, equals('test'));
   expect(application.coverImageHash, equals('31deabb7e45b6c8ecfef77d2f99c81a5'));
-  expect(application.flags, equals(ApplicationFlags(0)));
+  expect(application.flags, equals(ApplicationFlags(BigInt.zero)));
   expect(application.tags, isNull);
   expect(application.installationParameters, isNull);
   expect(application.customInstallUrl, isNull);

--- a/test/unit/http/managers/channel_manager_test.dart
+++ b/test/unit/http/managers/channel_manager_test.dart
@@ -276,7 +276,7 @@ void checkAnnouncementThread(Channel channel) {
   expect(channel.position, equals(-1));
   expect(channel.rateLimitPerUser, isNull);
   expect(channel.totalMessagesSent, equals(1));
-  expect(channel.flags, equals(ChannelFlags(0)));
+  expect(channel.flags, equals(ChannelFlags(BigInt.zero)));
 }
 
 final samplePrivateThread = {
@@ -336,7 +336,7 @@ void checkPrivateThread(Channel channel) {
   expect(channel.position, equals(-1));
   expect(channel.rateLimitPerUser, isNull);
   expect(channel.totalMessagesSent, equals(2));
-  expect(channel.flags, equals(ChannelFlags(0)));
+  expect(channel.flags, equals(ChannelFlags(BigInt.zero)));
 }
 
 final samplePermissionOverwrite = {
@@ -349,8 +349,8 @@ final samplePermissionOverwrite = {
 void checkPermissionOverwrite(PermissionOverwrite overwrite) {
   expect(overwrite.id, equals(Snowflake.zero));
   expect(overwrite.type, equals(PermissionOverwriteType.member));
-  expect(overwrite.allow, equals(Permissions(100)));
-  expect(overwrite.deny, equals(Permissions(11)));
+  expect(overwrite.allow, equals(Permissions(BigInt.from(100))));
+  expect(overwrite.deny, equals(Permissions(BigInt.from(11))));
 }
 
 final sampleForumTag = {
@@ -400,7 +400,7 @@ final sampleThreadMember = {
 void checkThreadMember(ThreadMember member) {
   expect(member.threadId, equals(Snowflake.zero));
   expect(member.userId, equals(Snowflake(1)));
-  expect(member.flags.value, equals(17));
+  expect(member.flags.value, equals(BigInt.from(17)));
   expect(member.joinTimestamp, equals(DateTime.utc(2023, 04, 03, 10, 49, 41)));
 }
 

--- a/test/unit/http/managers/guild_manager_test.dart
+++ b/test/unit/http/managers/guild_manager_test.dart
@@ -89,7 +89,7 @@ void checkGuild(Guild guild) {
   expect(guild.mfaLevel, equals(MfaLevel.elevated));
   expect(guild.applicationId, isNull);
   expect(guild.systemChannelId, isNull);
-  expect(guild.systemChannelFlags, equals(SystemChannelFlags(0)));
+  expect(guild.systemChannelFlags, equals(SystemChannelFlags(BigInt.zero)));
   expect(guild.rulesChannelId, equals(Snowflake(441688182833020939)));
   expect(guild.maxPresences, equals(40000));
   expect(guild.maxMembers, equals(250000));
@@ -202,7 +202,7 @@ void checkGuild2(Guild guild) {
   expect(guild.mfaLevel, equals(MfaLevel.none));
   expect(guild.applicationId, isNull);
   expect(guild.systemChannelId, isNull);
-  expect(guild.systemChannelFlags, equals(SystemChannelFlags(0)));
+  expect(guild.systemChannelFlags, equals(SystemChannelFlags(BigInt.zero)));
   expect(guild.rulesChannelId, isNull);
   expect(guild.maxPresences, isNull);
   expect(guild.maxMembers, equals(250000));

--- a/test/unit/http/managers/member_manager_test.dart
+++ b/test/unit/http/managers/member_manager_test.dart
@@ -27,7 +27,7 @@ void checkMember(Member member) {
   expect(member.premiumSince, isNull);
   expect(member.isDeaf, isFalse);
   expect(member.isMute, isFalse);
-  expect(member.flags, equals(MemberFlags(0)));
+  expect(member.flags, equals(MemberFlags(BigInt.zero)));
   expect(member.isPending, isFalse);
   expect(member.permissions, isNull);
   expect(member.communicationDisabledUntil, isNull);

--- a/test/unit/http/managers/message_manager_test.dart
+++ b/test/unit/http/managers/message_manager_test.dart
@@ -49,7 +49,7 @@ void checkMessage(Message message) {
   expect(message.activity, isNull);
   expect(message.applicationId, isNull);
   expect(message.reference, isNull);
-  expect(message.flags, equals(MessageFlags(0)));
+  expect(message.flags, equals(MessageFlags(BigInt.zero)));
   expect(message.referencedMessage, isNull);
   expect(message.thread, isNull);
   expect(message.position, isNull);
@@ -113,7 +113,7 @@ void checkCrosspostedMessage(Message message) {
   expect(message.reference?.channelId, equals(Snowflake(278325129692446722)));
   expect(message.reference?.guildId, equals(Snowflake(278325129692446720)));
   expect(message.reference?.messageId, equals(Snowflake(306588351130107906)));
-  expect(message.flags, equals(MessageFlags(2)));
+  expect(message.flags, equals(MessageFlags(BigInt.from(2))));
   expect(message.referencedMessage, isNull);
   expect(message.thread, isNull);
   expect(message.position, isNull);

--- a/test/unit/http/managers/role_manager_test.dart
+++ b/test/unit/http/managers/role_manager_test.dart
@@ -25,7 +25,7 @@ void checkRole(Role role) {
   expect(role.iconHash, equals('cf3ced8600b777c9486c6d8d84fb4327'));
   expect(role.unicodeEmoji, isNull);
   expect(role.position, equals(1));
-  expect(role.permissions, equals(Permissions(66321471)));
+  expect(role.permissions, equals(Permissions(BigInt.from(66321471))));
   expect(role.isMentionable, isFalse);
   expect(role.tags, isNull);
 }

--- a/test/unit/http/managers/user_manager_test.dart
+++ b/test/unit/http/managers/user_manager_test.dart
@@ -28,9 +28,9 @@ void checkSampleUser(User user) {
   expect(user.bannerHash, equals('06c16474723fe537c283b8efa61a30c8'));
   expect(user.accentColor, equals(DiscordColor(16711680)));
   expect(user.locale, isNull);
-  expect(user.flags, equals(UserFlags(64)));
+  expect(user.flags, equals(UserFlags(BigInt.from(64))));
   expect(user.nitroType, equals(NitroType.classic));
-  expect(user.publicFlags, equals(UserFlags(64)));
+  expect(user.publicFlags, equals(UserFlags(BigInt.from(64))));
 }
 
 final sampleConnection = {

--- a/test/unit/models/snowflake_test.dart
+++ b/test/unit/models/snowflake_test.dart
@@ -4,12 +4,12 @@ import 'package:test/test.dart';
 void main() {
   group('Snowflake', () {
     test('zero has correct value', () {
-      expect(Snowflake.zero.value, isZero);
+      expect(Snowflake.zero.value, equals(BigInt.zero));
       expect(Snowflake.zero.isZero, isTrue);
     });
 
     test('structure is parsed correctly', () {
-      const snowflake = Snowflake(175928847299117063);
+      final snowflake = Snowflake(175928847299117063);
 
       expect(snowflake.increment, equals(7));
       expect(snowflake.processId, equals(0));
@@ -18,7 +18,7 @@ void main() {
     });
 
     test('timestamp is parsed correctly', () {
-      const snowflake = Snowflake(175928847299117063);
+      final snowflake = Snowflake(175928847299117063);
 
       expect(snowflake.timestamp, DateTime.utc(2016, 04, 30, 11, 18, 25, 796));
     });

--- a/test/unit/utils/flags_test.dart
+++ b/test/unit/utils/flags_test.dart
@@ -4,9 +4,9 @@ import 'package:test/test.dart';
 void main() {
   group('Flag', () {
     test('fromOffset gives the correct value', () {
-      expect(Flag<Never>.fromOffset(0).value, equals(1 << 0));
-      expect(Flag<Never>.fromOffset(1).value, equals(1 << 1));
-      expect(Flag<Never>.fromOffset(10).value, equals(1 << 10));
+      expect(Flag<Never>.fromOffset(0).value, equals(BigInt.one << 0));
+      expect(Flag<Never>.fromOffset(1).value, equals(BigInt.one << 1));
+      expect(Flag<Never>.fromOffset(10).value, equals(BigInt.one << 10));
     });
   });
 
@@ -15,20 +15,20 @@ void main() {
       final zeroFlag = Flag<Never>.fromOffset(0);
       final oneFlag = Flag<Never>.fromOffset(1);
 
-      final flags = Flags<Never>(1);
+      final flags = Flags<Never>(BigInt.one);
 
       expect(flags.has(zeroFlag), isTrue);
       expect(flags.has(oneFlag), isFalse);
     });
 
     test('equality', () {
-      expect(Flags<Never>(1), equals(Flags<Never>(1)));
+      expect(Flags<Never>(BigInt.one), equals(Flags<Never>(BigInt.one)));
     });
 
     test('|', () {
-      final flags = Flags<Never>(3) | Flag<Never>.fromOffset(2) | Flags<Never>(0xff00);
+      final flags = Flags<Never>(BigInt.from(3)) | Flag<Never>.fromOffset(2) | Flags<Never>(BigInt.from(0xff00));
 
-      expect(flags, equals(Flags<Never>(0xff07)));
+      expect(flags, equals(Flags<Never>(BigInt.from(0xff07))));
     });
 
     test('iterator', () {
@@ -37,6 +37,15 @@ void main() {
       expect(flags, hasLength(3));
       expect(flags.first, equals(Flag<Never>.fromOffset(2)));
       expect(flags.last, equals(Flag<Never>.fromOffset(10)));
+    });
+
+    test('does not overflow', () {
+      // 128 enabled flags
+      final flags = Flags<Never>(BigInt.parse('ffffffffffffffffffffffffffffffff', radix: 16));
+
+      expect(flags.has(Flag<Never>.fromOffset(0)), isTrue);
+      expect(flags.has(Flag<Never>.fromOffset(64)), isTrue);
+      expect(flags.has(Flag<Never>.fromOffset(127)), isTrue);
     });
   });
 }


### PR DESCRIPTION
# Description

This PR changes Flags and Snowflakes to use BigInts instead of ints as their "backing store". Their API is unchanged (other than places the value is directly exposed).

This change has a few benefits: we are guaranteed to never overflow when parsing flags or snowflakes (the `Permissions` flags can already go as high as `1 << 42`, and `Snowflake` will run into issues once snowflake values exceed `2 ^ 63`) and this clears the way for (potential) support of the web platform in the future, where the maximum integer limit is much lower (`2 ^ 53`).

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
