### PR TITLE
Fix message update parsing

### DIFF
--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -805,7 +805,7 @@ class Gateway extends GatewayManager with EventParser {
       guildId: guildId,
       member: maybeParse(
         raw['member'],
-        (Map<String, Object?> raw) => PartialMember(
+        (Map<String, Object?> _) => PartialMember(
           id: Snowflake.parse((raw['author'] as Map<String, Object?>)['id']!),
           manager: client.guilds[guildId ?? Snowflake.zero].members,
         ),


### PR DESCRIPTION
# Description

Fix a bug in Gateway.parseMessageUpdate caused by a shadowed parameter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
