### PR TITLE
Make filename required in AttachmentBuilder

### DIFF
--- a/lib/src/builders/message/attachment.dart
+++ b/lib/src/builders/message/attachment.dart
@@ -8,11 +8,11 @@ import 'package:nyxx/src/models/message/attachment.dart';
 class AttachmentBuilder extends Builder<Attachment> {
   List<int> data;
 
-  String? fileName;
+  String fileName;
 
   String? description;
 
-  AttachmentBuilder({required this.data, this.fileName, this.description});
+  AttachmentBuilder({required this.data, required this.fileName, this.description});
 
   static Future<AttachmentBuilder> fromFile(File file, {String? description}) async {
     final data = await file.readAsBytes();
@@ -26,7 +26,7 @@ class AttachmentBuilder extends Builder<Attachment> {
 
   @override
   Map<String, Object?> build() => {
-        if (fileName != null) 'filename': fileName,
+        'filename': fileName,
         if (description != null) 'description': description,
       };
 }


### PR DESCRIPTION
# Description

Closes #536 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x]  I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
