### PR TITLE
Make all builders mutable

### DIFF
--- a/lib/src/builders/application_command.dart
+++ b/lib/src/builders/application_command.dart
@@ -8,23 +8,23 @@ import 'package:nyxx/src/models/permissions.dart';
 import 'package:nyxx/src/utils/flags.dart';
 
 class ApplicationCommandBuilder extends CreateBuilder<ApplicationCommand> {
-  final String name;
+  String name;
 
-  final Map<Locale, String>? nameLocalizations;
+  Map<Locale, String>? nameLocalizations;
 
-  final String? description;
+  String? description;
 
-  final Map<Locale, String>? descriptionLocalizations;
+  Map<Locale, String>? descriptionLocalizations;
 
-  final List<CommandOptionBuilder>? options;
+  List<CommandOptionBuilder>? options;
 
-  final Flags<Permissions>? defaultMemberPermissions;
+  Flags<Permissions>? defaultMemberPermissions;
 
-  final bool? hasDmPermission;
+  bool? hasDmPermission;
 
-  final ApplicationCommandType type;
+  ApplicationCommandType type;
 
-  final bool? isNsfw;
+  bool? isNsfw;
 
   ApplicationCommandBuilder({
     required this.name,
@@ -87,21 +87,21 @@ class ApplicationCommandBuilder extends CreateBuilder<ApplicationCommand> {
 }
 
 class ApplicationCommandUpdateBuilder extends UpdateBuilder<ApplicationCommand> {
-  final String? name;
+  String? name;
 
-  final Map<Locale, String>? nameLocalizations;
+  Map<Locale, String>? nameLocalizations;
 
-  final String? description;
+  String? description;
 
-  final Map<Locale, String>? descriptionLocalizations;
+  Map<Locale, String>? descriptionLocalizations;
 
-  final List<CommandOptionBuilder>? options;
+  List<CommandOptionBuilder>? options;
 
-  final Flags<Permissions>? defaultMemberPermissions;
+  Flags<Permissions>? defaultMemberPermissions;
 
-  final bool? hasDmPermission;
+  bool? hasDmPermission;
 
-  final bool? isNsfw;
+  bool? isNsfw;
 
   ApplicationCommandUpdateBuilder({
     this.name,
@@ -160,33 +160,33 @@ class ApplicationCommandUpdateBuilder extends UpdateBuilder<ApplicationCommand> 
 }
 
 class CommandOptionBuilder extends CreateBuilder<CommandOption> {
-  final CommandOptionType type;
+  CommandOptionType type;
 
-  final String name;
+  String name;
 
-  final Map<Locale, String>? nameLocalizations;
+  Map<Locale, String>? nameLocalizations;
 
-  final String description;
+  String description;
 
-  final Map<Locale, String>? descriptionLocalizations;
+  Map<Locale, String>? descriptionLocalizations;
 
-  final bool? isRequired;
+  bool? isRequired;
 
-  final List<CommandOptionChoiceBuilder<dynamic>>? choices;
+  List<CommandOptionChoiceBuilder<dynamic>>? choices;
 
-  final List<CommandOptionBuilder>? options;
+  List<CommandOptionBuilder>? options;
 
-  final List<ChannelType>? channelTypes;
+  List<ChannelType>? channelTypes;
 
-  final num? minValue;
+  num? minValue;
 
-  final num? maxValue;
+  num? maxValue;
 
-  final int? minLength;
+  int? minLength;
 
-  final int? maxLength;
+  int? maxLength;
 
-  final bool? hasAutocomplete;
+  bool? hasAutocomplete;
 
   CommandOptionBuilder({
     required this.type,
@@ -402,11 +402,11 @@ class CommandOptionBuilder extends CreateBuilder<CommandOption> {
 }
 
 class CommandOptionChoiceBuilder<T> extends CreateBuilder<CommandOptionChoice> {
-  final String name;
+  String name;
 
-  final Map<Locale, String>? nameLocalizations;
+  Map<Locale, String>? nameLocalizations;
 
-  final T value;
+  T value;
 
   CommandOptionChoiceBuilder({required this.name, this.nameLocalizations, required this.value});
 

--- a/lib/src/builders/application_role_connection.dart
+++ b/lib/src/builders/application_role_connection.dart
@@ -3,11 +3,11 @@ import 'package:nyxx/src/builders/sentinels.dart';
 import 'package:nyxx/src/models/user/application_role_connection.dart';
 
 class ApplicationRoleConnectionUpdateBuilder extends UpdateBuilder<ApplicationRoleConnection> {
-  final String? platformName;
+  String? platformName;
 
-  final String? platformUsername;
+  String? platformUsername;
 
-  final Map<String, String>? metadata;
+  Map<String, String>? metadata;
 
   ApplicationRoleConnectionUpdateBuilder({this.platformName = sentinelString, this.platformUsername = sentinelString, this.metadata});
 

--- a/lib/src/builders/channel/channel_position.dart
+++ b/lib/src/builders/channel/channel_position.dart
@@ -3,13 +3,13 @@ import 'package:nyxx/src/models/channel/guild_channel.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 
 class ChannelPositionBuilder extends UpdateBuilder<GuildChannel> {
-  final Snowflake channelId;
+  Snowflake channelId;
 
-  final int? position;
+  int? position;
 
-  final bool? lockPermissions;
+  bool? lockPermissions;
 
-  final Snowflake? parentId;
+  Snowflake? parentId;
 
   ChannelPositionBuilder({
     required this.channelId,

--- a/lib/src/builders/channel/forum_tag.dart
+++ b/lib/src/builders/channel/forum_tag.dart
@@ -3,13 +3,13 @@ import 'package:nyxx/src/models/channel/types/forum.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 
 class ForumTagBuilder extends CreateBuilder<ForumTag> {
-  final String name;
+  String name;
 
-  final bool? isModerated;
+  bool? isModerated;
 
-  final Snowflake? emojiId;
+  Snowflake? emojiId;
 
-  final String? emojiName;
+  String? emojiName;
 
   ForumTagBuilder({required this.name, this.isModerated, this.emojiId, this.emojiName});
 

--- a/lib/src/builders/channel/group_dm.dart
+++ b/lib/src/builders/channel/group_dm.dart
@@ -4,9 +4,9 @@ import 'package:nyxx/src/builders/builder.dart';
 import 'package:nyxx/src/models/channel/types/group_dm.dart';
 
 class GroupDmUpdateBuilder extends UpdateBuilder<GroupDmChannel> {
-  final String? name;
+  String? name;
 
-  final List<int>? icon;
+  List<int>? icon;
 
   GroupDmUpdateBuilder({this.name, this.icon});
 

--- a/lib/src/builders/channel/guild_channel.dart
+++ b/lib/src/builders/channel/guild_channel.dart
@@ -14,13 +14,13 @@ import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/utils/flags.dart';
 
 class GuildChannelBuilder<T extends GuildChannel> extends CreateBuilder<T> {
-  final String name;
+  String name;
 
-  final ChannelType type;
+  ChannelType type;
 
-  final int? position;
+  int? position;
 
-  final List<CreateBuilder<PermissionOverwrite>>? permissionOverwrites;
+  List<CreateBuilder<PermissionOverwrite>>? permissionOverwrites;
 
   GuildChannelBuilder({
     required this.name,
@@ -39,11 +39,11 @@ class GuildChannelBuilder<T extends GuildChannel> extends CreateBuilder<T> {
 }
 
 class GuildChannelUpdateBuilder<T extends GuildChannel> extends UpdateBuilder<T> {
-  final String? name;
+  String? name;
 
-  final int? position;
+  int? position;
 
-  final List<CreateBuilder<PermissionOverwrite>>? permissionOverwrites;
+  List<CreateBuilder<PermissionOverwrite>>? permissionOverwrites;
 
   GuildChannelUpdateBuilder({this.name, this.position = sentinelInteger, this.permissionOverwrites});
 
@@ -56,15 +56,15 @@ class GuildChannelUpdateBuilder<T extends GuildChannel> extends UpdateBuilder<T>
 }
 
 class GuildTextChannelBuilder extends GuildChannelBuilder<GuildTextChannel> {
-  final String? topic;
+  String? topic;
 
-  final Duration? rateLimitPerUser;
+  Duration? rateLimitPerUser;
 
-  final Snowflake? parentId;
+  Snowflake? parentId;
 
-  final bool? isNsfw;
+  bool? isNsfw;
 
-  final Duration? defaultAutoArchiveDuration;
+  Duration? defaultAutoArchiveDuration;
 
   GuildTextChannelBuilder({
     required super.name,
@@ -89,19 +89,19 @@ class GuildTextChannelBuilder extends GuildChannelBuilder<GuildTextChannel> {
 }
 
 class GuildTextChannelUpdateBuilder extends GuildChannelUpdateBuilder<GuildTextChannel> {
-  final ChannelType? type;
+  ChannelType? type;
 
-  final String? topic;
+  String? topic;
 
-  final bool? isNsfw;
+  bool? isNsfw;
 
-  final Duration? rateLimitPerUser;
+  Duration? rateLimitPerUser;
 
-  final Snowflake? parentId;
+  Snowflake? parentId;
 
-  final Duration? defaultAutoArchiveDuration;
+  Duration? defaultAutoArchiveDuration;
 
-  final Duration? defaultThreadRateLimitPerUser;
+  Duration? defaultThreadRateLimitPerUser;
 
   GuildTextChannelUpdateBuilder({
     super.name,
@@ -130,13 +130,13 @@ class GuildTextChannelUpdateBuilder extends GuildChannelUpdateBuilder<GuildTextC
 }
 
 class GuildAnnouncementChannelBuilder extends GuildChannelBuilder<GuildAnnouncementChannel> {
-  final String? topic;
+  String? topic;
 
-  final Snowflake? parentId;
+  Snowflake? parentId;
 
-  final bool? isNsfw;
+  bool? isNsfw;
 
-  final Duration? defaultAutoArchiveDuration;
+  Duration? defaultAutoArchiveDuration;
 
   GuildAnnouncementChannelBuilder({
     required super.name,
@@ -159,15 +159,15 @@ class GuildAnnouncementChannelBuilder extends GuildChannelBuilder<GuildAnnouncem
 }
 
 class GuildAnnouncementChannelUpdateBuilder extends GuildChannelUpdateBuilder<GuildAnnouncementChannel> {
-  final ChannelType? type;
+  ChannelType? type;
 
-  final String? topic;
+  String? topic;
 
-  final bool? isNsfw;
+  bool? isNsfw;
 
-  final Snowflake? parentId;
+  Snowflake? parentId;
 
-  final Duration? defaultAutoArchiveDuration;
+  Duration? defaultAutoArchiveDuration;
 
   GuildAnnouncementChannelUpdateBuilder({
     super.name,
@@ -192,21 +192,21 @@ class GuildAnnouncementChannelUpdateBuilder extends GuildChannelUpdateBuilder<Gu
 }
 
 class ForumChannelBuilder extends GuildChannelBuilder<ForumChannel> {
-  final String? topic;
+  String? topic;
 
-  final Duration? rateLimitPerUser;
+  Duration? rateLimitPerUser;
 
-  final Snowflake? parentId;
+  Snowflake? parentId;
 
-  final bool? isNsfw;
+  bool? isNsfw;
 
-  final Duration? defaultAutoArchiveDuration;
+  Duration? defaultAutoArchiveDuration;
 
-  final DefaultReaction? defaultReaction;
+  DefaultReaction? defaultReaction;
 
-  final List<CreateBuilder<ForumTag>>? tags;
+  List<CreateBuilder<ForumTag>>? tags;
 
-  final ForumSort? defaultSortOrder;
+  ForumSort? defaultSortOrder;
 
   ForumChannelBuilder({
     required super.name,
@@ -243,27 +243,27 @@ class ForumChannelBuilder extends GuildChannelBuilder<ForumChannel> {
 }
 
 class ForumChannelUpdateBuilder extends GuildChannelUpdateBuilder<ForumChannel> {
-  final String? topic;
+  String? topic;
 
-  final bool? isNsfw;
+  bool? isNsfw;
 
-  final Duration? rateLimitPerUser;
+  Duration? rateLimitPerUser;
 
-  final Snowflake? parentId;
+  Snowflake? parentId;
 
-  final Duration? defaultAutoArchiveDuration;
+  Duration? defaultAutoArchiveDuration;
 
-  final Flags<ChannelFlags>? flags;
+  Flags<ChannelFlags>? flags;
 
-  final List<CreateBuilder<ForumTag>>? tags;
+  List<CreateBuilder<ForumTag>>? tags;
 
-  final DefaultReaction? defaultReaction;
+  DefaultReaction? defaultReaction;
 
-  final Duration? defaultThreadRateLimitPerUser;
+  Duration? defaultThreadRateLimitPerUser;
 
-  final ForumSort? defaultSortOrder;
+  ForumSort? defaultSortOrder;
 
-  final ForumLayout? defaultLayout;
+  ForumLayout? defaultLayout;
 
   ForumChannelUpdateBuilder({
     super.name,
@@ -306,17 +306,17 @@ class ForumChannelUpdateBuilder extends GuildChannelUpdateBuilder<ForumChannel> 
 }
 
 abstract class _GuildVoiceOrStageChannelBuilder<T extends GuildChannel> extends GuildChannelBuilder<T> {
-  final int? bitRate;
+  int? bitRate;
 
-  final int? userLimit;
+  int? userLimit;
 
-  final Snowflake? parentId;
+  Snowflake? parentId;
 
-  final bool? isNsfw;
+  bool? isNsfw;
 
-  final String? rtcRegion;
+  String? rtcRegion;
 
-  final VideoQualityMode? videoQualityMode;
+  VideoQualityMode? videoQualityMode;
 
   _GuildVoiceOrStageChannelBuilder({
     required super.name,
@@ -372,17 +372,17 @@ class GuildStageChannelBuilder extends _GuildVoiceOrStageChannelBuilder<GuildSta
 }
 
 class _GuildVoiceOrStageChannelUpdateBuilder<T extends GuildChannel> extends GuildChannelUpdateBuilder<T> {
-  final bool? isNsfw;
+  bool? isNsfw;
 
-  final int? bitRate;
+  int? bitRate;
 
-  final int? userLimit;
+  int? userLimit;
 
-  final Snowflake? parentId;
+  Snowflake? parentId;
 
-  final String? rtcRegion;
+  String? rtcRegion;
 
-  final VideoQualityMode? videoQualityMode;
+  VideoQualityMode? videoQualityMode;
 
   _GuildVoiceOrStageChannelUpdateBuilder({
     super.name,

--- a/lib/src/builders/channel/stage_instance.dart
+++ b/lib/src/builders/channel/stage_instance.dart
@@ -2,11 +2,11 @@ import 'package:nyxx/src/builders/builder.dart';
 import 'package:nyxx/src/models/channel/stage_instance.dart';
 
 class StageInstanceBuilder extends CreateBuilder<StageInstance> {
-  final String topic;
+  String topic;
 
-  final PrivacyLevel? privacyLevel;
+  PrivacyLevel? privacyLevel;
 
-  final bool? sendStartNotification;
+  bool? sendStartNotification;
 
   StageInstanceBuilder({
     required this.topic,
@@ -23,9 +23,9 @@ class StageInstanceBuilder extends CreateBuilder<StageInstance> {
 }
 
 class StageInstanceUpdateBuilder extends UpdateBuilder<StageInstance> {
-  final String? topic;
+  String? topic;
 
-  final PrivacyLevel? privacyLevel;
+  PrivacyLevel? privacyLevel;
 
   StageInstanceUpdateBuilder({this.topic, this.privacyLevel});
 

--- a/lib/src/builders/channel/thread.dart
+++ b/lib/src/builders/channel/thread.dart
@@ -7,11 +7,11 @@ import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/utils/flags.dart';
 
 class ThreadFromMessageBuilder extends CreateBuilder<Thread> {
-  final String name;
+  String name;
 
-  final Duration? autoArchiveDuration;
+  Duration? autoArchiveDuration;
 
-  final Duration? rateLimitPerUser;
+  Duration? rateLimitPerUser;
 
   ThreadFromMessageBuilder({required this.name, this.autoArchiveDuration, this.rateLimitPerUser});
 
@@ -29,15 +29,15 @@ class ThreadBuilder extends CreateBuilder<Thread> {
   static const archiveThreeDays = Duration(minutes: 4320);
   static const archiveOneWeek = Duration(minutes: 10080);
 
-  final String name;
+  String name;
 
-  final Duration? autoArchiveDuration;
+  Duration? autoArchiveDuration;
 
-  final ChannelType type;
+  ChannelType type;
 
-  final bool? invitable;
+  bool? invitable;
 
-  final Duration? rateLimitPerUser;
+  Duration? rateLimitPerUser;
 
   ThreadBuilder({required this.name, this.autoArchiveDuration, required this.type, this.invitable, this.rateLimitPerUser});
 
@@ -52,15 +52,15 @@ class ThreadBuilder extends CreateBuilder<Thread> {
 }
 
 class ForumThreadBuilder extends CreateBuilder<Thread> {
-  final String name;
+  String name;
 
-  final Duration? autoArchiveDuration;
+  Duration? autoArchiveDuration;
 
-  final Duration? rateLimitPerUser;
+  Duration? rateLimitPerUser;
 
-  final MessageBuilder message;
+  MessageBuilder message;
 
-  final List<Snowflake>? appliedTags;
+  List<Snowflake>? appliedTags;
 
   ForumThreadBuilder({required this.name, this.autoArchiveDuration, this.rateLimitPerUser, required this.message, this.appliedTags});
 
@@ -75,21 +75,21 @@ class ForumThreadBuilder extends CreateBuilder<Thread> {
 }
 
 class ThreadUpdateBuilder extends UpdateBuilder<Thread> {
-  final String? name;
+  String? name;
 
-  final bool? isArchived;
+  bool? isArchived;
 
-  final Duration? autoArchiveDuration;
+  Duration? autoArchiveDuration;
 
-  final bool? isLocked;
+  bool? isLocked;
 
-  final bool? isInvitable;
+  bool? isInvitable;
 
-  final Duration? rateLimitPerUser;
+  Duration? rateLimitPerUser;
 
-  final Flags<ChannelFlags>? flags;
+  Flags<ChannelFlags>? flags;
 
-  final List<Snowflake>? appliedTags;
+  List<Snowflake>? appliedTags;
 
   ThreadUpdateBuilder({
     this.name,

--- a/lib/src/builders/emoji/emoji.dart
+++ b/lib/src/builders/emoji/emoji.dart
@@ -5,15 +5,15 @@ import 'package:nyxx/src/models/snowflake.dart';
 
 class EmojiBuilder implements CreateBuilder<GuildEmoji> {
   /// The name of the emoji.
-  final String name;
+  String name;
 
   /// The 128x128 emoji image.
-  final ImageBuilder image;
+  ImageBuilder image;
 
   /// The roles allowed to use this emoji.
-  final Iterable<Snowflake> roles;
+  Iterable<Snowflake> roles;
 
-  const EmojiBuilder({
+  EmojiBuilder({
     required this.name,
     required this.image,
     required this.roles,
@@ -29,12 +29,12 @@ class EmojiBuilder implements CreateBuilder<GuildEmoji> {
 
 class EmojiUpdateBuilder implements UpdateBuilder<GuildEmoji> {
   /// The name of the emoji.
-  final String? name;
+  String? name;
 
   /// The roles allowed to use this emoji.
-  final Iterable<Snowflake>? roles;
+  Iterable<Snowflake>? roles;
 
-  const EmojiUpdateBuilder({
+  EmojiUpdateBuilder({
     this.name,
     this.roles,
   });

--- a/lib/src/builders/emoji/reaction.dart
+++ b/lib/src/builders/emoji/reaction.dart
@@ -2,9 +2,9 @@ import 'package:nyxx/src/models/emoji.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 
 class ReactionBuilder {
-  final String name;
+  String name;
 
-  final Snowflake? id;
+  Snowflake? id;
 
   ReactionBuilder({required this.name, required this.id});
 

--- a/lib/src/builders/guild/auto_moderation.dart
+++ b/lib/src/builders/guild/auto_moderation.dart
@@ -3,21 +3,21 @@ import 'package:nyxx/src/models/guild/auto_moderation.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 
 class AutoModerationRuleBuilder extends CreateBuilder<AutoModerationRule> {
-  final String name;
+  String name;
 
-  final AutoModerationEventType eventType;
+  AutoModerationEventType eventType;
 
-  final TriggerType triggerType;
+  TriggerType triggerType;
 
-  final TriggerMetadata? metadata;
+  TriggerMetadata? metadata;
 
-  final List<AutoModerationAction> actions;
+  List<AutoModerationAction> actions;
 
-  final bool? isEnabled;
+  bool? isEnabled;
 
-  final List<Snowflake>? exemptRoleIds;
+  List<Snowflake>? exemptRoleIds;
 
-  final List<Snowflake>? exemptChannelIds;
+  List<Snowflake>? exemptChannelIds;
 
   AutoModerationRuleBuilder({
     required this.name,
@@ -63,19 +63,19 @@ class AutoModerationRuleBuilder extends CreateBuilder<AutoModerationRule> {
 }
 
 class AutoModerationRuleUpdateBuilder extends UpdateBuilder<AutoModerationRule> {
-  final String? name;
+  String? name;
 
-  final AutoModerationEventType? eventType;
+  AutoModerationEventType? eventType;
 
-  final TriggerMetadata? metadata;
+  TriggerMetadata? metadata;
 
-  final List<AutoModerationAction>? actions;
+  List<AutoModerationAction>? actions;
 
-  final bool? isEnabled;
+  bool? isEnabled;
 
-  final List<Snowflake>? exemptRoleIds;
+  List<Snowflake>? exemptRoleIds;
 
-  final List<Snowflake>? exemptChannelIds;
+  List<Snowflake>? exemptChannelIds;
 
   AutoModerationRuleUpdateBuilder({
     this.name,

--- a/lib/src/builders/guild/guild.dart
+++ b/lib/src/builders/guild/guild.dart
@@ -10,27 +10,27 @@ import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/utils/flags.dart';
 
 class GuildBuilder extends CreateBuilder<Guild> {
-  final String name;
+  String name;
 
-  final ImageBuilder? icon;
+  ImageBuilder? icon;
 
-  final VerificationLevel? verificationLevel;
+  VerificationLevel? verificationLevel;
 
-  final MessageNotificationLevel? defaultMessageNotificationLevel;
+  MessageNotificationLevel? defaultMessageNotificationLevel;
 
-  final ExplicitContentFilterLevel? explicitContentFilterLevel;
+  ExplicitContentFilterLevel? explicitContentFilterLevel;
 
-  final List<RoleBuilder>? roles;
+  List<RoleBuilder>? roles;
 
-  final List<GuildChannelBuilder>? channels;
+  List<GuildChannelBuilder>? channels;
 
-  final Snowflake? afkChannelId;
+  Snowflake? afkChannelId;
 
-  final Duration? afkTimeout;
+  Duration? afkTimeout;
 
-  final Snowflake? systemChannelId;
+  Snowflake? systemChannelId;
 
-  final Flags<SystemChannelFlags>? systemChannelFlags;
+  Flags<SystemChannelFlags>? systemChannelFlags;
 
   GuildBuilder({
     required this.name,
@@ -63,43 +63,43 @@ class GuildBuilder extends CreateBuilder<Guild> {
 }
 
 class GuildUpdateBuilder extends UpdateBuilder<Guild> {
-  final String? name;
+  String? name;
 
-  final VerificationLevel? verificationLevel;
+  VerificationLevel? verificationLevel;
 
-  final MessageNotificationLevel? defaultMessageNotificationLevel;
+  MessageNotificationLevel? defaultMessageNotificationLevel;
 
-  final ExplicitContentFilterLevel? explicitContentFilterLevel;
+  ExplicitContentFilterLevel? explicitContentFilterLevel;
 
-  final Snowflake? afkChannelId;
+  Snowflake? afkChannelId;
 
-  final Duration? afkTimeout;
+  Duration? afkTimeout;
 
-  final ImageBuilder? icon;
+  ImageBuilder? icon;
 
-  final Snowflake? newOwnerId;
+  Snowflake? newOwnerId;
 
-  final ImageBuilder? splash;
+  ImageBuilder? splash;
 
-  final ImageBuilder? discoverySplash;
+  ImageBuilder? discoverySplash;
 
-  final ImageBuilder? banner;
+  ImageBuilder? banner;
 
-  final Snowflake? systemChannelId;
+  Snowflake? systemChannelId;
 
-  final Flags<SystemChannelFlags>? systemChannelFlags;
+  Flags<SystemChannelFlags>? systemChannelFlags;
 
-  final Snowflake? rulesChannelId;
+  Snowflake? rulesChannelId;
 
-  final Snowflake? publicUpdatesChannelId;
+  Snowflake? publicUpdatesChannelId;
 
-  final Locale? preferredLocale;
+  Locale? preferredLocale;
 
-  final Flags<GuildFeatures>? features;
+  Flags<GuildFeatures>? features;
 
-  final String? description;
+  String? description;
 
-  final bool? premiumProgressBarEnabled;
+  bool? premiumProgressBarEnabled;
 
   GuildUpdateBuilder({
     this.name,

--- a/lib/src/builders/guild/member.dart
+++ b/lib/src/builders/guild/member.dart
@@ -5,17 +5,17 @@ import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/utils/flags.dart';
 
 class MemberBuilder extends CreateBuilder<Member> {
-  final String accessToken;
+  String accessToken;
 
-  final Snowflake userId;
+  Snowflake userId;
 
-  final String? nick;
+  String? nick;
 
-  final List<Snowflake>? roleIds;
+  List<Snowflake>? roleIds;
 
-  final bool? isMute;
+  bool? isMute;
 
-  final bool? isDeaf;
+  bool? isDeaf;
 
   MemberBuilder({
     required this.accessToken,
@@ -37,19 +37,19 @@ class MemberBuilder extends CreateBuilder<Member> {
 }
 
 class MemberUpdateBuilder extends UpdateBuilder<Member> {
-  final String? nick;
+  String? nick;
 
-  final List<Snowflake>? roleIds;
+  List<Snowflake>? roleIds;
 
-  final bool? isMute;
+  bool? isMute;
 
-  final bool? isDeaf;
+  bool? isDeaf;
 
-  final Snowflake? voiceChannelId;
+  Snowflake? voiceChannelId;
 
-  final DateTime? communicationDisabledUntil;
+  DateTime? communicationDisabledUntil;
 
-  final Flags<MemberFlags>? flags;
+  Flags<MemberFlags>? flags;
 
   MemberUpdateBuilder({
     this.nick = sentinelString,
@@ -74,7 +74,7 @@ class MemberUpdateBuilder extends UpdateBuilder<Member> {
 }
 
 class CurrentMemberUpdateBuilder extends UpdateBuilder<Member> {
-  final String? nick;
+  String? nick;
 
   CurrentMemberUpdateBuilder({this.nick = sentinelString});
 

--- a/lib/src/builders/guild/scheduled_event.dart
+++ b/lib/src/builders/guild/scheduled_event.dart
@@ -6,23 +6,23 @@ import 'package:nyxx/src/models/guild/scheduled_event.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 
 class ScheduledEventBuilder extends CreateBuilder<ScheduledEvent> {
-  final Snowflake? channelId;
+  Snowflake? channelId;
 
-  final EntityMetadata? metadata;
+  EntityMetadata? metadata;
 
-  final String name;
+  String name;
 
-  final PrivacyLevel privacyLevel;
+  PrivacyLevel privacyLevel;
 
-  final DateTime scheduledStartTime;
+  DateTime scheduledStartTime;
 
-  final DateTime? scheduledEndTime;
+  DateTime? scheduledEndTime;
 
-  final String? description;
+  String? description;
 
-  final ScheduledEntityType type;
+  ScheduledEntityType type;
 
-  final ImageBuilder? image;
+  ImageBuilder? image;
 
   ScheduledEventBuilder({
     required this.channelId,
@@ -51,25 +51,25 @@ class ScheduledEventBuilder extends CreateBuilder<ScheduledEvent> {
 }
 
 class ScheduledEventUpdateBuilder extends UpdateBuilder<ScheduledEvent> {
-  final Snowflake? channelId;
+  Snowflake? channelId;
 
-  final EntityMetadata? metadata;
+  EntityMetadata? metadata;
 
-  final String? name;
+  String? name;
 
-  final PrivacyLevel? privacyLevel;
+  PrivacyLevel? privacyLevel;
 
-  final DateTime? scheduledStartTime;
+  DateTime? scheduledStartTime;
 
-  final DateTime? scheduledEndTime;
+  DateTime? scheduledEndTime;
 
-  final String? description;
+  String? description;
 
-  final ScheduledEntityType? type;
+  ScheduledEntityType? type;
 
-  final EventStatus? status;
+  EventStatus? status;
 
-  final ImageBuilder? image;
+  ImageBuilder? image;
 
   ScheduledEventUpdateBuilder({
     this.channelId = sentinelSnowflake,

--- a/lib/src/builders/guild/template.dart
+++ b/lib/src/builders/guild/template.dart
@@ -3,9 +3,9 @@ import 'package:nyxx/src/builders/sentinels.dart';
 import 'package:nyxx/src/models/guild/template.dart';
 
 class GuildTemplateBuilder extends CreateBuilder<GuildTemplate> {
-  final String name;
+  String name;
 
-  final String? description;
+  String? description;
 
   GuildTemplateBuilder({required this.name, this.description});
 
@@ -17,9 +17,9 @@ class GuildTemplateBuilder extends CreateBuilder<GuildTemplate> {
 }
 
 class GuildTemplateUpdateBuilder extends UpdateBuilder<GuildTemplate> {
-  final String? name;
+  String? name;
 
-  final String? description;
+  String? description;
 
   GuildTemplateUpdateBuilder({this.name, this.description = sentinelString});
 

--- a/lib/src/builders/guild/welcome_screen.dart
+++ b/lib/src/builders/guild/welcome_screen.dart
@@ -3,11 +3,11 @@ import 'package:nyxx/src/builders/sentinels.dart';
 import 'package:nyxx/src/models/guild/welcome_screen.dart';
 
 class WelcomeScreenUpdateBuilder extends UpdateBuilder<WelcomeScreen> {
-  final bool? isEnabled;
+  bool? isEnabled;
 
-  final List<WelcomeScreenChannel>? channels;
+  List<WelcomeScreenChannel>? channels;
 
-  final String? description;
+  String? description;
 
   WelcomeScreenUpdateBuilder({this.isEnabled, this.channels, this.description = sentinelString});
 

--- a/lib/src/builders/guild/widget.dart
+++ b/lib/src/builders/guild/widget.dart
@@ -4,9 +4,9 @@ import 'package:nyxx/src/models/guild/guild_widget.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 
 class WidgetSettingsUpdateBuilder extends UpdateBuilder<WidgetSettings> {
-  final bool? isEnabled;
+  bool? isEnabled;
 
-  final Snowflake? channelId;
+  Snowflake? channelId;
 
   WidgetSettingsUpdateBuilder({this.isEnabled, this.channelId = sentinelSnowflake});
 

--- a/lib/src/builders/image.dart
+++ b/lib/src/builders/image.dart
@@ -4,16 +4,16 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 
 class ImageBuilder {
-  final List<int> data;
-  final String format;
+  List<int> data;
+  String format;
 
-  const ImageBuilder({required this.data, required this.format});
+  ImageBuilder({required this.data, required this.format});
 
-  const ImageBuilder.png(this.data) : format = 'png';
+  ImageBuilder.png(this.data) : format = 'png';
 
-  const ImageBuilder.jpeg(this.data) : format = 'jpeg';
+  ImageBuilder.jpeg(this.data) : format = 'jpeg';
 
-  const ImageBuilder.gif(this.data) : format = 'gif';
+  ImageBuilder.gif(this.data) : format = 'gif';
 
   static Future<ImageBuilder> fromFile(File file, {String? format}) async {
     format ??= p.extension(file.path);

--- a/lib/src/builders/interaction_response.dart
+++ b/lib/src/builders/interaction_response.dart
@@ -5,9 +5,9 @@ import 'package:nyxx/src/builders/message/message.dart';
 import 'package:nyxx/src/models/message/message.dart';
 
 class InteractionResponseBuilder extends CreateBuilder<InteractionResponseBuilder> {
-  final InteractionCallbackType type;
+  InteractionCallbackType type;
 
-  final dynamic data;
+  dynamic data;
 
   InteractionResponseBuilder({required this.type, required this.data});
 
@@ -71,7 +71,7 @@ class InteractionResponseBuilder extends CreateBuilder<InteractionResponseBuilde
 }
 
 class _EphemeralMessageBuilder extends MessageBuilder {
-  final bool? isEphemeral;
+  bool? isEphemeral;
 
   _EphemeralMessageBuilder({
     required super.content,
@@ -116,11 +116,11 @@ enum InteractionCallbackType {
 }
 
 class ModalBuilder extends CreateBuilder<ModalBuilder> {
-  final String customId;
+  String customId;
 
-  final String title;
+  String title;
 
-  final List<TextInputBuilder> components;
+  List<TextInputBuilder> components;
 
   ModalBuilder({required this.customId, required this.title, required this.components});
 

--- a/lib/src/builders/invite.dart
+++ b/lib/src/builders/invite.dart
@@ -4,19 +4,19 @@ import 'package:nyxx/src/models/invite/invite.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 
 class InviteBuilder extends CreateBuilder<Invite> {
-  final Duration? maxAge;
+  Duration? maxAge;
 
-  final int? maxUses;
+  int? maxUses;
 
-  final bool? isTemporary;
+  bool? isTemporary;
 
-  final bool? isUnique;
+  bool? isUnique;
 
-  final TargetType? targetType;
+  TargetType? targetType;
 
-  final Snowflake? targetUserId;
+  Snowflake? targetUserId;
 
-  final Snowflake? targetApplicationId;
+  Snowflake? targetApplicationId;
 
   InviteBuilder({
     this.maxAge = sentinelDuration,

--- a/lib/src/builders/message/allowed_mentions.dart
+++ b/lib/src/builders/message/allowed_mentions.dart
@@ -1,13 +1,13 @@
 import 'package:nyxx/src/models/snowflake.dart';
 
 class AllowedMentions {
-  final List<String>? parse;
+  List<String>? parse;
 
-  final List<Snowflake>? users;
+  List<Snowflake>? users;
 
-  final List<Snowflake>? roles;
+  List<Snowflake>? roles;
 
-  final bool? repliedUser;
+  bool? repliedUser;
 
   AllowedMentions({this.parse, this.users, this.roles, this.repliedUser});
 

--- a/lib/src/builders/message/attachment.dart
+++ b/lib/src/builders/message/attachment.dart
@@ -6,11 +6,11 @@ import 'package:nyxx/src/builders/builder.dart';
 import 'package:nyxx/src/models/message/attachment.dart';
 
 class AttachmentBuilder extends Builder<Attachment> {
-  final List<int> data;
+  List<int> data;
 
-  final String? fileName;
+  String? fileName;
 
-  final String? description;
+  String? description;
 
   AttachmentBuilder({required this.data, this.fileName, this.description});
 

--- a/lib/src/builders/message/component.dart
+++ b/lib/src/builders/message/component.dart
@@ -4,7 +4,7 @@ import 'package:nyxx/src/models/emoji.dart';
 import 'package:nyxx/src/models/message/component.dart';
 
 abstract class MessageComponentBuilder extends CreateBuilder<MessageComponent> {
-  final MessageComponentType type;
+  MessageComponentType type;
 
   MessageComponentBuilder({required this.type});
 
@@ -13,7 +13,7 @@ abstract class MessageComponentBuilder extends CreateBuilder<MessageComponent> {
 }
 
 class ActionRowBuilder extends MessageComponentBuilder {
-  final List<MessageComponentBuilder> components;
+  List<MessageComponentBuilder> components;
 
   ActionRowBuilder({required this.components}) : super(type: MessageComponentType.actionRow);
 
@@ -25,17 +25,17 @@ class ActionRowBuilder extends MessageComponentBuilder {
 }
 
 class ButtonBuilder extends MessageComponentBuilder {
-  final ButtonStyle style;
+  ButtonStyle style;
 
-  final String? label;
+  String? label;
 
-  final Emoji? emoji;
+  Emoji? emoji;
 
-  final String? customId;
+  String? customId;
 
-  final Uri? url;
+  Uri? url;
 
-  final bool? isDisabled;
+  bool? isDisabled;
 
   ButtonBuilder({
     required this.style,
@@ -64,19 +64,19 @@ class ButtonBuilder extends MessageComponentBuilder {
 }
 
 class SelectMenuBuilder extends MessageComponentBuilder {
-  final String customId;
+  String customId;
 
-  final List<SelectMenuOptionBuilder>? options;
+  List<SelectMenuOptionBuilder>? options;
 
-  final List<ChannelType>? channelTypes;
+  List<ChannelType>? channelTypes;
 
-  final String? placeholder;
+  String? placeholder;
 
-  final int? minValues;
+  int? minValues;
 
-  final int? maxValues;
+  int? maxValues;
 
-  final bool? isDisabled;
+  bool? isDisabled;
 
   SelectMenuBuilder({
     required super.type,
@@ -103,15 +103,15 @@ class SelectMenuBuilder extends MessageComponentBuilder {
 }
 
 class SelectMenuOptionBuilder extends CreateBuilder<SelectMenuOption> {
-  final String label;
+  String label;
 
-  final String value;
+  String value;
 
-  final String? description;
+  String? description;
 
-  final Emoji? emoji;
+  Emoji? emoji;
 
-  final bool? isDefault;
+  bool? isDefault;
 
   SelectMenuOptionBuilder({
     required this.label,
@@ -137,21 +137,21 @@ class SelectMenuOptionBuilder extends CreateBuilder<SelectMenuOption> {
 }
 
 class TextInputBuilder extends MessageComponentBuilder {
-  final String customId;
+  String customId;
 
-  final TextInputStyle style;
+  TextInputStyle style;
 
-  final String label;
+  String label;
 
-  final int? minLength;
+  int? minLength;
 
-  final int? maxLength;
+  int? maxLength;
 
-  final bool? isRequired;
+  bool? isRequired;
 
-  final String? value;
+  String? value;
 
-  final String? placeholder;
+  String? placeholder;
 
   TextInputBuilder({
     required this.customId,

--- a/lib/src/builders/message/message.dart
+++ b/lib/src/builders/message/message.dart
@@ -8,29 +8,29 @@ import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 
 class MessageBuilder extends CreateBuilder<Message> {
-  final String? content;
+  String? content;
 
-  final dynamic /* int | String */ nonce;
+  dynamic /* int | String */ nonce;
 
-  final bool? tts;
+  bool? tts;
 
-  final List<Embed>? embeds;
+  List<Embed>? embeds;
 
-  final AllowedMentions? allowedMentions;
+  AllowedMentions? allowedMentions;
 
-  final Snowflake? replyId;
+  Snowflake? replyId;
 
-  final bool? requireReplyToExist;
+  bool? requireReplyToExist;
 
-  final List<ActionRowBuilder>? components;
+  List<ActionRowBuilder>? components;
 
-  final List<Snowflake>? stickerIds;
+  List<Snowflake>? stickerIds;
 
-  final List<AttachmentBuilder>? attachments;
+  List<AttachmentBuilder>? attachments;
 
-  final bool? suppressEmbeds;
+  bool? suppressEmbeds;
 
-  final bool? suppressNotifications;
+  bool? suppressNotifications;
 
   MessageBuilder({
     this.content,
@@ -134,17 +134,17 @@ class MessageBuilder extends CreateBuilder<Message> {
 }
 
 class MessageUpdateBuilder extends UpdateBuilder<Message> {
-  final String? content;
+  String? content;
 
-  final List<Embed>? embeds;
+  List<Embed>? embeds;
 
-  final bool? suppressEmbeds;
+  bool? suppressEmbeds;
 
-  final AllowedMentions? allowedMentions;
+  AllowedMentions? allowedMentions;
 
-  final List<ActionRowBuilder>? components;
+  List<ActionRowBuilder>? components;
 
-  final List<AttachmentBuilder>? attachments;
+  List<AttachmentBuilder>? attachments;
 
   MessageUpdateBuilder({
     this.content = sentinelString,

--- a/lib/src/builders/permission_overwrite.dart
+++ b/lib/src/builders/permission_overwrite.dart
@@ -5,13 +5,13 @@ import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/utils/flags.dart';
 
 class PermissionOverwriteBuilder extends CreateBuilder<PermissionOverwrite> {
-  final Snowflake id;
+  Snowflake id;
 
-  final PermissionOverwriteType type;
+  PermissionOverwriteType type;
 
-  final Flags<Permissions>? allow;
+  Flags<Permissions>? allow;
 
-  final Flags<Permissions>? deny;
+  Flags<Permissions>? deny;
 
   PermissionOverwriteBuilder({required this.id, required this.type, this.allow, this.deny});
 

--- a/lib/src/builders/presence.dart
+++ b/lib/src/builders/presence.dart
@@ -3,13 +3,13 @@ import 'package:nyxx/src/models/gateway/events/presence.dart';
 import 'package:nyxx/src/models/presence.dart';
 
 class PresenceBuilder extends CreateBuilder<PresenceUpdateEvent> {
-  final DateTime? since;
+  DateTime? since;
 
-  final List<ActivityBuilder>? activities;
+  List<ActivityBuilder>? activities;
 
-  final CurrentUserStatus status;
+  CurrentUserStatus status;
 
-  final bool isAfk;
+  bool isAfk;
 
   PresenceBuilder({this.since, this.activities, required this.status, required this.isAfk});
 
@@ -38,11 +38,11 @@ enum CurrentUserStatus {
 }
 
 class ActivityBuilder extends CreateBuilder<Activity> {
-  final String name;
+  String name;
 
-  final ActivityType type;
+  ActivityType type;
 
-  final Uri? url;
+  Uri? url;
 
   ActivityBuilder({required this.name, required this.type, this.url});
 

--- a/lib/src/builders/role.dart
+++ b/lib/src/builders/role.dart
@@ -7,19 +7,19 @@ import 'package:nyxx/src/models/role.dart';
 import 'package:nyxx/src/utils/flags.dart';
 
 class RoleBuilder extends CreateBuilder<Role> {
-  final String? name;
+  String? name;
 
-  final Flags<Permissions>? permissions;
+  Flags<Permissions>? permissions;
 
-  final DiscordColor? color;
+  DiscordColor? color;
 
-  final bool? isHoisted;
+  bool? isHoisted;
 
-  final ImageBuilder? icon;
+  ImageBuilder? icon;
 
-  final String? unicodeEmoji;
+  String? unicodeEmoji;
 
-  final bool? isMentionable;
+  bool? isMentionable;
 
   RoleBuilder({
     this.name,
@@ -44,19 +44,19 @@ class RoleBuilder extends CreateBuilder<Role> {
 }
 
 class RoleUpdateBuilder extends UpdateBuilder<Role> {
-  final String? name;
+  String? name;
 
-  final Permissions? permissions;
+  Permissions? permissions;
 
-  final DiscordColor? color;
+  DiscordColor? color;
 
-  final bool? isHoisted;
+  bool? isHoisted;
 
-  final ImageBuilder? icon;
+  ImageBuilder? icon;
 
-  final String? unicodeEmoji;
+  String? unicodeEmoji;
 
-  final bool? isMentionable;
+  bool? isMentionable;
 
   RoleUpdateBuilder({
     this.name,

--- a/lib/src/builders/sticker.dart
+++ b/lib/src/builders/sticker.dart
@@ -5,16 +5,16 @@ import 'package:nyxx/src/models/sticker/guild_sticker.dart';
 
 class StickerBuilder implements CreateBuilder<GuildSticker> {
   /// Name of the sticker (2-30 characters)
-  final String name;
+  String name;
 
   /// Description of the sticker (empty or 2-100 characters)
-  final String description;
+  String description;
 
   /// Autocomplete/suggestion tags for the sticker (max 200 characters)
-  final String tags;
+  String tags;
 
   /// The sticker file to upload
-  final ImageBuilder file;
+  ImageBuilder file;
 
   StickerBuilder({required this.name, this.description = '', required this.tags, required this.file});
 
@@ -28,13 +28,13 @@ class StickerBuilder implements CreateBuilder<GuildSticker> {
 
 class StickerUpdateBuilder implements UpdateBuilder<GuildSticker> {
   /// Name of the sticker (2-30 characters)
-  final String? name;
+  String? name;
 
   /// Description of the sticker (empty or 2-100 characters)
-  final String description;
+  String description;
 
   /// Autocomplete/suggestion tags for the sticker (max 200 characters)
-  final String? tags;
+  String? tags;
 
   StickerUpdateBuilder({this.name, this.description = sentinelString, this.tags});
 

--- a/lib/src/builders/user.dart
+++ b/lib/src/builders/user.dart
@@ -3,10 +3,10 @@ import 'package:nyxx/src/builders/image.dart';
 import 'package:nyxx/src/models/user/user.dart';
 
 class UserUpdateBuilder extends UpdateBuilder<User> {
-  final String? username;
-  final ImageBuilder? avatar;
+  String? username;
+  ImageBuilder? avatar;
 
-  const UserUpdateBuilder({this.username, this.avatar});
+  UserUpdateBuilder({this.username, this.avatar});
 
   @override
   Map<String, Object?> build() => {

--- a/lib/src/builders/voice.dart
+++ b/lib/src/builders/voice.dart
@@ -4,9 +4,9 @@ import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/voice/voice_state.dart';
 
 class VoiceStateUpdateBuilder extends UpdateBuilder<VoiceState> {
-  final Snowflake? channelId;
+  Snowflake? channelId;
 
-  final bool? suppress;
+  bool? suppress;
 
   VoiceStateUpdateBuilder({this.channelId, this.suppress});
 
@@ -18,7 +18,7 @@ class VoiceStateUpdateBuilder extends UpdateBuilder<VoiceState> {
 }
 
 class CurrentUserVoiceStateUpdateBuilder extends VoiceStateUpdateBuilder {
-  final DateTime? requestToSpeakTimeStamp;
+  DateTime? requestToSpeakTimeStamp;
 
   CurrentUserVoiceStateUpdateBuilder({super.channelId, super.suppress, this.requestToSpeakTimeStamp = sentinelDateTime});
 
@@ -30,11 +30,11 @@ class CurrentUserVoiceStateUpdateBuilder extends VoiceStateUpdateBuilder {
 }
 
 class GatewayVoiceStateBuilder extends CreateBuilder<VoiceState> {
-  final Snowflake? channelId;
+  Snowflake? channelId;
 
-  final bool isMuted;
+  bool isMuted;
 
-  final bool isDeafened;
+  bool isDeafened;
 
   GatewayVoiceStateBuilder({required this.channelId, required this.isMuted, required this.isDeafened});
 

--- a/lib/src/builders/webhook.dart
+++ b/lib/src/builders/webhook.dart
@@ -5,12 +5,12 @@ import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/webhook.dart';
 
 class WebhookBuilder extends CreateBuilder<Webhook> {
-  final String name;
+  String name;
 
   // Not used in build, but used to determine the proper route when creating webhooks.
-  final Snowflake channelId;
+  Snowflake channelId;
 
-  final ImageBuilder? avatar;
+  ImageBuilder? avatar;
 
   WebhookBuilder({required this.name, required this.channelId, this.avatar});
 
@@ -22,11 +22,11 @@ class WebhookBuilder extends CreateBuilder<Webhook> {
 }
 
 class WebhookUpdateBuilder extends UpdateBuilder<Webhook> {
-  final String? name;
+  String? name;
 
-  final ImageBuilder? avatar;
+  ImageBuilder? avatar;
 
-  final Snowflake? channelId;
+  Snowflake? channelId;
 
   WebhookUpdateBuilder({
     this.name,


### PR DESCRIPTION
# Description

This PR changes all builders to be mutable. There isn't a reason for builders not to be mutable, since they are user controlled anyway, and making them mutable allows them to be reused with some fields changed.

nyxx_commands also depends on modifying certain fields in `MessageBuilder` or `SelectMenuBuilder` to implement some basic features.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
