### PR TITLE
fix: required activities field is not being sent in presence update payload

### DIFF
--- a/lib/src/builders/presence.dart
+++ b/lib/src/builders/presence.dart
@@ -16,7 +16,7 @@ class PresenceBuilder extends CreateBuilder<PresenceUpdateEvent> {
   @override
   Map<String, Object?> build() => {
         'since': since?.millisecondsSinceEpoch,
-        if (activities != null) 'activities': activities!.map((e) => e.build()).toList(),
+        'activities': activities?.map((e) => e.build()).toList(),
         'status': status.value,
         'afk': isAfk,
       };


### PR DESCRIPTION
# Description

Fixes an issue where the bot fails to connect the gateway and logs `Unresumable invalid session` when `PresenceBuilder()` activities is ignored.

```dart
PresenceBuilder(
  since: DateTime.now(),
  // activities: []
  status: CustomUserStatus.online,
  isAfk: false
);
```

When sending a presence update event payload, the `activities` field is supposed to send. Check the [docs](https://discord.com/developers/docs/topics/gateway-events#update-presence-gateway-presence-update-structure), there is no `?` after `activities`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
