### PR TITLE
Handle batch rate limits correctly

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -129,7 +129,7 @@ class NyxxRest with ManagerMixin implements Nyxx {
   @override
   Future<void> close() {
     logger.info('Closing client');
-    return _doClose(this, () async => httpHandler.httpClient.close(), options.plugins);
+    return _doClose(this, () async => httpHandler.close(), options.plugins);
   }
 }
 
@@ -175,7 +175,7 @@ class NyxxGateway with ManagerMixin, EventMixin implements NyxxRest {
     logger.info('Closing client');
     return _doClose(this, () async {
       await gateway.close();
-      httpHandler.httpClient.close();
+      httpHandler.close();
     }, options.plugins);
   }
 }

--- a/lib/src/http/bucket.dart
+++ b/lib/src/http/bucket.dart
@@ -46,13 +46,18 @@ class HttpBucket {
 
   final Set<HttpRequest> _inflightRequests = {};
 
+  /// The number of in-flight requests in this bucket.
+  ///
+  /// {@macro in_flight_requests}
+  int get inflightRequests => _inflightRequests.length;
+
   int _remaining;
 
   /// The remaining number of requests that can be made in this reset period.
   ///
   /// This value accounts for in-flight requests, see [addInflightRequest] and
   /// [removeInflightRequest] for more information.
-  int get remaining => _remaining - _inflightRequests.length;
+  int get remaining => _remaining - inflightRequests;
 
   DateTime _resetAt;
 
@@ -124,7 +129,7 @@ class HttpBucket {
   /// Add [request] to this bucket's in-flight requests.
   ///
   /// {@template in_flight_requests}
-  /// In flight requests are requets that have been sent by the client but have not yet received a
+  /// In flight requests are requests that have been sent by the client but have not yet received a
   /// response from the API. These requests count towards the [remaining] count to avoid sending too
   /// many requests at once.
   /// {@endtemplate}

--- a/lib/src/http/handler.dart
+++ b/lib/src/http/handler.dart
@@ -150,7 +150,7 @@ class HttpHandler {
   }
 
   void _updateRatelimitBucket(HttpRequest request, BaseResponse response) {
-    final bucket = _buckets.values.firstWhereSafe(
+    HttpBucket? bucket = _buckets.values.firstWhereSafe(
       (bucket) => bucket.contains(response),
       orElse: () => HttpBucket.fromResponse(this, response),
     );
@@ -159,6 +159,7 @@ class HttpHandler {
       return;
     }
 
+    bucket.updateWith(response);
     _buckets[request.rateLimitId] = bucket;
   }
 
@@ -195,5 +196,11 @@ class HttpHandler {
     }
 
     return parsedResponse;
+  }
+
+  void close() {
+    httpClient.close();
+    _onRequestController.close();
+    _onResponseController.close();
   }
 }


### PR DESCRIPTION
# Description

Fixes an issue in the rate limiting code where multiple requests would be held but then sent at the same time - thereby overflowing the rate limit bucket.

Also fixes rate limit buckets not being updated on responses.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
