### PR TITLE
Fix using ephemeral responses with message component interactions

### DIFF
--- a/lib/src/models/interaction.dart
+++ b/lib/src/models/interaction.dart
@@ -295,7 +295,7 @@ class MessageComponentInteraction extends Interaction<MessageComponentInteractio
       if (updateMessage == true) {
         await manager.createResponse(id, token, InteractionResponseBuilder.updateMessage(builder as MessageUpdateBuilder));
       } else {
-        await manager.createResponse(id, token, InteractionResponseBuilder.channelMessage(builder as MessageBuilder));
+        await manager.createResponse(id, token, InteractionResponseBuilder.channelMessage(builder as MessageBuilder, isEphemeral: isEphemeral));
       }
     } else {
       assert(updateMessage == _didUpdateMessage || updateMessage == null, 'Cannot change the value of updateMessage between acknowledge and respond');
@@ -310,7 +310,7 @@ class MessageComponentInteraction extends Interaction<MessageComponentInteractio
       if (updateMessage == true) {
         await manager.updateOriginalResponse(token, builder as MessageUpdateBuilder);
       } else {
-        await manager.createFollowup(token, builder as MessageBuilder);
+        await manager.createFollowup(token, builder as MessageBuilder, isEphemeral: isEphemeral);
       }
     }
   }


### PR DESCRIPTION
# Description

Fixes `isEphemeral: true` not making the response ephemeral for message component interactions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
