### PR TITLE
fix: incorrect "description_localizations" key's value build in CommandOptionBuilder

### DIFF
--- a/lib/src/builders/application_command.dart
+++ b/lib/src/builders/application_command.dart
@@ -388,7 +388,7 @@ class CommandOptionBuilder extends CreateBuilder<CommandOption> {
         if (nameLocalizations != null) 'name_localizations': {for (final MapEntry(:key, :value) in nameLocalizations!.entries) key.identifier: value},
         'description': description,
         if (descriptionLocalizations != null)
-          'description_localizations': {for (final MapEntry(:key, :value) in nameLocalizations!.entries) key.identifier: value},
+          'description_localizations': {for (final MapEntry(:key, :value) in descriptionLocalizations!.entries) key.identifier: value},
         if (isRequired != null) 'required': isRequired,
         if (choices != null) 'choices': choices!.map((e) => e.build()).toList(),
         if (options != null) 'options': options!.map((e) => e.build()).toList(),

--- a/lib/src/http/managers/channel_manager.dart
+++ b/lib/src/http/managers/channel_manager.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' show MultipartFile;
-import 'package:nyxx/nyxx.dart';
 import 'package:nyxx/src/builders/builder.dart';
 import 'package:nyxx/src/builders/channel/stage_instance.dart';
 import 'package:nyxx/src/builders/channel/thread.dart';
@@ -24,6 +23,7 @@ import 'package:nyxx/src/models/channel/types/forum.dart';
 import 'package:nyxx/src/models/channel/types/group_dm.dart';
 import 'package:nyxx/src/models/channel/types/guild_announcement.dart';
 import 'package:nyxx/src/models/channel/types/guild_category.dart';
+import 'package:nyxx/src/models/channel/types/guild_media.dart';
 import 'package:nyxx/src/models/channel/types/guild_stage.dart';
 import 'package:nyxx/src/models/channel/types/guild_text.dart';
 import 'package:nyxx/src/models/channel/types/guild_voice.dart';

--- a/lib/src/plugin/ignore_exceptions.dart
+++ b/lib/src/plugin/ignore_exceptions.dart
@@ -13,6 +13,7 @@ class IgnoreExceptions extends NyxxPlugin {
   String get name => 'IgnoreExceptions';
 
   /// The logger used to report the errors.
+  @override
   Logger get logger => Logger('IgnoreExceptions');
 
   static int _clients = 0;


### PR DESCRIPTION
# Description

Fixes a bug with slash command localization (particularly in **sub-commands**).

When both localization name & description are set, the localization description uses the value of localization name which leads the slash command to have same localization name & description values.

### Example

```dart
final command = ChatGroup(
  'name',
  '.',
  localizedNames: { Locale.hi: 'नेम' },
  children: [
    ChatCommand(
      'sub_name',
      'sub_description',
      localizedNames: { Locale.hi: 'सब_नेम' },
      localizedDescriptions: { Locale.hi: 'सब_डिस्क्रिप्शन' },
      id('sub_name', (ChatContext ctx) async {
        await ctx.respond(MessageBuilder(content: 'Meow!'));
      })
    )
  ]
);
```

<details>
<summary> Preview output </summary>

![Screenshot_20231022_215048](https://github.com/nyxx-discord/nyxx/assets/95774950/08741d16-2abc-4c64-ab2d-2033252e83cb)

</details>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
