### PR TITLE
Add onRateLimit stream to HttpHandler

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -68,7 +68,7 @@ export 'src/builders/interaction_response.dart' show InteractionResponseBuilder,
 export 'src/cache/cache.dart' show Cache, CacheConfig;
 
 export 'src/http/bucket.dart' show HttpBucket;
-export 'src/http/handler.dart' show HttpHandler, Oauth2HttpHandler;
+export 'src/http/handler.dart' show HttpHandler, Oauth2HttpHandler, RateLimitInfo;
 export 'src/http/request.dart' show BasicRequest, HttpRequest, MultipartRequest, FormDataRequest;
 export 'src/http/response.dart' show FieldError, HttpErrorData, HttpResponse, HttpResponseError, HttpResponseSuccess;
 export 'src/http/route.dart' show HttpRoute, HttpRouteParam, HttpRoutePart;

--- a/test/unit/http/handler_test.dart
+++ b/test/unit/http/handler_test.dart
@@ -149,6 +149,7 @@ void main() {
           );
         });
 
+        expect(handler.onRateLimit.where((event) => event.isAnticipated), emits(predicate((_) => true)));
         expect(handler.execute(request), completes);
       });
 
@@ -185,6 +186,8 @@ void main() {
             },
           );
         });
+
+        expect(handler.onRateLimit.where((event) => !event.isAnticipated), emits(predicate((_) => true)));
 
         await expectLater(
           handler.execute(request),
@@ -232,6 +235,8 @@ void main() {
             },
           );
         });
+
+        expect(handler.onRateLimit.where((event) => event.isGlobal), emits(predicate((_) => true)));
 
         await expectLater(
           handler.execute(request),


### PR DESCRIPTION
# Description

Adds a stream to HttpHandler which users can listen to to be notified when the client encounters a rate limit.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
