### PR TITLE
Avoid hardcoding maxOffset in _FlagIterator

### DIFF
--- a/lib/src/utils/flags.dart
+++ b/lib/src/utils/flags.dart
@@ -49,9 +49,6 @@ class _FlagIterator<T extends Flags<T>> implements Iterator<Flag<T>> {
 
   _FlagIterator(this.source);
 
-  // TODO: Rewrite this to avoid hardcoding a max offset.
-  static const maxOffset = 64;
-
   int? offset;
 
   @override
@@ -63,7 +60,7 @@ class _FlagIterator<T extends Flags<T>> implements Iterator<Flag<T>> {
         offset = offset! + 1;
       }
 
-      if (offset! > maxOffset) {
+      if (offset! > source.value.bitLength) {
         return false;
       }
     } while (!source.has(current));


### PR DESCRIPTION
# Description

Changes _FlagIterator to only iterate as many times as needed instead of a fixed 64 times.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
