### PR TITLE
Allow users to specify stdout and stderr in Logging plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you're already familiar with Discord's API, here's a quick example to get you
 import 'package:nyxx/nyxx.dart';
 
 void main() async {
-  final client = await Nyxx.connectWebsocket('<TOKEN>', GatewayIntents.allUnprivileged);
+  final client = await Nyxx.connectGateway('<TOKEN>', GatewayIntents.allUnprivileged);
 
   final botUser = await client.users.fetchCurrentUser();
 

--- a/lib/src/plugin/logging.dart
+++ b/lib/src/plugin/logging.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:logging/logging.dart';
 import 'package:nyxx/src/api_options.dart';
@@ -30,6 +30,16 @@ class Logging extends NyxxPlugin {
   /// Whether to censor the token of clients this plugin is attached to.
   final bool censorToken;
 
+  /// The sink normal messages are sent to.
+  ///
+  /// Defaults to [io.stdout].
+  final StringSink stdout;
+
+  /// The sink error messages are sent to.
+  ///
+  /// Defaults to [io.stderr].
+  final StringSink stderr;
+
   /// Create a new instance of the [Logging] plugin.
   Logging({
     this.stderrLevel = Level.WARNING,
@@ -37,7 +47,10 @@ class Logging extends NyxxPlugin {
     this.logLevel = Level.INFO,
     this.truncateLogsAt = 1000,
     this.censorToken = true,
-  });
+    StringSink? stdout,
+    StringSink? stderr,
+  })  : stdout = stdout ?? io.stdout,
+        stderr = stderr ?? io.stderr;
 
   static int _clients = 0;
 


### PR DESCRIPTION
# Description

Closes #539.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
