### PR TITLE
Change PartialTextChannel to return TextChannel when fetching

### DIFF
--- a/lib/src/http/managers/emoji_manager.dart
+++ b/lib/src/http/managers/emoji_manager.dart
@@ -54,7 +54,7 @@ class EmojiManager extends Manager<Emoji> {
   }
 
   @override
-  FutureOr<GuildEmoji> get(Snowflake id) async => await super.get(id) as GuildEmoji;
+  Future<GuildEmoji> get(Snowflake id) async => await super.get(id) as GuildEmoji;
 
   @override
   Future<GuildEmoji> fetch(Snowflake id) async {

--- a/lib/src/http/managers/manager.dart
+++ b/lib/src/http/managers/manager.dart
@@ -21,7 +21,7 @@ abstract class ReadOnlyManager<T extends ManagedSnowflakeEntity<T>> {
   T parse(Map<String, Object?> raw);
 
   /// Get an item by its [id] from the cache if it exists, else [fetch] it from the API.
-  FutureOr<T> get(Snowflake id) async => cache[id] ?? await fetch(id);
+  Future<T> get(Snowflake id) async => cache[id] ?? await fetch(id);
 
   /// Fetch the item with the given [id] from the API.
   ///

--- a/lib/src/models/channel/stage_instance.dart
+++ b/lib/src/models/channel/stage_instance.dart
@@ -53,7 +53,7 @@ class StageInstance extends SnowflakeEntity<StageInstance> {
   Future<StageInstance> fetch() => manager.fetchStageInstance(channelId);
 
   @override
-  FutureOr<StageInstance> get() async => manager.stageInstanceCache[channelId] ?? await fetch();
+  Future<StageInstance> get() async => manager.stageInstanceCache[channelId] ?? await fetch();
 }
 
 /// The privacy level of a [StageInstance].

--- a/lib/src/models/channel/text_channel.dart
+++ b/lib/src/models/channel/text_channel.dart
@@ -28,11 +28,11 @@ class PartialTextChannel extends PartialChannel {
   /// * Discord API Reference: https://discord.com/developers/docs/resources/channel#trigger-typing-indicator
   Future<void> triggerTyping() => manager.triggerTyping(id);
 
-  @override
-  Future<TextChannel> get() async => await super.get() as TextChannel;
-
-  @override
-  Future<TextChannel> fetch() async => await super.get() as TextChannel;
+  // DO NOT override get() and fetch() to return TextChannels
+  // Although this improves the API, all PartialChannels returned
+  // by ChannelManager.[] are PartialTextChannels, so the overrides
+  // added in this class would be used by *all* PartialChannels,
+  // even non-text ones.
 }
 
 //// A text channel

--- a/lib/src/models/channel/text_channel.dart
+++ b/lib/src/models/channel/text_channel.dart
@@ -27,6 +27,12 @@ class PartialTextChannel extends PartialChannel {
   /// * [ChannelManager.triggerTyping]
   /// * Discord API Reference: https://discord.com/developers/docs/resources/channel#trigger-typing-indicator
   Future<void> triggerTyping() => manager.triggerTyping(id);
+
+  @override
+  Future<TextChannel> get() async => await super.get() as TextChannel;
+
+  @override
+  Future<TextChannel> fetch() async => await super.get() as TextChannel;
 }
 
 //// A text channel

--- a/lib/src/models/snowflake_entity/snowflake_entity.dart
+++ b/lib/src/models/snowflake_entity/snowflake_entity.dart
@@ -15,7 +15,7 @@ abstract class SnowflakeEntity<T extends SnowflakeEntity<T>> with ToStringHelper
 
   /// If this entity exists in the manager's cache, return the cached instance. Otherwise, [fetch]
   /// this entity and return it.
-  FutureOr<T> get();
+  Future<T> get();
 
   /// Fetch this entity from the API.
   Future<T> fetch();
@@ -39,7 +39,7 @@ abstract class ManagedSnowflakeEntity<T extends ManagedSnowflakeEntity<T>> exten
   ManagedSnowflakeEntity({required super.id});
 
   @override
-  FutureOr<T> get() => manager.get(id);
+  Future<T> get() => manager.get(id);
 
   @override
   Future<T> fetch() => manager.fetch(id);


### PR DESCRIPTION
# Description

Change the `get()` and `fetch()` methods on `PartialTextChannel` to return `TextChannel` instead of just `Channel`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
