### PR TITLE
fix: initial voice state cache sets null-guild based cache key

### DIFF
--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -42,6 +42,7 @@ import 'package:nyxx/src/models/interaction.dart';
 import 'package:nyxx/src/models/presence.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/user/user.dart';
+import 'package:nyxx/src/models/voice/voice_state.dart';
 import 'package:nyxx/src/utils/iterable_extension.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
@@ -128,7 +129,26 @@ class Gateway extends GatewayManager with EventParser {
               client.channels.cache.addEntities(event.threads);
               client.channels.stageInstanceCache.addEntities(event.stageInstances);
               event.guild.scheduledEvents.cache.addEntities(event.scheduledEvents);
-              client.voice.cache.addEntries(event.voiceStates.map((e) => MapEntry(e.cacheKey, e)));
+
+              client.voice.cache.addEntries(event.voiceStates.map((e) {
+                final voiceState = VoiceState(
+                    manager: client.voice,
+                    guildId: event.guild.id,
+                    channelId: e.channelId,
+                    userId: e.userId,
+                    member: event.guild.members.cache[e.userId],
+                    sessionId: e.sessionId,
+                    isServerDeafened: e.isServerDeafened,
+                    isServerMuted: e.isServerMuted,
+                    isSelfDeafened: e.isSelfDeafened,
+                    isSelfMuted: e.isSelfMuted,
+                    isStreaming: e.isStreaming,
+                    isVideoEnabled: e.isVideoEnabled,
+                    isSuppressed: e.isSuppressed,
+                    requestedToSpeakAt: e.requestedToSpeakAt);
+
+                return MapEntry(voiceState.cacheKey, voiceState);
+              }));
             }(),
           GuildUpdateEvent(:final guild) => client.guilds.cache[guild.id] = guild,
           GuildDeleteEvent(:final guild, isUnavailable: false) => client.guilds.cache.remove(guild.id),


### PR DESCRIPTION
## Description

Assume, a bot has connected to gateway or joined a new guild. When the bot receives `GUILD_CREATE` event, internally nyxx will cache & transmit the event data to their respective cache instances as we expect it to do but there is a catch with how nyxx stores the cache for users who are pre-connected into a voice channel before the bot connects to gateway/joins the guild.

https://github.com/nyxx-discord/nyxx/blob/31ab26d4eb1709bb36284029f29be6f13ec0b83b/lib/src/gateway/gateway.dart#L131

In the above code, nyxx transforms `List<VoiceState>` as `MappedListIterable<VoiceState, Map<Snowflake, VoiceState>>` & directly adds them into `Cache<VoiceState>`.

Now, here is the main issue. In `GUILD_CREATE` event, Discord doesn't provide `guild_id` key in `voice_states` (since we already have `event.id` provided). So, the value of `guild_id` here will be `null`. Therefore, from the above code snippet, the `e.cacheKey` value will be of `Snowflake(Object.hash(null, USER_ID))` return value; which is a bit of incorrect. Instead of using `null`, it should use `event.guild.id` value.

Having `null` will not synchronize with the original pre-connected user's cached voice state when the bot receives `VOICE_STATE_UPDATE` event. It will create a new cache entry.

This pull request fixes the initial pre-connected user's voice state cache to synchronize with `VOICE_STATE_UPDATE` event.

### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

A minor breaking change affecting only how nyxx handles voice states caches of pre-connected users.

## Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works


[1]: https://pub.dev/documentation/nyxx/latest/nyxx/VoiceState-class.html