### PR TITLE
Add back a way for users to create ephemeral interaction followups

### DIFF
--- a/lib/src/http/managers/interaction_manager.dart
+++ b/lib/src/http/managers/interaction_manager.dart
@@ -282,7 +282,7 @@ class InteractionManager {
 
     final builtMessagePayload = builder.build();
     if (isEphemeral != null) {
-      built['flags'] = (built['flags'] as int? ?? 0) | (isEphemeral ? MessageFlags.ephemeral.value : 0);
+      builtMessagePayload['flags'] = (builtMessagePayload['flags'] as int? ?? 0) | (isEphemeral ? MessageFlags.ephemeral.value : 0);
     }
 
     final HttpRequest request;
@@ -297,13 +297,13 @@ class InteractionManager {
           filename: attachments[i].fileName,
         ));
 
-        ((built['attachments'] as List)[i] as Map)['id'] = i.toString();
+        ((builtMessagePayload['attachments'] as List)[i] as Map)['id'] = i.toString();
       }
 
       request = MultipartRequest(
         route,
         method: 'POST',
-        jsonPayload: jsonEncode(built),
+        jsonPayload: jsonEncode(builtMessagePayload),
         files: files,
         applyGlobalRateLimit: false,
       );
@@ -311,7 +311,7 @@ class InteractionManager {
       request = BasicRequest(
         route,
         method: 'POST',
-        body: jsonEncode(built),
+        body: jsonEncode(builtMessagePayload),
         applyGlobalRateLimit: false,
       );
     }

--- a/lib/src/http/managers/interaction_manager.dart
+++ b/lib/src/http/managers/interaction_manager.dart
@@ -280,7 +280,7 @@ class InteractionManager {
       ..webhooks(id: applicationId.toString())
       ..add(HttpRoutePart(token));
 
-    final built = builder.build();
+    final builtMessagePayload = builder.build();
     if (isEphemeral != null) {
       built['flags'] = (built['flags'] as int? ?? 0) | (isEphemeral ? MessageFlags.ephemeral.value : 0);
     }

--- a/lib/src/http/managers/interaction_manager.dart
+++ b/lib/src/http/managers/interaction_manager.dart
@@ -275,15 +275,19 @@ class InteractionManager {
   Future<void> deleteOriginalResponse(String token) => _deleteResponse(token, '@original');
 
   /// Create a followup to an interaction.
-  Future<Message> createFollowup(String token, MessageBuilder builder) async {
+  Future<Message> createFollowup(String token, MessageBuilder builder, {bool? isEphemeral}) async {
     final route = HttpRoute()
       ..webhooks(id: applicationId.toString())
       ..add(HttpRoutePart(token));
 
+    final built = builder.build();
+    if (isEphemeral != null) {
+      built['flags'] = (built['flags'] as int? ?? 0) | (isEphemeral ? MessageFlags.ephemeral.value : 0);
+    }
+
     final HttpRequest request;
     if (!identical(builder.attachments, sentinelList) && builder.attachments?.isNotEmpty == true) {
       final attachments = builder.attachments!;
-      final payload = builder.build();
 
       final files = <MultipartFile>[];
       for (int i = 0; i < attachments.length; i++) {
@@ -293,13 +297,13 @@ class InteractionManager {
           filename: attachments[i].fileName,
         ));
 
-        ((payload['attachments'] as List)[i] as Map)['id'] = i.toString();
+        ((built['attachments'] as List)[i] as Map)['id'] = i.toString();
       }
 
       request = MultipartRequest(
         route,
         method: 'POST',
-        jsonPayload: jsonEncode(payload),
+        jsonPayload: jsonEncode(built),
         files: files,
         applyGlobalRateLimit: false,
       );
@@ -307,7 +311,7 @@ class InteractionManager {
       request = BasicRequest(
         route,
         method: 'POST',
-        body: jsonEncode(builder.build()),
+        body: jsonEncode(built),
         applyGlobalRateLimit: false,
       );
     }

--- a/lib/src/models/interaction.dart
+++ b/lib/src/models/interaction.dart
@@ -138,7 +138,7 @@ mixin MessageResponse<T> on Interaction<T> {
   Future<void> deleteOriginalResponse() => manager.deleteOriginalResponse(token);
 
   /// Create a followup to this interaction.
-  Future<Message> createFollowup(MessageBuilder builder) => manager.createFollowup(token, builder);
+  Future<Message> createFollowup(MessageBuilder builder, {bool? isEphemeral}) => manager.createFollowup(token, builder, isEphemeral: isEphemeral);
 
   /// Fetch a followup to this interaction.
   Future<Message> fetchFollowup(Snowflake id) => manager.fetchFollowup(token, id);


### PR DESCRIPTION
# Description

#519 accidentally remove the ability to create ephemeral followups. This PR adds this functionality back.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
