### PR TITLE
Fix parsing scheduled events without channels

### DIFF
--- a/lib/src/http/managers/scheduled_event_manager.dart
+++ b/lib/src/http/managers/scheduled_event_manager.dart
@@ -26,7 +26,7 @@ class ScheduledEventManager extends Manager<ScheduledEvent> {
       id: Snowflake.parse(raw['id']!),
       manager: this,
       guildId: Snowflake.parse(raw['guild_id']!),
-      channelId: Snowflake.parse(raw['channel_id']!),
+      channelId: maybeParse(raw['channel_id'], Snowflake.parse),
       creatorId: maybeParse(raw['creator_id'], Snowflake.parse),
       name: raw['name'] as String,
       description: raw['description'] as String?,

--- a/test/unit/http/managers/scheduled_event_manager_test.dart
+++ b/test/unit/http/managers/scheduled_event_manager_test.dart
@@ -23,10 +23,46 @@ final sampleScheduledEvent = {
   'image': null,
 };
 
+final sampleScheduledEvent2 = {
+  'id': '0',
+  'guild_id': '1',
+  'creator_id': '3',
+  'name': 'test',
+  'description': 'a test event',
+  'scheduled_start_time': '2023-06-10T16:37:18Z',
+  'scheduled_end_time': '2023-06-10T16:37:18Z',
+  'privacy_level': 2,
+  'status': 1,
+  'entity_type': 1,
+  'entity_id': '2',
+  'creator': sampleUser,
+  'user_count': null,
+  'image': null,
+};
+
 void checkScheduledEvent(ScheduledEvent event) {
   expect(event.id, equals(Snowflake.zero));
   expect(event.guildId, equals(Snowflake(1)));
   expect(event.channelId, equals(Snowflake(2)));
+  expect(event.creatorId, equals(Snowflake(3)));
+  expect(event.name, equals('test'));
+  expect(event.description, equals('a test event'));
+  expect(event.scheduledStartTime, equals(DateTime.utc(2023, 06, 10, 16, 37, 18)));
+  expect(event.scheduledEndTime, equals(DateTime.utc(2023, 06, 10, 16, 37, 18)));
+  expect(event.privacyLevel, equals(PrivacyLevel.guildOnly));
+  expect(event.status, equals(EventStatus.scheduled));
+  expect(event.type, equals(ScheduledEntityType.stageInstance));
+  expect(event.entityId, equals(Snowflake(2)));
+  expect(event.metadata, isNull);
+  checkSampleUser(event.creator!);
+  expect(event.userCount, isNull);
+  expect(event.coverImageHash, isNull);
+}
+
+void checkScheduledEvent2(ScheduledEvent event) {
+  expect(event.id, equals(Snowflake.zero));
+  expect(event.guildId, equals(Snowflake(1)));
+  expect(event.channelId, isNull);
   expect(event.creatorId, equals(Snowflake(3)));
   expect(event.name, equals('test'));
   expect(event.description, equals('a test event'));
@@ -62,6 +98,8 @@ void main() {
     '/guilds/0/scheduled-events',
     sampleObject: sampleScheduledEvent,
     sampleMatches: checkScheduledEvent,
+    additionalSampleObjects: [sampleScheduledEvent2],
+    additionalSampleMatchers: [checkScheduledEvent2],
     additionalParsingTests: [
       ParsingTest<ScheduledEventManager, ScheduledEventUser, Map<String, Object?>>(
         name: 'parseScheduledEventUser',


### PR DESCRIPTION
# Description

The `channel_id` field in scheduled events is not required. This PR fixes the parsing code that failed when it wasn't present.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
