### PR TITLE
Don't stringify classes without ToStringHelper

### DIFF
--- a/lib/src/utils/to_string_helper/mirrors_impl.dart
+++ b/lib/src/utils/to_string_helper/mirrors_impl.dart
@@ -65,15 +65,7 @@ String stringifyInstance(InstanceMirror mirror) {
   for (final identifier in outputtedGetters.map((getter) => getter.simpleName)) {
     late final String representation;
     try {
-      final value = mirror.getField(identifier);
-
-      // If the value has a custom `toString` implementation, call that. Otherwise recursively
-      // stringify the value.
-      if (value.type.instanceMembers[#toString]!.owner != reflectClass(Object)) {
-        representation = value.reflectee.toString();
-      } else {
-        representation = stringifyInstance(value);
-      }
+      representation = mirror.getField(identifier).reflectee.toString();
     } catch (e) {
       representation = '<$e>';
     }


### PR DESCRIPTION
# Description

Stringifying some classes without `ToStringHelper` (e.g `Stream`) results in async errors (e.g `Stream.first`) that are not caught in `stringifyInstance`, as well as filling up the console output.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
