### PR TITLE
Add CommandOptionMentionable type

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -266,7 +266,7 @@ export 'src/models/sticker/global_sticker.dart' show GlobalSticker, PartialGloba
 export 'src/models/sticker/sticker.dart' show Sticker, StickerType, StickerFormatType, StickerItem;
 export 'src/models/sticker/sticker_pack.dart' show StickerPack;
 export 'src/models/commands/application_command.dart' show ApplicationCommand, PartialApplicationCommand, ApplicationCommandType;
-export 'src/models/commands/application_command_option.dart' show CommandOption, CommandOptionChoice, CommandOptionType;
+export 'src/models/commands/application_command_option.dart' show CommandOption, CommandOptionChoice, CommandOptionType, CommandOptionMentionable;
 export 'src/models/commands/application_command_permissions.dart' show CommandPermission, CommandPermissions, CommandPermissionType;
 export 'src/models/team.dart' show Team, TeamMember, TeamMembershipState;
 export 'src/models/interaction.dart'

--- a/lib/src/models/commands/application_command_option.dart
+++ b/lib/src/models/commands/application_command_option.dart
@@ -1,5 +1,6 @@
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/locale.dart';
+import 'package:nyxx/src/models/snowflake_entity/snowflake_entity.dart';
 import 'package:nyxx/src/utils/to_string_helper/to_string_helper.dart';
 
 /// {@template command_option}
@@ -114,3 +115,8 @@ class CommandOptionChoice {
   /// {@macro command_option_choice}
   CommandOptionChoice({required this.name, required this.nameLocalizations, required this.value});
 }
+
+/// A common superclass for entities that can be passed in options of type [CommandOptionType.mentionable].
+///
+/// The only subtypes are [User] and [Role].
+abstract interface class CommandOptionMentionable<T extends CommandOptionMentionable<T>> implements SnowflakeEntity<T> {}

--- a/lib/src/models/role.dart
+++ b/lib/src/models/role.dart
@@ -1,6 +1,7 @@
 import 'package:nyxx/src/http/cdn/cdn_asset.dart';
 import 'package:nyxx/src/http/managers/role_manager.dart';
 import 'package:nyxx/src/http/route.dart';
+import 'package:nyxx/src/models/commands/application_command_option.dart';
 import 'package:nyxx/src/models/discord_color.dart';
 import 'package:nyxx/src/models/permissions.dart';
 import 'package:nyxx/src/models/snowflake.dart';
@@ -22,7 +23,7 @@ class PartialRole extends WritableSnowflakeEntity<Role> {
 /// External references:
 /// * Discord API Reference: https://discord.com/developers/docs/topics/permissions#role-object
 /// {@endtemplate}
-class Role extends PartialRole {
+class Role extends PartialRole implements CommandOptionMentionable<Role> {
   /// The name of this role.
   final String name;
 

--- a/lib/src/models/user/user.dart
+++ b/lib/src/models/user/user.dart
@@ -1,6 +1,7 @@
 import 'package:nyxx/src/http/cdn/cdn_asset.dart';
 import 'package:nyxx/src/http/managers/user_manager.dart';
 import 'package:nyxx/src/http/route.dart';
+import 'package:nyxx/src/models/commands/application_command_option.dart';
 import 'package:nyxx/src/models/discord_color.dart';
 import 'package:nyxx/src/models/locale.dart';
 import 'package:nyxx/src/models/message/author.dart';
@@ -25,7 +26,7 @@ class PartialUser extends ManagedSnowflakeEntity<User> {
 /// External references:
 /// * Discord API Reference: https://discord.com/developers/docs/resources/user#users-resource
 /// {@endtemplate}
-class User extends PartialUser implements MessageAuthor {
+class User extends PartialUser implements MessageAuthor, CommandOptionMentionable<User> {
   /// The user's username.
   @override
   final String username;


### PR DESCRIPTION
# Description

Adds a common supertype to `User` and `Role` for use as a type when using code with `CommandOptionType.mentionable`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
