### PR TITLE
Only parse message update message as a partial message

### DIFF
--- a/lib/src/models/gateway/events/message.dart
+++ b/lib/src/models/gateway/events/message.dart
@@ -39,9 +39,9 @@ class MessageUpdateEvent extends DispatchEvent {
   final List<User> mentions;
 
   /// The updated message.
-  final Message message;
+  final PartialMessage message;
 
-  /// The message as it was cached before the updated.
+  /// The message as it was cached before the update.
   final Message? oldMessage;
 
   /// {@macro message_update_event}


### PR DESCRIPTION
# Description

The message update event was incorrectly implemented as expecting a complete message, when only a partial message is guaranteed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
