### PR TITLE
fix: invalid client voice state update, export NyxxPluginState

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -291,7 +291,7 @@ export 'src/models/interaction.dart'
 export 'src/utils/flags.dart' show Flag, Flags;
 export 'src/intents.dart' show GatewayIntents;
 
-export 'src/plugin/plugin.dart' show NyxxPlugin;
+export 'src/plugin/plugin.dart' show NyxxPlugin, NyxxPluginState;
 export 'src/plugin/logging.dart' show Logging, logging;
 export 'src/plugin/cli_integration.dart' show CliIntegration, cliIntegration;
 export 'src/plugin/ignore_exceptions.dart' show IgnoreExceptions, ignoreExceptions;

--- a/lib/src/builders/voice.dart
+++ b/lib/src/builders/voice.dart
@@ -41,7 +41,7 @@ class GatewayVoiceStateBuilder extends CreateBuilder<VoiceState> {
   @override
   Map<String, Object?> build() => {
         'channel_id': channelId?.toString(),
-        'mute': isMuted,
-        'deaf': isDeafened,
+        'self_mute': isMuted,
+        'self_deaf': isDeafened,
       };
 }


### PR DESCRIPTION
# Description

Fixes an issue where the client can't mute/deafen itself in a voice channel due to incorrect fields (`mute` & `deaf`) being sent.

The correct fields should be `self_mute` & `self_deaf` as shown in Discord [docs](https://discord.com/developers/docs/topics/voice-connections#retrieving-voice-server-information-gateway-voice-state-update-example).

## Connected issues & other potential problems

2nd commit is related to #554 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
