### PR TITLE
feat: new username system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.1.0
+__16.06.2023__
+
+- feature: Support the new unique username system with global display names.
+- bug: remove the `!` in the mention string as it has been deprecated.
+
 ## 5.0.4
 __04.06.2023__
 

--- a/lib/src/core/application/app_team_user.dart
+++ b/lib/src/core/application/app_team_user.dart
@@ -49,7 +49,7 @@ class AppTeamUser extends SnowflakeEntity implements IAppTeamUser {
   @override
   String avatarUrl({String format = 'webp', int? size, bool animated = false}) {
     if (avatar == null) {
-      return client.cdnHttpEndpoints.defaultAvatar(int.tryParse(discriminator) ?? 0);
+      return client.cdnHttpEndpoints.defaultAvatar(int.tryParse(discriminator) ?? 0, id.id);
     }
 
     return client.cdnHttpEndpoints.avatar(id, avatar!, format: format, size: size, animated: animated);

--- a/lib/src/core/guild/webhook.dart
+++ b/lib/src/core/guild/webhook.dart
@@ -189,7 +189,7 @@ class Webhook extends SnowflakeEntity implements IWebhook {
   @override
   String avatarUrl({String format = 'webp', int? size, bool animated = false}) {
     if (avatarHash == null) {
-      return client.cdnHttpEndpoints.defaultAvatar(defaultAvatarId);
+      return client.cdnHttpEndpoints.defaultAvatar(defaultAvatarId, id.id);
     }
 
     return client.cdnHttpEndpoints.avatar(id, avatarHash!, format: format, size: size, animated: animated);

--- a/lib/src/internal/cdn_http_endpoints.dart
+++ b/lib/src/internal/cdn_http_endpoints.dart
@@ -174,7 +174,6 @@ class CdnHttpEndpoints implements ICdnHttpEndpoints {
         ..embed()
         ..avatars(id: index.toString()),
       format: 'png',
-      animated: false,
     );
   }
 

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -33,7 +33,7 @@ class Constants {
   static const int apiVersion = 10;
 
   /// Version of Nyxx
-  static const String version = "5.0.4";
+  static const String version = "5.1.0";
 
   /// Url to Nyxx repo
   static const String repoUrl = "https://github.com/nyxx-discord/nyxx";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx
-version: 5.0.4
+version: 5.1.0
 description: A Discord library for Dart. Simple, robust framework for creating discord bots for Dart language.
 homepage: https://github.com/nyxx-discord/nyxx
 repository: https://github.com/nyxx-discord/nyxx

--- a/test/integration/integration.dart
+++ b/test/integration/integration.dart
@@ -138,7 +138,7 @@ main() async {
     expect(userBot.discriminator, equals(1759));
     expect(userBot.formattedDiscriminator, equals("1759"));
     expect(userBot.bot, isTrue);
-    expect(userBot.mention, "<@!${testUserBotSnowflake.toString()}>");
+    expect(userBot.mention, "<@${testUserBotSnowflake.toString()}>");
     expect(userBot.tag, equals("Running on Dart#1759"));
     expect(userBot.avatarUrl(), equals('https://cdn.discordapp.com/avatars/476603965396746242/be6107505d7b9d15292da4e54d88836e.webp'));
   });


### PR DESCRIPTION
# Description
Adds the new username pomelo update.

I also removed the bang from the mention of the user since it's been deprecated times ago.

## Connected issues & other potential problems
https://github.com/discord/discord-api-docs/pull/6218

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
