### PR TITLE
Fix voice states not being cached correctly in GUILD_CREATE event

### DIFF
--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -545,7 +545,10 @@ class Gateway extends GatewayManager with EventParser {
       joinedAt: DateTime.parse(raw['joined_at'] as String),
       isLarge: raw['large'] as bool,
       memberCount: raw['member_count'] as int,
-      voiceStates: parseMany(raw['voice_states'] as List<Object?>, client.voice.parseVoiceState),
+      voiceStates: parseMany(
+        raw['voice_states'] as List<Object?>,
+        (Map<String, Object?> raw) => client.voice.parseVoiceState(raw, guildId: guild.id),
+      ),
       members: parseMany(raw['members'] as List<Object?>, client.guilds[guild.id].members.parse),
       channels: parseMany(raw['channels'] as List<Object?>, (Map<String, Object?> raw) => client.channels.parse(raw, guildId: guild.id) as GuildChannel),
       threads: parseMany(raw['threads'] as List<Object?>, (Map<String, Object?> raw) => client.channels.parse(raw, guildId: guild.id) as Thread),

--- a/lib/src/http/managers/voice_manager.dart
+++ b/lib/src/http/managers/voice_manager.dart
@@ -19,8 +19,8 @@ class VoiceManager {
   VoiceManager(this.client) : cache = Cache(client, 'voiceStates', client.options.voiceStateConfig);
 
   /// Parse a [VoiceState] from a [Map].
-  VoiceState parseVoiceState(Map<String, Object?> raw) {
-    final guildId = maybeParse(raw['guild_id'], Snowflake.parse);
+  VoiceState parseVoiceState(Map<String, Object?> raw, {Snowflake? guildId}) {
+    guildId ??= maybeParse(raw['guild_id'], Snowflake.parse);
 
     return VoiceState(
       manager: this,

--- a/lib/src/http/managers/voice_manager.dart
+++ b/lib/src/http/managers/voice_manager.dart
@@ -13,9 +13,11 @@ class VoiceManager {
   final NyxxRest client;
 
   /// The cache for voice states.
+  @Deprecated('Use PartialGuild.voiceStates instead')
   final Cache<VoiceState> cache;
 
   /// Create a new [VoiceManager].
+  // ignore: deprecated_member_use_from_same_package
   VoiceManager(this.client) : cache = Cache(client, 'voiceStates', client.options.voiceStateConfig);
 
   /// Parse a [VoiceState] from a [Map].

--- a/lib/src/models/guild/guild.dart
+++ b/lib/src/models/guild/guild.dart
@@ -6,6 +6,7 @@ import 'package:nyxx/src/builders/guild/template.dart';
 import 'package:nyxx/src/builders/guild/welcome_screen.dart';
 import 'package:nyxx/src/builders/guild/widget.dart';
 import 'package:nyxx/src/builders/voice.dart';
+import 'package:nyxx/src/cache/cache.dart';
 import 'package:nyxx/src/http/cdn/cdn_asset.dart';
 import 'package:nyxx/src/http/managers/application_command_manager.dart';
 import 'package:nyxx/src/http/managers/audit_log_manager.dart';
@@ -40,6 +41,7 @@ import 'package:nyxx/src/models/snowflake_entity/snowflake_entity.dart';
 import 'package:nyxx/src/models/sticker/guild_sticker.dart';
 import 'package:nyxx/src/models/user/user.dart';
 import 'package:nyxx/src/models/voice/voice_region.dart';
+import 'package:nyxx/src/models/voice/voice_state.dart';
 import 'package:nyxx/src/utils/flags.dart';
 
 /// A partial [Guild].
@@ -70,6 +72,9 @@ class PartialGuild extends WritableSnowflakeEntity<Guild> {
 
   /// An [AuditLogManager] for the audit log of this guild.
   AuditLogManager get auditLogs => AuditLogManager(manager.client.options.auditLogEntryConfig, manager.client, guildId: id);
+
+  /// A [Cache] for [VoiceState]s in this guild.
+  Cache<VoiceState> get voiceStates => Cache(manager.client, '$id.voiceStates', manager.client.options.voiceStateConfig);
 
   /// A [GuildApplicationCommandManager] for the application commands of this guild.
   GuildApplicationCommandManager get commands => GuildApplicationCommandManager(

--- a/lib/src/models/voice/voice_state.dart
+++ b/lib/src/models/voice/voice_state.dart
@@ -79,6 +79,7 @@ class VoiceState with ToStringHelper {
   bool get isMuted => isServerMuted || isSelfMuted;
 
   /// The key this voice state will have in the [NyxxRest.voice] cache.
+  @Deprecated('Use PartialGuild.voiceStates instead')
   Snowflake get cacheKey => Snowflake(Object.hash(guildId, userId));
 
   /// The guild this voice state is in.


### PR DESCRIPTION
# Description

Fixes a parsing issue in GUILD_CREATE that caused voice states to not have their guild ID set. Also fixes an issue with potential hash collisions leading to bad caching of voice states.

Supercedes #574.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
