### PR TITLE
Improve plugin interface and errors

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -315,3 +315,4 @@ export 'package:http/http.dart'
         BaseResponse,
         StreamedResponse;
 export 'package:logging/logging.dart' show Logger, Level;
+export 'package:runtime_type/runtime_type.dart' show RuntimeType;

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -127,3 +127,15 @@ class AlreadyRespondedError extends AlreadyAcknowledgedError {
   @override
   String toString() => 'Interaction has already been responded to';
 }
+
+/// An error thrown when an issue with a client's plugin is encountered.
+class PluginError extends Error {
+  /// The message for this [PluginError].
+  final String message;
+
+  /// Create a new [PluginError].
+  PluginError(this.message);
+
+  @override
+  String toString() => message;
+}

--- a/lib/src/models/channel/thread.dart
+++ b/lib/src/models/channel/thread.dart
@@ -97,7 +97,7 @@ class PartialThreadMember {
 
 /// {@template thread_member}
 /// Additional information associated with a [Member] in a [Thread].
-/// {@endtemplate thread_member}
+/// {@endtemplate}
 class ThreadMember extends PartialThreadMember {
   /// The manager for this [ThreadMember].
   final ChannelManager manager;

--- a/lib/src/plugin/plugin.dart
+++ b/lib/src/plugin/plugin.dart
@@ -1,14 +1,22 @@
 import 'dart:async';
 
+import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:nyxx/src/api_options.dart';
 import 'package:nyxx/src/client.dart';
 import 'package:nyxx/src/client_options.dart';
+import 'package:runtime_type/runtime_type.dart';
 
 /// Provides access to the connection and closing process for implementing plugins.
 abstract class NyxxPlugin<ClientType extends Nyxx> {
   /// The name of this plugin.
-  String get name;
+  String get name => runtimeType.toString();
+
+  /// A logger that can be used to log messages from this plugin.
+  Logger get logger => Logger(name);
+
+  /// The type of client this plugin requires.
+  RuntimeType<ClientType> get clientType => RuntimeType<ClientType>();
 
   late final Expando<NyxxPluginState<ClientType, NyxxPlugin<ClientType>>> _states = Expando('$name plugin states');
 
@@ -63,6 +71,9 @@ abstract class NyxxPlugin<ClientType extends Nyxx> {
 class NyxxPluginState<ClientType extends Nyxx, PluginType extends NyxxPlugin<ClientType>> {
   /// The plugin this state belongs to.
   final PluginType plugin;
+
+  /// A logger that can be used to log messages from this plugin.
+  Logger get logger => plugin.logger;
 
   /// Create a new plugin state.
   NyxxPluginState(this.plugin);


### PR DESCRIPTION
# Description

Adds a built-in logger to the plugin interface and better errors when plugins don't match the client type.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
