### PR TITLE
Use more precise emoji type in reaction events

### DIFF
--- a/lib/src/models/gateway/events/message.dart
+++ b/lib/src/models/gateway/events/message.dart
@@ -129,7 +129,7 @@ class MessageReactionAddEvent extends DispatchEvent {
   final Member? member;
 
   /// The emoji that was added.
-  final PartialEmoji emoji;
+  final Emoji emoji;
 
   /// {@macro message_reaction_add_event}
   MessageReactionAddEvent({
@@ -172,7 +172,7 @@ class MessageReactionRemoveEvent extends DispatchEvent {
   final Snowflake? guildId;
 
   /// The emoji that was removed.
-  final PartialEmoji emoji;
+  final Emoji emoji;
 
   /// {@macro message_reaction_remove_event}
   MessageReactionRemoveEvent({


### PR DESCRIPTION
# Description

Reaction events used to use `PartialEmoji` when the API returns an object that is always parseable to an `Emoji`. This PR changes these events to use the more precise type.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x]  I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
