### PR TITLE
Add more bitwise operators on `Flags`

### DIFF
--- a/lib/src/utils/flags.dart
+++ b/lib/src/utils/flags.dart
@@ -22,7 +22,7 @@ class Flags<T extends Flags<T>> extends IterableBase<Flag<T>> with ToStringHelpe
   /// Return a set of flags that has all the flags set in both `this` and [other].
   Flags<T> operator &(Flags<T> other) => Flags(value & other.value);
 
-  /// Return a set of flags that has all the flags set in `this` but not in [other].
+  /// Return a set of flags that has all the flags set in `this` or in `other` but not in both.
   Flags<T> operator ^(Flags<T> other) => Flags(value ^ other.value);
 
   /// Returns the opposite of this set of flags.

--- a/lib/src/utils/flags.dart
+++ b/lib/src/utils/flags.dart
@@ -22,6 +22,12 @@ class Flags<T extends Flags<T>> extends IterableBase<Flag<T>> with ToStringHelpe
   /// Return a set of flags that has all the flags set in both `this` and [other].
   Flags<T> operator &(Flags<T> other) => Flags(value & other.value);
 
+  /// Return a set of flags that has all the flags set in `this` but not in [other].
+  Flags<T> operator ^(Flags<T> other) => Flags(value ^ other.value);
+
+  /// Returns the opposite of this set of flags.
+  Flags<T> operator ~() => Flags(~value);
+
   @override
   bool operator ==(Object other) => identical(this, other) || (other is Flags<T> && other.value == value);
 


### PR DESCRIPTION
# Description
Add more bitwise operators on `Flags`

## Connected issues & other potential problems

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
