### PR TITLE
chore: add missing state field in ActivityBuilder

### DIFF
--- a/lib/src/builders/presence.dart
+++ b/lib/src/builders/presence.dart
@@ -40,16 +40,19 @@ enum CurrentUserStatus {
 class ActivityBuilder extends CreateBuilder<Activity> {
   String name;
 
+  String? state;
+
   ActivityType type;
 
   Uri? url;
 
-  ActivityBuilder({required this.name, required this.type, this.url});
+  ActivityBuilder({required this.name, required this.type, this.state, this.url});
 
   @override
   Map<String, Object?> build() => {
         'name': name,
         'type': type.value,
+        if (state != null) 'state': state!,
         if (url != null) 'url': url!.toString(),
       };
 }


### PR DESCRIPTION
# Description

Allows setting **Activity State** in **Activities**.

[![Screenshot_20230920_120332](https://github.com/nyxx-discord/nyxx/assets/95774950/a7cada50-77a7-4ae9-b4aa-45f3ea73301b)](https://discord.com/developers/docs/change-log#activity-state-for-bot-users)

![Screenshot_20230920-113353](https://github.com/nyxx-discord/nyxx/assets/95774950/1ee2ed59-c602-4d2e-a905-a85d3e40c986)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works