### PR TITLE
Add helper constructors to some builders

### DIFF
--- a/lib/src/builders/channel/thread.dart
+++ b/lib/src/builders/channel/thread.dart
@@ -41,6 +41,10 @@ class ThreadBuilder extends CreateBuilder<Thread> {
 
   ThreadBuilder({required this.name, this.autoArchiveDuration, required this.type, this.invitable, this.rateLimitPerUser});
 
+  ThreadBuilder.publicThread({required this.name, this.autoArchiveDuration, this.rateLimitPerUser}) : type = ChannelType.publicThread;
+
+  ThreadBuilder.privateThread({required this.name, this.autoArchiveDuration, this.invitable, this.rateLimitPerUser}) : type = ChannelType.privateThread;
+
   @override
   Map<String, Object?> build() => {
         'name': name,

--- a/lib/src/builders/message/component.dart
+++ b/lib/src/builders/message/component.dart
@@ -1,8 +1,8 @@
-import 'package:nyxx/nyxx.dart';
 import 'package:nyxx/src/builders/builder.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/emoji.dart';
 import 'package:nyxx/src/models/message/component.dart';
+import 'package:nyxx/src/models/snowflake.dart';
 
 abstract class MessageComponentBuilder extends CreateBuilder<MessageComponent> {
   MessageComponentType type;
@@ -47,6 +47,46 @@ class ButtonBuilder extends MessageComponentBuilder {
     this.isDisabled,
   }) : super(type: MessageComponentType.button);
 
+  ButtonBuilder.primary({
+    this.label,
+    this.emoji,
+    required String customId,
+    this.isDisabled,
+  })  : style = ButtonStyle.primary,
+        super(type: MessageComponentType.button);
+
+  ButtonBuilder.secondary({
+    this.label,
+    this.emoji,
+    required String customId,
+    this.isDisabled,
+  })  : style = ButtonStyle.secondary,
+        super(type: MessageComponentType.button);
+
+  ButtonBuilder.success({
+    this.label,
+    this.emoji,
+    required String customId,
+    this.isDisabled,
+  })  : style = ButtonStyle.success,
+        super(type: MessageComponentType.button);
+
+  ButtonBuilder.danger({
+    this.label,
+    this.emoji,
+    required String customId,
+    this.isDisabled,
+  })  : style = ButtonStyle.danger,
+        super(type: MessageComponentType.button);
+
+  ButtonBuilder.link({
+    this.label,
+    this.emoji,
+    required Uri this.url,
+    this.isDisabled,
+  })  : style = ButtonStyle.link,
+        super(type: MessageComponentType.button);
+
   @override
   Map<String, Object?> build() => {
         ...super.build(),
@@ -89,6 +129,48 @@ class SelectMenuBuilder extends MessageComponentBuilder {
     this.maxValues,
     this.isDisabled,
   });
+
+  SelectMenuBuilder.stringSelect({
+    required this.customId,
+    required List<SelectMenuOptionBuilder> this.options,
+    this.placeholder,
+    this.minValues,
+    this.maxValues,
+    this.isDisabled,
+  }) : super(type: MessageComponentType.stringSelect);
+
+  SelectMenuBuilder.userSelect({
+    required this.customId,
+    this.placeholder,
+    this.minValues,
+    this.maxValues,
+    this.isDisabled,
+  }) : super(type: MessageComponentType.userSelect);
+
+  SelectMenuBuilder.roleSelect({
+    required this.customId,
+    this.placeholder,
+    this.minValues,
+    this.maxValues,
+    this.isDisabled,
+  }) : super(type: MessageComponentType.roleSelect);
+
+  SelectMenuBuilder.mentionableSelect({
+    required this.customId,
+    this.channelTypes,
+    this.placeholder,
+    this.minValues,
+    this.maxValues,
+    this.isDisabled,
+  }) : super(type: MessageComponentType.mentionableSelect);
+
+  SelectMenuBuilder.channelSelect({
+    required this.customId,
+    this.placeholder,
+    this.minValues,
+    this.maxValues,
+    this.isDisabled,
+  }) : super(type: MessageComponentType.channelSelect);
 
   @override
   Map<String, Object?> build() => {

--- a/lib/src/builders/sticker.dart
+++ b/lib/src/builders/sticker.dart
@@ -31,7 +31,7 @@ class StickerUpdateBuilder implements UpdateBuilder<GuildSticker> {
   String? name;
 
   /// Description of the sticker (empty or 2-100 characters)
-  String description;
+  String? description;
 
   /// Autocomplete/suggestion tags for the sticker (max 200 characters)
   String? tags;
@@ -40,7 +40,7 @@ class StickerUpdateBuilder implements UpdateBuilder<GuildSticker> {
 
   @override
   Map<String, Object?> build() => {
-        if (!identical(description, sentinelString)) "description": description,
+        if (!identical(description, sentinelString)) "description": description ?? '',
         if (name != null) "name": name,
         if (tags != null) "tags": tags,
       };


### PR DESCRIPTION
# Description

Some builders have fields that are only available under certain circumstances (often, when a specific other argument is specified). This PR adds constructors that clarify which fields are available where.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
