### PR TITLE
Improve caching and reduce incorrect ID use

### DIFF
--- a/lib/src/cache/cache.dart
+++ b/lib/src/cache/cache.dart
@@ -146,7 +146,3 @@ class Cache<T> with MapMixin<Snowflake, T> {
     return result;
   }
 }
-
-extension SnowflakeCache<T extends SnowflakeEntity<T>> on Cache<T> {
-  void addEntities(Iterable<T> entities) => addEntries(entities.map((e) => MapEntry(e.id, e)));
-}

--- a/lib/src/cache/cache.dart
+++ b/lib/src/cache/cache.dart
@@ -95,7 +95,9 @@ class Cache<T> with MapMixin<Snowflake, T> {
 
     _store.update(
       (identifier: identifier, key: key),
-      (entry) => entry..value = value,
+      (entry) => entry
+        ..value = value
+        ..accessCount ~/= 2,
       ifAbsent: () => _CacheEntry(value),
     );
 

--- a/lib/src/http/managers/application_command_manager.dart
+++ b/lib/src/http/managers/application_command_manager.dart
@@ -12,6 +12,7 @@ import 'package:nyxx/src/models/commands/application_command_permissions.dart';
 import 'package:nyxx/src/models/locale.dart';
 import 'package:nyxx/src/models/permissions.dart';
 import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 /// A [Manager] for [ApplicationCommand]s.
@@ -114,7 +115,7 @@ abstract class ApplicationCommandManager extends Manager<ApplicationCommand> {
     final response = await client.httpHandler.executeSafe(request);
     final commands = parseMany(response.jsonBody as List, parse);
 
-    cache.addEntities(commands);
+    commands.forEach(client.updateCacheWith);
     return commands;
   }
 
@@ -129,7 +130,7 @@ abstract class ApplicationCommandManager extends Manager<ApplicationCommand> {
     final response = await client.httpHandler.executeSafe(request);
     final command = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[command.id] = command;
+    client.updateCacheWith(command);
     return command;
   }
 
@@ -144,7 +145,7 @@ abstract class ApplicationCommandManager extends Manager<ApplicationCommand> {
     final response = await client.httpHandler.executeSafe(request);
     final command = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[command.id] = command;
+    client.updateCacheWith(command);
     return command;
   }
 
@@ -159,7 +160,7 @@ abstract class ApplicationCommandManager extends Manager<ApplicationCommand> {
     final response = await client.httpHandler.executeSafe(request);
     final command = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[command.id] = command;
+    client.updateCacheWith(command);
     return command;
   }
 
@@ -186,9 +187,8 @@ abstract class ApplicationCommandManager extends Manager<ApplicationCommand> {
     final response = await client.httpHandler.executeSafe(request);
     final commands = parseMany(response.jsonBody as List, parse);
 
-    cache
-      ..clear()
-      ..addEntities(commands);
+    cache.clear();
+    commands.forEach(client.updateCacheWith);
     return commands;
   }
 }
@@ -246,7 +246,7 @@ class GuildApplicationCommandManager extends ApplicationCommandManager {
     final response = await client.httpHandler.executeSafe(request);
     final permissions = parseMany(response.jsonBody as List, parseCommandPermissions);
 
-    permissionsCache.addEntities(permissions);
+    permissions.forEach(client.updateCacheWith);
     return permissions;
   }
 
@@ -262,7 +262,7 @@ class GuildApplicationCommandManager extends ApplicationCommandManager {
     final response = await client.httpHandler.executeSafe(request);
     final permissions = parseCommandPermissions(response.jsonBody as Map<String, Object?>);
 
-    permissionsCache[permissions.id] = permissions;
+    client.updateCacheWith(permissions);
     return permissions;
   }
 

--- a/lib/src/http/managers/audit_log_manager.dart
+++ b/lib/src/http/managers/audit_log_manager.dart
@@ -1,4 +1,3 @@
-import 'package:nyxx/src/cache/cache.dart';
 import 'package:nyxx/src/errors.dart';
 import 'package:nyxx/src/http/managers/manager.dart';
 import 'package:nyxx/src/http/request.dart';
@@ -6,6 +5,7 @@ import 'package:nyxx/src/http/route.dart';
 import 'package:nyxx/src/models/guild/audit_log.dart';
 import 'package:nyxx/src/models/permission_overwrite.dart';
 import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 class AuditLogManager extends ReadOnlyManager<AuditLogEntry> {
@@ -92,30 +92,24 @@ class AuditLogManager extends ReadOnlyManager<AuditLogEntry> {
 
       return client.guilds[guildId].commands.parse(raw);
     });
-    for (final command in applicationCommands) {
-      if (command.guild == null) {
-        client.commands.cache[command.id] = command;
-      } else {
-        client.guilds[command.guildId!].commands.cache[command.id] = command;
-      }
-    }
+    applicationCommands.forEach(client.updateCacheWith);
 
     final autoModerationRules = parseMany(responseBody['auto_moderation_rules'] as List<Object?>, client.guilds[guildId].autoModerationRules.parse);
-    client.guilds[guildId].autoModerationRules.cache.addEntities(autoModerationRules);
+    autoModerationRules.forEach(client.updateCacheWith);
 
     final scheduledEvents = parseMany(responseBody['guild_scheduled_events'] as List<Object?>, client.guilds[guildId].scheduledEvents.parse);
-    client.guilds[guildId].scheduledEvents.cache.addEntities(scheduledEvents);
+    scheduledEvents.forEach(client.updateCacheWith);
 
     final threads = parseMany(responseBody['threads'] as List<Object?>, client.channels.parse);
-    client.channels.cache.addEntities(threads);
+    threads.forEach(client.updateCacheWith);
 
     final users = parseMany(responseBody['users'] as List<Object?>, client.users.parse);
-    client.users.cache.addEntities(users);
+    users.forEach(client.updateCacheWith);
 
     final webhooks = parseMany(responseBody['webhooks'] as List<Object?>, client.webhooks.parse);
-    client.webhooks.cache.addEntities(webhooks);
+    webhooks.forEach(client.updateCacheWith);
 
-    cache.addEntities(entries);
+    entries.forEach(client.updateCacheWith);
     return entries;
   }
 }

--- a/lib/src/http/managers/auto_moderation_manager.dart
+++ b/lib/src/http/managers/auto_moderation_manager.dart
@@ -1,12 +1,12 @@
 import 'dart:convert';
 
 import 'package:nyxx/src/builders/guild/auto_moderation.dart';
-import 'package:nyxx/src/cache/cache.dart';
 import 'package:nyxx/src/http/managers/manager.dart';
 import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/route.dart';
 import 'package:nyxx/src/models/guild/auto_moderation.dart';
 import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 class AutoModerationManager extends Manager<AutoModerationRule> {
@@ -73,7 +73,7 @@ class AutoModerationManager extends Manager<AutoModerationRule> {
     final response = await client.httpHandler.executeSafe(request);
     final rule = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[rule.id] = rule;
+    client.updateCacheWith(rule);
     return rule;
   }
 
@@ -87,7 +87,7 @@ class AutoModerationManager extends Manager<AutoModerationRule> {
     final response = await client.httpHandler.executeSafe(request);
     final rules = parseMany(response.jsonBody as List<Object?>, parse);
 
-    cache.addEntities(rules);
+    rules.forEach(client.updateCacheWith);
     return rules;
   }
 
@@ -102,7 +102,7 @@ class AutoModerationManager extends Manager<AutoModerationRule> {
     final response = await client.httpHandler.executeSafe(request);
     final rule = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[rule.id] = rule;
+    client.updateCacheWith(rule);
     return rule;
   }
 
@@ -117,7 +117,7 @@ class AutoModerationManager extends Manager<AutoModerationRule> {
     final response = await client.httpHandler.executeSafe(request);
     final rule = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[rule.id] = rule;
+    client.updateCacheWith(rule);
     return rule;
   }
 

--- a/lib/src/http/managers/channel_manager.dart
+++ b/lib/src/http/managers/channel_manager.dart
@@ -512,7 +512,10 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     final request = BasicRequest(route);
 
     final response = await client.httpHandler.executeSafe(request);
-    return parseMany(response.jsonBody as List<Object?>, client.invites.parseWithMetadata);
+    final invite = parseMany(response.jsonBody as List<Object?>, client.invites.parseWithMetadata);
+
+    client.updateCacheWith(invite);
+    return invite;
   }
 
   /// Create an invite in a guild channel.
@@ -523,7 +526,10 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     final request = BasicRequest(route, method: 'POST', auditLogReason: auditLogReason, body: jsonEncode(builder.build()));
 
     final response = await client.httpHandler.executeSafe(request);
-    return client.invites.parse(response.jsonBody as Map<String, Object?>);
+    final invite = client.invites.parse(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(invite);
+    return invite;
   }
 
   /// Add a channel to another channel's followers.
@@ -670,6 +676,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
 
     final response = await client.httpHandler.executeSafe(request);
     // TODO: Can we provide the guildId?
+    // Don't update the cache since the guildId for the member will be Snowflake.zero
     return parseThreadMember(response.jsonBody as Map<String, Object?>);
   }
 
@@ -689,6 +696,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
 
     final response = await client.httpHandler.executeSafe(request);
     // TODO: Can we provide the guildId?
+    // Don't update the cache since the guildId for the member will be Snowflake.zero
     return parseMany(response.jsonBody as List, parseThreadMember);
   }
 
@@ -709,7 +717,10 @@ class ChannelManager extends ReadOnlyManager<Channel> {
 
     final response = await client.httpHandler.executeSafe(request);
     // TODO: Can we provide the guild ID?
-    return parseThreadList(response.jsonBody as Map<String, Object?>);
+    final threadList = parseThreadList(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(threadList);
+    return threadList;
   }
 
   /// List the private archived threads in a channel.
@@ -729,7 +740,10 @@ class ChannelManager extends ReadOnlyManager<Channel> {
 
     final response = await client.httpHandler.executeSafe(request);
     // TODO: Can we provide the guild ID?
-    return parseThreadList(response.jsonBody as Map<String, Object?>);
+    final threadList = parseThreadList(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(threadList);
+    return threadList;
   }
 
   /// List the private archived threads the current user has joined in a channel.
@@ -750,7 +764,10 @@ class ChannelManager extends ReadOnlyManager<Channel> {
 
     final response = await client.httpHandler.executeSafe(request);
     // TODO: Can we provide the guild ID?
-    return parseThreadList(response.jsonBody as Map<String, Object?>);
+    final threadList = parseThreadList(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(threadList);
+    return threadList;
   }
 
   /// Start a stage instance in a channel.

--- a/lib/src/http/managers/channel_manager.dart
+++ b/lib/src/http/managers/channel_manager.dart
@@ -406,21 +406,23 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     );
   }
 
-  ThreadMember parseThreadMember(Map<String, Object?> raw) {
+  ThreadMember parseThreadMember(Map<String, Object?> raw, {Snowflake? guildId}) {
+    final userId = Snowflake.parse(raw['user_id']!);
+
     return ThreadMember(
       manager: this,
       joinTimestamp: DateTime.parse(raw['join_timestamp'] as String),
       flags: Flags<Never>(raw['flags'] as int),
       threadId: Snowflake.parse(raw['id']!),
-      userId: Snowflake.parse(raw['user_id']!),
-      member: maybeParse(raw['member'], client.guilds[Snowflake.zero].members.parse),
+      userId: userId,
+      member: maybeParse(raw['member'], (Map<String, Object?> raw) => client.guilds[guildId ?? Snowflake.zero].members.parse(raw, userId: userId)),
     );
   }
 
-  ThreadList parseThreadList(Map<String, Object?> raw) {
+  ThreadList parseThreadList(Map<String, Object?> raw, {Snowflake? guildId}) {
     return ThreadList(
       threads: parseMany(raw['threads'] as List, parse).cast<Thread>(),
-      members: parseMany(raw['members'] as List, parseThreadMember),
+      members: parseMany(raw['members'] as List, (Map<String, Object?> raw) => parseThreadMember(raw, guildId: guildId)),
       hasMore: raw['has_more'] as bool? ?? false,
     );
   }
@@ -667,6 +669,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     );
 
     final response = await client.httpHandler.executeSafe(request);
+    // TODO: Can we provide the guildId?
     return parseThreadMember(response.jsonBody as Map<String, Object?>);
   }
 
@@ -685,6 +688,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     );
 
     final response = await client.httpHandler.executeSafe(request);
+    // TODO: Can we provide the guildId?
     return parseMany(response.jsonBody as List, parseThreadMember);
   }
 
@@ -704,6 +708,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     );
 
     final response = await client.httpHandler.executeSafe(request);
+    // TODO: Can we provide the guild ID?
     return parseThreadList(response.jsonBody as Map<String, Object?>);
   }
 
@@ -723,6 +728,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     );
 
     final response = await client.httpHandler.executeSafe(request);
+    // TODO: Can we provide the guild ID?
     return parseThreadList(response.jsonBody as Map<String, Object?>);
   }
 
@@ -743,6 +749,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     );
 
     final response = await client.httpHandler.executeSafe(request);
+    // TODO: Can we provide the guild ID?
     return parseThreadList(response.jsonBody as Map<String, Object?>);
   }
 

--- a/lib/src/http/managers/channel_manager.dart
+++ b/lib/src/http/managers/channel_manager.dart
@@ -512,10 +512,10 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     final request = BasicRequest(route);
 
     final response = await client.httpHandler.executeSafe(request);
-    final invite = parseMany(response.jsonBody as List<Object?>, client.invites.parseWithMetadata);
+    final invites = parseMany(response.jsonBody as List<Object?>, client.invites.parseWithMetadata);
 
-    client.updateCacheWith(invite);
-    return invite;
+    invites.forEach(client.updateCacheWith);
+    return invites;
   }
 
   /// Create an invite in a guild channel.

--- a/lib/src/http/managers/channel_manager.dart
+++ b/lib/src/http/managers/channel_manager.dart
@@ -35,6 +35,7 @@ import 'package:nyxx/src/models/invite/invite_metadata.dart';
 import 'package:nyxx/src/models/permission_overwrite.dart';
 import 'package:nyxx/src/models/permissions.dart';
 import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/flags.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
@@ -444,7 +445,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     final response = await client.httpHandler.executeSafe(request);
     final channel = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[channel.id] = channel;
+    client.updateCacheWith(channel);
     return channel;
   }
 
@@ -461,7 +462,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     final response = await client.httpHandler.executeSafe(request);
     final channel = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[channel.id] = channel;
+    client.updateCacheWith(channel);
     return channel;
   }
 
@@ -556,7 +557,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     final response = await client.httpHandler.executeSafe(request);
     final thread = parse(response.jsonBody as Map<String, Object?>) as Thread;
 
-    cache[thread.id] = thread;
+    client.updateCacheWith(thread);
     return thread;
   }
 
@@ -570,7 +571,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     final response = await client.httpHandler.executeSafe(request);
     final thread = parse(response.jsonBody as Map<String, Object?>) as Thread;
 
-    cache[thread.id] = thread;
+    client.updateCacheWith(thread);
     return thread;
   }
 
@@ -609,7 +610,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     final response = await client.httpHandler.executeSafe(request);
     final thread = parse(response.jsonBody as Map<String, Object?>) as Thread;
 
-    cache[thread.id] = thread;
+    client.updateCacheWith(thread);
     return thread;
   }
 
@@ -758,7 +759,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     final response = await client.httpHandler.executeSafe(request);
     final stageInstance = parseStageInstance(response.jsonBody as Map<String, Object?>);
 
-    stageInstanceCache[stageInstance.channelId] = stageInstance;
+    client.updateCacheWith(stageInstance);
     return stageInstance;
   }
 
@@ -770,7 +771,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     final response = await client.httpHandler.executeSafe(request);
     final stageInstance = parseStageInstance(response.jsonBody as Map<String, Object?>);
 
-    stageInstanceCache[stageInstance.channelId] = stageInstance;
+    client.updateCacheWith(stageInstance);
     return stageInstance;
   }
 
@@ -787,7 +788,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     final response = await client.httpHandler.executeSafe(request);
     final stageInstance = parseStageInstance(response.jsonBody as Map<String, Object?>);
 
-    stageInstanceCache[stageInstance.channelId] = stageInstance;
+    client.updateCacheWith(stageInstance);
     return stageInstance;
   }
 

--- a/lib/src/http/managers/emoji_manager.dart
+++ b/lib/src/http/managers/emoji_manager.dart
@@ -2,11 +2,11 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:nyxx/src/builders/emoji/emoji.dart';
-import 'package:nyxx/src/cache/cache.dart';
 import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/route.dart';
 import 'package:nyxx/src/models/emoji.dart';
 import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 import 'manager.dart';
@@ -69,7 +69,7 @@ class EmojiManager extends Manager<Emoji> {
     final response = await client.httpHandler.executeSafe(request);
     final emoji = parse(response.jsonBody as Map<String, Object?>) as GuildEmoji;
 
-    cache[emoji.id] = emoji;
+    client.updateCacheWith(emoji);
     return emoji;
   }
 
@@ -84,7 +84,7 @@ class EmojiManager extends Manager<Emoji> {
     final response = await client.httpHandler.executeSafe(request);
     final emojis = parseMany(response.jsonBody as List<Object?>, (Map<String, Object?> raw) => parse(raw) as GuildEmoji);
 
-    cache.addEntities(emojis);
+    emojis.forEach(client.updateCacheWith);
     return emojis;
   }
 
@@ -100,7 +100,7 @@ class EmojiManager extends Manager<Emoji> {
     final response = await client.httpHandler.executeSafe(request);
     final emoji = parse(response.jsonBody as Map<String, Object?>) as GuildEmoji;
 
-    cache[emoji.id] = emoji;
+    client.updateCacheWith(emoji);
     return emoji;
   }
 
@@ -116,7 +116,7 @@ class EmojiManager extends Manager<Emoji> {
     final response = await client.httpHandler.executeSafe(request);
     final emoji = parse(response.jsonBody as Map<String, Object?>) as GuildEmoji;
 
-    cache[emoji.id] = emoji;
+    client.updateCacheWith(emoji);
     return emoji;
   }
 

--- a/lib/src/http/managers/entitlement_manager.dart
+++ b/lib/src/http/managers/entitlement_manager.dart
@@ -1,13 +1,13 @@
 import 'dart:convert';
 
 import 'package:nyxx/src/builders/entitlement.dart';
-import 'package:nyxx/src/cache/cache.dart';
 import 'package:nyxx/src/errors.dart';
 import 'package:nyxx/src/http/managers/manager.dart';
 import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/route.dart';
 import 'package:nyxx/src/models/entitlement.dart';
 import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 /// A [Manager] for [Entitlement]s.
@@ -63,7 +63,7 @@ class EntitlementManager extends ReadOnlyManager<Entitlement> {
     final response = await client.httpHandler.executeSafe(request);
     final entitlements = parseMany(response.jsonBody as List<Object?>, parse);
 
-    cache.addEntities(entitlements);
+    entitlements.forEach(client.updateCacheWith);
     return entitlements;
   }
 
@@ -87,7 +87,7 @@ class EntitlementManager extends ReadOnlyManager<Entitlement> {
     final response = await client.httpHandler.executeSafe(request);
     final entitlement = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[entitlement.id] = entitlement;
+    client.updateCacheWith(entitlement);
     return entitlement;
   }
 

--- a/lib/src/http/managers/guild_manager.dart
+++ b/lib/src/http/managers/guild_manager.dart
@@ -9,7 +9,6 @@ import 'package:nyxx/src/builders/guild/welcome_screen.dart';
 import 'package:nyxx/src/builders/guild/widget.dart';
 import 'package:nyxx/src/builders/image.dart';
 import 'package:nyxx/src/builders/voice.dart';
-import 'package:nyxx/src/cache/cache.dart';
 import 'package:nyxx/src/http/managers/manager.dart';
 import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/route.dart';
@@ -30,6 +29,7 @@ import 'package:nyxx/src/models/permissions.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/user/user.dart';
 import 'package:nyxx/src/models/voice/voice_region.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/flags.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
@@ -314,7 +314,7 @@ class GuildManager extends Manager<Guild> {
     final response = await client.httpHandler.executeSafe(request);
     final guild = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[guild.id] = guild;
+    client.updateCacheWith(guild);
     return guild;
   }
 
@@ -326,7 +326,7 @@ class GuildManager extends Manager<Guild> {
     final response = await client.httpHandler.executeSafe(request);
     final guild = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[guild.id] = guild;
+    client.updateCacheWith(guild);
     return guild;
   }
 
@@ -338,7 +338,7 @@ class GuildManager extends Manager<Guild> {
     final response = await client.httpHandler.executeSafe(request);
     final guild = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[guild.id] = guild;
+    client.updateCacheWith(guild);
     return guild;
   }
 
@@ -372,7 +372,7 @@ class GuildManager extends Manager<Guild> {
     final response = await client.httpHandler.executeSafe(request);
     final channels = parseMany(response.jsonBody as List, client.channels.parse).cast<GuildChannel>();
 
-    client.channels.cache.addEntities(channels);
+    channels.forEach(client.updateCacheWith);
     return channels;
   }
 
@@ -386,7 +386,7 @@ class GuildManager extends Manager<Guild> {
     final response = await client.httpHandler.executeSafe(request);
     final channel = client.channels.parse(response.jsonBody as Map<String, Object?>) as T;
 
-    client.channels.cache[channel.id] = channel;
+    client.updateCacheWith(channel);
     return channel;
   }
 
@@ -411,7 +411,7 @@ class GuildManager extends Manager<Guild> {
     final response = await client.httpHandler.executeSafe(request);
     final list = client.channels.parseThreadList(response.jsonBody as Map<String, Object?>);
 
-    client.channels.cache.addEntities(list.threads);
+    client.updateCacheWith(list);
     return list;
   }
 
@@ -675,7 +675,7 @@ class GuildManager extends Manager<Guild> {
     final response = await client.httpHandler.executeSafe(request);
     final guild = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[guild.id] = guild;
+    client.updateCacheWith(guild);
     return guild;
   }
 

--- a/lib/src/http/managers/guild_manager.dart
+++ b/lib/src/http/managers/guild_manager.dart
@@ -255,7 +255,7 @@ class GuildManager extends Manager<Guild> {
 
     // Discord passes an "empty" emoji object when unset instead of null
     if (rawEmoji['id'] != null || rawEmoji['name'] != null) {
-      emoji = this[guildId ?? Snowflake.zero].emojis.parse(raw['emoji'] as Map<String, Object?>);
+      emoji = client.guilds[guildId ?? Snowflake.zero].emojis.parse(raw['emoji'] as Map<String, Object?>);
     }
 
     return OnboardingPromptOption(
@@ -384,7 +384,7 @@ class GuildManager extends Manager<Guild> {
     final request = BasicRequest(route, method: 'POST', auditLogReason: auditLogReason, body: jsonEncode(builder.build()));
 
     final response = await client.httpHandler.executeSafe(request);
-    final channel = client.channels.parse(response.jsonBody as Map<String, Object?>) as T;
+    final channel = client.channels.parse(response.jsonBody as Map<String, Object?>, guildId: id) as T;
 
     client.updateCacheWith(channel);
     return channel;
@@ -409,7 +409,7 @@ class GuildManager extends Manager<Guild> {
     final request = BasicRequest(route);
 
     final response = await client.httpHandler.executeSafe(request);
-    final list = client.channels.parseThreadList(response.jsonBody as Map<String, Object?>);
+    final list = client.channels.parseThreadList(response.jsonBody as Map<String, Object?>, guildId: id);
 
     client.updateCacheWith(list);
     return list;

--- a/lib/src/http/managers/guild_manager.dart
+++ b/lib/src/http/managers/guild_manager.dart
@@ -387,7 +387,7 @@ class GuildManager extends Manager<Guild> {
     final request = BasicRequest(route, method: 'POST', auditLogReason: auditLogReason, body: jsonEncode(builder.build()));
 
     final response = await client.httpHandler.executeSafe(request);
-    final channel = client.channels.parse(response.jsonBody as Map<String, Object?>, guildId: id) as T;
+    final channel = client.channels.parse(response.jsonBody as Map<String, Object?>) as T;
 
     client.updateCacheWith(channel);
     return channel;

--- a/lib/src/http/managers/guild_manager.dart
+++ b/lib/src/http/managers/guild_manager.dart
@@ -125,7 +125,7 @@ class GuildManager extends Manager<Guild> {
     for (final entry in _nameToGuildFeature.entries) entry.value: entry.key,
   };
 
-  /// Parse an [GuildFeatures] from [raw]./// Parse [GuildFeatures] from [raw].
+  /// Parse an [GuildFeatures] from [raw].
   GuildFeatures parseGuildFeatures(List<Object?> raw) {
     final featureFlags = parseMany(raw, parseGuildFeature);
 
@@ -359,7 +359,10 @@ class GuildManager extends Manager<Guild> {
     final request = BasicRequest(route);
 
     final response = await client.httpHandler.executeSafe(request);
-    return parseGuildPreview(response.jsonBody as Map<String, Object?>);
+    final preview = parseGuildPreview(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(preview);
+    return preview;
   }
 
   /// Fetch the channels in a guild.
@@ -423,7 +426,10 @@ class GuildManager extends Manager<Guild> {
     final request = BasicRequest(route);
 
     final response = await client.httpHandler.executeSafe(request);
-    return parseMany(response.jsonBody as List, parseBan);
+    final bans = parseMany(response.jsonBody as List, parseBan);
+
+    bans.forEach(client.updateCacheWith);
+    return bans;
   }
 
   /// Fetch a ban in a guild.
@@ -434,7 +440,10 @@ class GuildManager extends Manager<Guild> {
     final request = BasicRequest(route);
 
     final response = await client.httpHandler.executeSafe(request);
-    return parseBan(response.jsonBody as Map<String, Object?>);
+    final ban = parseBan(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(ban);
+    return ban;
   }
 
   /// Create a ban in a guild.
@@ -539,7 +548,10 @@ class GuildManager extends Manager<Guild> {
     final request = BasicRequest(route);
 
     final response = await client.httpHandler.executeSafe(request);
-    return parseMany(response.jsonBody as List, client.invites.parse);
+    final invites = parseMany(response.jsonBody as List, client.invites.parse);
+
+    invites.forEach(client.updateCacheWith);
+    return invites;
   }
 
   /// Fetch a guild's widget settings.
@@ -662,7 +674,10 @@ class GuildManager extends Manager<Guild> {
     final request = BasicRequest(route);
 
     final response = await client.httpHandler.executeSafe(request);
-    return parseGuildTemplate(response.jsonBody as Map<String, Object?>);
+    final template = parseGuildTemplate(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(template);
+    return template;
   }
 
   /// Create a guild from a guild template.
@@ -687,7 +702,10 @@ class GuildManager extends Manager<Guild> {
     final request = BasicRequest(route);
 
     final response = await client.httpHandler.executeSafe(request);
-    return parseMany(response.jsonBody as List<Object?>, parseGuildTemplate);
+    final templates = parseMany(response.jsonBody as List<Object?>, parseGuildTemplate);
+
+    templates.forEach(client.updateCacheWith);
+    return templates;
   }
 
   /// Create a guild template from a guild.
@@ -698,7 +716,10 @@ class GuildManager extends Manager<Guild> {
     final request = BasicRequest(route, method: 'POST', body: jsonEncode(builder.build()));
 
     final response = await client.httpHandler.executeSafe(request);
-    return parseGuildTemplate(response.jsonBody as Map<String, Object?>);
+    final template = parseGuildTemplate(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(template);
+    return template;
   }
 
   /// Sync a guild template to the source guild.
@@ -709,7 +730,10 @@ class GuildManager extends Manager<Guild> {
     final request = BasicRequest(route, method: 'PUT');
 
     final response = await client.httpHandler.executeSafe(request);
-    return parseGuildTemplate(response.jsonBody as Map<String, Object?>);
+    final template = parseGuildTemplate(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(template);
+    return template;
   }
 
   /// Update a guild template.
@@ -720,7 +744,10 @@ class GuildManager extends Manager<Guild> {
     final request = BasicRequest(route, method: 'PATCH', body: jsonEncode(builder.build()));
 
     final response = await client.httpHandler.executeSafe(request);
-    return parseGuildTemplate(response.jsonBody as Map<String, Object?>);
+    final template = parseGuildTemplate(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(template);
+    return template;
   }
 
   /// Delete a guild template.
@@ -731,6 +758,10 @@ class GuildManager extends Manager<Guild> {
     final request = BasicRequest(route, method: 'DELETE');
 
     final response = await client.httpHandler.executeSafe(request);
-    return parseGuildTemplate(response.jsonBody as Map<String, Object?>);
+    final template = parseGuildTemplate(response.jsonBody as Map<String, Object?>);
+
+    // Templates aren't cached, so we don't need to remove it from any cache, but it still contains a nested user object we can cache.
+    client.updateCacheWith(template);
+    return template;
   }
 }

--- a/lib/src/http/managers/integration_manager.dart
+++ b/lib/src/http/managers/integration_manager.dart
@@ -1,10 +1,10 @@
-import 'package:nyxx/src/cache/cache.dart';
 import 'package:nyxx/src/errors.dart';
 import 'package:nyxx/src/http/managers/manager.dart';
 import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/route.dart';
 import 'package:nyxx/src/models/guild/integration.dart';
 import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 /// A [Manager] for [Integration]s.
@@ -80,7 +80,7 @@ class IntegrationManager extends ReadOnlyManager<Integration> {
     final response = await client.httpHandler.executeSafe(request);
     final integrations = parseMany(response.jsonBody as List, parse);
 
-    cache.addEntities(integrations);
+    integrations.forEach(client.updateCacheWith);
     return integrations;
   }
 

--- a/lib/src/http/managers/interaction_manager.dart
+++ b/lib/src/http/managers/interaction_manager.dart
@@ -17,6 +17,7 @@ import 'package:nyxx/src/models/message/component.dart';
 import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/permissions.dart';
 import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 /// A [Manager] for [Interaction]s.
@@ -337,7 +338,10 @@ class InteractionManager {
     final response = await client.httpHandler.executeSafe(request);
 
     final channelId = Snowflake.parse((response.jsonBody as Map<String, Object?>)['channel_id']!);
-    return (client.channels[channelId] as PartialTextChannel).messages.parse(response.jsonBody as Map<String, Object?>);
+    final message = (client.channels[channelId] as PartialTextChannel).messages.parse(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(message);
+    return message;
   }
 
   /// Fetch a followup to an interaction.
@@ -358,7 +362,10 @@ class InteractionManager {
     final response = await client.httpHandler.executeSafe(request);
 
     final channelId = Snowflake.parse((response.jsonBody as Map<String, Object?>)['channel_id']!);
-    return (client.channels[channelId] as PartialTextChannel).messages.parse(response.jsonBody as Map<String, Object?>);
+    final message = (client.channels[channelId] as PartialTextChannel).messages.parse(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(message);
+    return message;
   }
 
   Future<Message> _updateResponse(String token, String messageId, MessageUpdateBuilder builder) async {
@@ -400,7 +407,10 @@ class InteractionManager {
 
     final response = await client.httpHandler.executeSafe(request);
     final channelId = Snowflake.parse((response.jsonBody as Map<String, Object?>)['channel_id']!);
-    return (client.channels[channelId] as PartialTextChannel).messages.parse(response.jsonBody as Map<String, Object?>);
+    final message = (client.channels[channelId] as PartialTextChannel).messages.parse(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(message);
+    return message;
   }
 
   Future<void> _deleteResponse(String token, String messageId) async {

--- a/lib/src/http/managers/interaction_manager.dart
+++ b/lib/src/http/managers/interaction_manager.dart
@@ -37,11 +37,16 @@ class InteractionManager {
     final id = Snowflake.parse(raw['id']!);
     final applicationId = Snowflake.parse(raw['application_id']!);
     final channel = maybeParse(raw['channel'], (Map<String, Object?> raw) => client.channels[Snowflake.parse(raw['id']!)]);
-    final member = maybeParse(raw['member'], client.guilds[guildId ?? Snowflake.zero].members.parse);
+    // Don't use a tearoff so we don't evaluate `guildId!` unless member is set.
+    final member = maybeParse(raw['member'], (Map<String, Object?> raw) => client.guilds[guildId!].members.parse(raw));
     final user = maybeParse(raw['user'], client.users.parse);
     final token = raw['token'] as String;
     final version = raw['version'] as int;
-    final message = maybeParse(raw['message'], (client.channels[channelId ?? Snowflake.zero] as PartialTextChannel).messages.parse);
+    // Don't use a tearoff so we don't evaluate `channelId!` unless message is set.
+    final message = maybeParse(
+      raw['message'],
+      (Map<String, Object?> raw) => (client.channels[channelId!] as PartialTextChannel).messages.parse(raw, guildId: guildId),
+    );
     final appPermissions = maybeParse(raw['app_permissions'], (String raw) => Permissions(int.parse(raw)));
     final locale = maybeParse(raw['locale'], Locale.parse);
     final guildLocale = maybeParse(raw['guild_locale'], Locale.parse);
@@ -90,7 +95,7 @@ class InteractionManager {
           id: id,
           applicationId: applicationId,
           type: type,
-          data: parseMessageComponentInteractionData(raw['data'] as Map<String, Object?>),
+          data: parseMessageComponentInteractionData(raw['data'] as Map<String, Object?>, guildId: guildId, channelId: channelId),
           guildId: guildId,
           channel: channel,
           channelId: channelId,
@@ -152,6 +157,8 @@ class InteractionManager {
       type: ApplicationCommandType.parse(raw['type'] as int),
       resolved: maybeParse(raw['resolved'], (Map<String, Object?> raw) => parseResolvedData(raw, guildId: guildId, channelId: channelId)),
       options: maybeParseMany(raw['options'], parseInteractionOption),
+      // This guild_id is the ID of the guild the command is registered in, so it may be null even if the command was executed in a guild.
+      // Because of this, we still need the guildId parameter for the actual guild the command was executed in.
       guildId: maybeParse(raw['guild_id'], Snowflake.parse),
       targetId: maybeParse(raw['target_id'], Snowflake.parse),
     );
@@ -219,12 +226,12 @@ class InteractionManager {
     );
   }
 
-  MessageComponentInteractionData parseMessageComponentInteractionData(Map<String, Object?> raw) {
+  MessageComponentInteractionData parseMessageComponentInteractionData(Map<String, Object?> raw, {Snowflake? guildId, Snowflake? channelId}) {
     return MessageComponentInteractionData(
       customId: raw['custom_id'] as String,
       type: MessageComponentType.parse(raw['component_type'] as int),
       values: maybeParseMany(raw['values']),
-      resolved: maybeParse(raw['resolved'], parseResolvedData),
+      resolved: maybeParse(raw['resolved'], (Map<String, Object?> raw) => parseResolvedData(raw, guildId: guildId, channelId: channelId)),
     );
   }
 

--- a/lib/src/http/managers/invite_manager.dart
+++ b/lib/src/http/managers/invite_manager.dart
@@ -38,7 +38,8 @@ class InviteManager {
       approximatePresenceCount: raw['approximate_presence_count'] as int?,
       approximateMemberCount: raw['approximate_member_count'] as int?,
       expiresAt: maybeParse(raw['expires_at'], DateTime.parse),
-      guildScheduledEvent: maybeParse(raw['guild_scheduled_event'], client.guilds[guild?.id ?? Snowflake.zero].scheduledEvents.parse),
+      // Don't use a tearoff so we don't evaluate `guild!.id` unless guild_scheduled_event is set.
+      guildScheduledEvent: maybeParse(raw['guild_scheduled_event'], (Map<String, Object?> raw) => client.guilds[guild!.id].scheduledEvents.parse(raw)),
     );
   }
 

--- a/lib/src/http/managers/invite_manager.dart
+++ b/lib/src/http/managers/invite_manager.dart
@@ -7,6 +7,7 @@ import 'package:nyxx/src/models/guild/guild.dart';
 import 'package:nyxx/src/models/invite/invite.dart';
 import 'package:nyxx/src/models/invite/invite_metadata.dart';
 import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 /// A manager for [Invite]s.
@@ -76,7 +77,10 @@ class InviteManager {
     });
 
     final response = await client.httpHandler.executeSafe(request);
-    return parse(response.jsonBody as Map<String, Object?>);
+    final invite = parse(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(invite);
+    return invite;
   }
 
   /// Delete an invite.
@@ -85,6 +89,10 @@ class InviteManager {
     final request = BasicRequest(route, method: 'DELETE');
 
     final response = await client.httpHandler.executeSafe(request);
-    return parse(response.jsonBody as Map<String, Object?>);
+    final invite = parse(response.jsonBody as Map<String, Object?>);
+
+    // Invites aren't cached, so we don't need to remove it, but it still contains nested objects we can cache.
+    client.updateCacheWith(invite);
+    return invite;
   }
 }

--- a/lib/src/http/managers/member_manager.dart
+++ b/lib/src/http/managers/member_manager.dart
@@ -124,7 +124,10 @@ class MemberManager extends Manager<Member> {
     final request = BasicRequest(route, queryParameters: {'query': query, if (limit != null) 'limit': limit.toString()});
 
     final response = await client.httpHandler.executeSafe(request);
-    return parseMany(response.jsonBody as List, parse);
+    final members = parseMany(response.jsonBody as List, parse);
+
+    members.forEach(client.updateCacheWith);
+    return members;
   }
 
   /// Update the current member in the guild.

--- a/lib/src/http/managers/member_manager.dart
+++ b/lib/src/http/managers/member_manager.dart
@@ -49,7 +49,7 @@ class MemberManager extends Manager<Member> {
     final request = BasicRequest(route);
 
     final response = await client.httpHandler.executeSafe(request);
-    final member = parse(response.jsonBody as Map<String, Object?>);
+    final member = parse(response.jsonBody as Map<String, Object?>, userId: id);
 
     client.updateCacheWith(member);
     return member;
@@ -84,7 +84,7 @@ class MemberManager extends Manager<Member> {
       throw MemberAlreadyExistsException(guildId, builder.userId);
     }
 
-    final member = parse(response.jsonBody as Map<String, Object?>);
+    final member = parse(response.jsonBody as Map<String, Object?>, userId: builder.userId);
 
     client.updateCacheWith(member);
     return member;
@@ -98,7 +98,7 @@ class MemberManager extends Manager<Member> {
     final request = BasicRequest(route, method: 'PATCH', auditLogReason: auditLogReason, body: jsonEncode(builder.build()));
 
     final response = await client.httpHandler.executeSafe(request);
-    final member = parse(response.jsonBody as Map<String, Object?>);
+    final member = parse(response.jsonBody as Map<String, Object?>, userId: id);
 
     client.updateCacheWith(member);
     return member;
@@ -135,7 +135,7 @@ class MemberManager extends Manager<Member> {
     final request = BasicRequest(route, method: 'PATCH', body: jsonEncode(builder.build()));
 
     final response = await client.httpHandler.executeSafe(request);
-    final member = parse(response.jsonBody as Map<String, Object?>);
+    final member = parse(response.jsonBody as Map<String, Object?>, userId: client.user.id);
 
     client.updateCacheWith(member);
     return member;

--- a/lib/src/http/managers/member_manager.dart
+++ b/lib/src/http/managers/member_manager.dart
@@ -24,7 +24,7 @@ class MemberManager extends Manager<Member> {
   @override
   Member parse(Map<String, Object?> raw, {Snowflake? userId}) {
     return Member(
-      id: userId ?? Snowflake.parse((raw['user'] as Map<String, Object?>)['id']!),
+      id: maybeParse((raw['user'] as Map<String, Object?>?)?['id'], Snowflake.parse) ?? userId ?? Snowflake.zero,
       manager: this,
       user: maybeParse(raw['user'], client.users.parse),
       nick: raw['nick'] as String?,

--- a/lib/src/http/managers/member_manager.dart
+++ b/lib/src/http/managers/member_manager.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:nyxx/src/builders/guild/member.dart';
-import 'package:nyxx/src/cache/cache.dart';
 import 'package:nyxx/src/errors.dart';
 import 'package:nyxx/src/http/managers/manager.dart';
 import 'package:nyxx/src/http/request.dart';
@@ -9,6 +8,7 @@ import 'package:nyxx/src/http/route.dart';
 import 'package:nyxx/src/models/guild/member.dart';
 import 'package:nyxx/src/models/permissions.dart';
 import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 /// A manager for [Member]s.
@@ -51,7 +51,7 @@ class MemberManager extends Manager<Member> {
     final response = await client.httpHandler.executeSafe(request);
     final member = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[member.id] = member;
+    client.updateCacheWith(member);
     return member;
   }
 
@@ -68,7 +68,7 @@ class MemberManager extends Manager<Member> {
     final response = await client.httpHandler.executeSafe(request);
     final members = parseMany(response.jsonBody as List, parse);
 
-    cache.addEntities(members);
+    members.forEach(client.updateCacheWith);
     return members;
   }
 
@@ -86,7 +86,7 @@ class MemberManager extends Manager<Member> {
 
     final member = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[member.id] = member;
+    client.updateCacheWith(member);
     return member;
   }
 
@@ -100,7 +100,7 @@ class MemberManager extends Manager<Member> {
     final response = await client.httpHandler.executeSafe(request);
     final member = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[member.id] = member;
+    client.updateCacheWith(member);
     return member;
   }
 
@@ -137,7 +137,7 @@ class MemberManager extends Manager<Member> {
     final response = await client.httpHandler.executeSafe(request);
     final member = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[member.id] = member;
+    client.updateCacheWith(member);
     return member;
   }
 

--- a/lib/src/http/managers/message_manager.dart
+++ b/lib/src/http/managers/message_manager.dart
@@ -4,7 +4,6 @@ import 'package:http/http.dart' show MultipartFile;
 import 'package:nyxx/src/builders/emoji/reaction.dart';
 import 'package:nyxx/src/builders/message/message.dart';
 import 'package:nyxx/src/builders/sentinels.dart';
-import 'package:nyxx/src/cache/cache.dart';
 import 'package:nyxx/src/http/managers/manager.dart';
 import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/route.dart';
@@ -25,6 +24,7 @@ import 'package:nyxx/src/models/message/reference.dart';
 import 'package:nyxx/src/models/message/role_subscription_data.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/user/user.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 /// A manager for [Message]s in a [TextChannel].
@@ -337,7 +337,7 @@ class MessageManager extends Manager<Message> {
     final response = await client.httpHandler.executeSafe(request);
     final message = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[message.id] = message;
+    client.updateCacheWith(message);
     return message;
   }
 
@@ -351,7 +351,7 @@ class MessageManager extends Manager<Message> {
     final response = await client.httpHandler.executeSafe(request);
     final message = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[message.id] = message;
+    client.updateCacheWith(message);
     return message;
   }
 
@@ -390,7 +390,7 @@ class MessageManager extends Manager<Message> {
     final response = await client.httpHandler.executeSafe(request);
     final message = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[message.id] = message;
+    client.updateCacheWith(message);
     return message;
   }
 
@@ -424,7 +424,7 @@ class MessageManager extends Manager<Message> {
     final response = await client.httpHandler.executeSafe(request);
     final messages = parseMany(response.jsonBody as List, parse);
 
-    cache.addEntities(messages);
+    messages.forEach(client.updateCacheWith);
     return messages;
   }
 
@@ -439,7 +439,7 @@ class MessageManager extends Manager<Message> {
     final response = await client.httpHandler.executeSafe(request);
     final message = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[message.id] = message;
+    client.updateCacheWith(message);
     return message;
   }
 
@@ -466,7 +466,7 @@ class MessageManager extends Manager<Message> {
     final response = await client.httpHandler.executeSafe(request);
     final messages = parseMany(response.jsonBody as List, parse);
 
-    cache.addEntities(messages);
+    messages.forEach(client.updateCacheWith);
     return messages;
   }
 

--- a/lib/src/http/managers/message_manager.dart
+++ b/lib/src/http/managers/message_manager.dart
@@ -9,6 +9,7 @@ import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/route.dart';
 import 'package:nyxx/src/models/application.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
+import 'package:nyxx/src/models/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/thread.dart';
 import 'package:nyxx/src/models/discord_color.dart';
 import 'package:nyxx/src/models/interaction.dart';
@@ -39,7 +40,11 @@ class MessageManager extends Manager<Message> {
   PartialMessage operator [](Snowflake id) => PartialMessage(id: id, manager: this);
 
   @override
-  Message parse(Map<String, Object?> raw) {
+  Message parse(Map<String, Object?> raw, {Snowflake? guildId}) {
+    if (client.channels.cache[channelId] case GuildChannel(guildId: final guildIdFromChannel)) {
+      guildId ??= guildIdFromChannel;
+    }
+
     final webhookId = maybeParse(raw['webhook_id'], Snowflake.parse);
 
     return Message(
@@ -81,7 +86,7 @@ class MessageManager extends Manager<Message> {
       position: raw['position'] as int?,
       roleSubscriptionData: maybeParse(raw['role_subscription_data'], parseRoleSubscriptionData),
       stickers: parseMany(raw['sticker_items'] as List? ?? [], client.stickers.parseStickerItem),
-      resolved: maybeParse(raw['resolved'], client.interactions.parseResolvedData),
+      resolved: maybeParse(raw['resolved'], (Map<String, Object?> raw) => client.interactions.parseResolvedData(raw, guildId: guildId, channelId: channelId)),
     );
   }
 

--- a/lib/src/http/managers/message_manager.dart
+++ b/lib/src/http/managers/message_manager.dart
@@ -563,8 +563,10 @@ class MessageManager extends Manager<Message> {
     final request = BasicRequest(route);
 
     final response = await client.httpHandler.executeSafe(request);
+    final users = parseMany(response.jsonBody as List, client.users.parse);
 
-    return parseMany(response.jsonBody as List, client.users.parse);
+    users.forEach(client.updateCacheWith);
+    return users;
   }
 
   // TODO once oauth2 is implemented: Group DM control endpoints

--- a/lib/src/http/managers/role_manager.dart
+++ b/lib/src/http/managers/role_manager.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:nyxx/src/builders/role.dart';
-import 'package:nyxx/src/cache/cache.dart';
 import 'package:nyxx/src/errors.dart';
 import 'package:nyxx/src/http/managers/manager.dart';
 import 'package:nyxx/src/http/request.dart';
@@ -10,6 +9,7 @@ import 'package:nyxx/src/models/discord_color.dart';
 import 'package:nyxx/src/models/permissions.dart';
 import 'package:nyxx/src/models/role.dart';
 import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 /// A manager for [Role]s.
@@ -60,7 +60,7 @@ class RoleManager extends Manager<Role> {
     final response = await client.httpHandler.executeSafe(request);
     final roles = parseMany(response.jsonBody as List, parse);
 
-    cache.addEntities(roles);
+    roles.forEach(client.updateCacheWith);
     return roles;
   }
 
@@ -86,7 +86,7 @@ class RoleManager extends Manager<Role> {
     final response = await client.httpHandler.executeSafe(request);
     final role = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[role.id] = role;
+    client.updateCacheWith(role);
     return role;
   }
 
@@ -100,7 +100,7 @@ class RoleManager extends Manager<Role> {
     final response = await client.httpHandler.executeSafe(request);
     final role = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[role.id] = role;
+    client.updateCacheWith(role);
     return role;
   }
 
@@ -130,7 +130,7 @@ class RoleManager extends Manager<Role> {
     final response = await client.httpHandler.executeSafe(request);
     final roles = parseMany(response.jsonBody as List, parse);
 
-    cache.addEntities(roles);
+    roles.forEach(client.updateCacheWith);
     return roles;
   }
 }

--- a/lib/src/http/managers/scheduled_event_manager.dart
+++ b/lib/src/http/managers/scheduled_event_manager.dart
@@ -142,6 +142,9 @@ class ScheduledEventManager extends Manager<ScheduledEvent> {
     });
 
     final response = await client.httpHandler.executeSafe(request);
-    return parseMany(response.jsonBody as List<Object?>, parseScheduledEventUser);
+    final users = parseMany(response.jsonBody as List<Object?>, parseScheduledEventUser);
+
+    users.forEach(client.updateCacheWith);
+    return users;
   }
 }

--- a/lib/src/http/managers/scheduled_event_manager.dart
+++ b/lib/src/http/managers/scheduled_event_manager.dart
@@ -50,11 +50,13 @@ class ScheduledEventManager extends Manager<ScheduledEvent> {
   }
 
   ScheduledEventUser parseScheduledEventUser(Map<String, Object?> raw) {
+    final user = client.users.parse(raw['user'] as Map<String, Object?>);
+
     return ScheduledEventUser(
       manager: this,
       scheduledEventId: Snowflake.parse(raw['guild_scheduled_event_id']!),
-      user: client.users.parse(raw['user'] as Map<String, Object?>),
-      member: maybeParse(raw['member'], client.guilds[guildId].members.parse),
+      user: user,
+      member: maybeParse(raw['member'], (Map<String, Object?> raw) => client.guilds[guildId].members.parse(raw, userId: user.id)),
     );
   }
 

--- a/lib/src/http/managers/scheduled_event_manager.dart
+++ b/lib/src/http/managers/scheduled_event_manager.dart
@@ -1,13 +1,13 @@
 import 'dart:convert';
 
 import 'package:nyxx/src/builders/guild/scheduled_event.dart';
-import 'package:nyxx/src/cache/cache.dart';
 import 'package:nyxx/src/http/managers/manager.dart';
 import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/route.dart';
 import 'package:nyxx/src/models/channel/stage_instance.dart';
 import 'package:nyxx/src/models/guild/scheduled_event.dart';
 import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 /// A [Manager] for [ScheduledEvent]s.
@@ -68,7 +68,7 @@ class ScheduledEventManager extends Manager<ScheduledEvent> {
     final response = await client.httpHandler.executeSafe(request);
     final event = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[event.id] = event;
+    client.updateCacheWith(event);
     return event;
   }
 
@@ -82,7 +82,7 @@ class ScheduledEventManager extends Manager<ScheduledEvent> {
     final response = await client.httpHandler.executeSafe(request);
     final events = parseMany(response.jsonBody as List<Object?>, parse);
 
-    cache.addEntities(events);
+    events.forEach(client.updateCacheWith);
     return events;
   }
 
@@ -96,7 +96,7 @@ class ScheduledEventManager extends Manager<ScheduledEvent> {
     final response = await client.httpHandler.executeSafe(request);
     final event = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[event.id] = event;
+    client.updateCacheWith(event);
     return event;
   }
 
@@ -110,7 +110,7 @@ class ScheduledEventManager extends Manager<ScheduledEvent> {
     final response = await client.httpHandler.executeSafe(request);
     final event = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[event.id] = event;
+    client.updateCacheWith(event);
     return event;
   }
 

--- a/lib/src/http/managers/sticker_manager.dart
+++ b/lib/src/http/managers/sticker_manager.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:http/http.dart';
 import 'package:nyxx/src/builders/sticker.dart';
-import 'package:nyxx/src/cache/cache.dart';
 import 'package:nyxx/src/http/managers/manager.dart';
 import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/route.dart';
@@ -11,6 +10,7 @@ import 'package:nyxx/src/models/sticker/global_sticker.dart';
 import 'package:nyxx/src/models/sticker/guild_sticker.dart';
 import 'package:nyxx/src/models/sticker/sticker.dart';
 import 'package:nyxx/src/models/sticker/sticker_pack.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 class GuildStickerManager extends Manager<GuildSticker> {
@@ -32,8 +32,8 @@ class GuildStickerManager extends Manager<GuildSticker> {
     final response = await client.httpHandler.executeSafe(request);
 
     final sticker = parse(response.jsonBody as Map<String, Object?>);
-    cache[sticker.id] = sticker;
 
+    client.updateCacheWith(sticker);
     return sticker;
   }
 
@@ -46,7 +46,7 @@ class GuildStickerManager extends Manager<GuildSticker> {
     final response = await client.httpHandler.executeSafe(request);
 
     final stickers = parseMany(response.jsonBody as List<Object?>, (Map<String, Object?> raw) => parse(raw));
-    cache.addEntities(stickers);
+    stickers.forEach(client.updateCacheWith);
 
     return stickers;
   }
@@ -73,7 +73,7 @@ class GuildStickerManager extends Manager<GuildSticker> {
 
     final sticker = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[sticker.id] = sticker;
+    client.updateCacheWith(sticker);
     return sticker;
   }
 
@@ -105,7 +105,7 @@ class GuildStickerManager extends Manager<GuildSticker> {
 
     final sticker = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[sticker.id] = sticker;
+    client.updateCacheWith(sticker);
     return sticker;
   }
 }
@@ -125,7 +125,7 @@ class GlobalStickerManager extends ReadOnlyManager<GlobalSticker> {
 
     final sticker = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[sticker.id] = sticker;
+    client.updateCacheWith(sticker);
     return sticker;
   }
 

--- a/lib/src/http/managers/sticker_manager.dart
+++ b/lib/src/http/managers/sticker_manager.dart
@@ -22,15 +22,31 @@ class GuildStickerManager extends Manager<GuildSticker> {
   PartialGuildSticker operator [](Snowflake id) => PartialGuildSticker(id: id, manager: this);
 
   @override
+  GuildSticker parse(Map<String, Object?> raw) {
+    return GuildSticker(
+      manager: this,
+      id: Snowflake.parse(raw['id']!),
+      name: raw['name'] as String,
+      description: raw['description'] as String?,
+      tags: raw['tags'] as String,
+      type: StickerType.parse(raw['type'] as int),
+      formatType: StickerFormatType.parse(raw['format_type'] as int),
+      available: raw['available'] as bool? ?? false,
+      guildId: Snowflake.parse(raw['guild_id']!),
+      user: ((raw['user'] ?? {}) as Map)['id'] != null ? client.users[Snowflake.parse((raw['user'] as Map<String, Object?>)['id']!)] : null,
+      sortValue: raw['sort_value'] as int?,
+    );
+  }
+
+  @override
   Future<GuildSticker> create(StickerBuilder builder) async {
     final route = HttpRoute()
       ..guilds(id: guildId.toString())
       ..stickers();
-
     final request = FormDataRequest(route,
         method: 'POST', formParams: builder.build().cast<String, String>(), files: [MultipartFile.fromBytes('file', builder.file.buildRawData())]);
-    final response = await client.httpHandler.executeSafe(request);
 
+    final response = await client.httpHandler.executeSafe(request);
     final sticker = parse(response.jsonBody as Map<String, Object?>);
 
     client.updateCacheWith(sticker);
@@ -41,13 +57,12 @@ class GuildStickerManager extends Manager<GuildSticker> {
     final route = HttpRoute()
       ..guilds(id: guildId.toString())
       ..stickers();
-
     final request = BasicRequest(route);
+
     final response = await client.httpHandler.executeSafe(request);
-
     final stickers = parseMany(response.jsonBody as List<Object?>, (Map<String, Object?> raw) => parse(raw));
-    stickers.forEach(client.updateCacheWith);
 
+    stickers.forEach(client.updateCacheWith);
     return stickers;
   }
 
@@ -78,23 +93,6 @@ class GuildStickerManager extends Manager<GuildSticker> {
   }
 
   @override
-  GuildSticker parse(Map<String, Object?> raw) {
-    return GuildSticker(
-      manager: this,
-      id: Snowflake.parse(raw['id']!),
-      name: raw['name'] as String,
-      description: raw['description'] as String?,
-      tags: raw['tags'] as String,
-      type: StickerType.parse(raw['type'] as int),
-      formatType: StickerFormatType.parse(raw['format_type'] as int),
-      available: raw['available'] as bool? ?? false,
-      guildId: Snowflake.parse(raw['guild_id']!),
-      user: ((raw['user'] ?? {}) as Map)['id'] != null ? client.users[Snowflake.parse((raw['user'] as Map<String, Object?>)['id']!)] : null,
-      sortValue: raw['sort_value'] as int?,
-    );
-  }
-
-  @override
   Future<GuildSticker> update(Snowflake id, StickerUpdateBuilder builder) async {
     final route = HttpRoute()
       ..guilds(id: guildId.toString())
@@ -117,34 +115,20 @@ class GlobalStickerManager extends ReadOnlyManager<GlobalSticker> {
   PartialGlobalSticker operator [](Snowflake id) => PartialGlobalSticker(id: id, manager: this);
 
   @override
-  Future<GlobalSticker> fetch(Snowflake id) async {
-    final route = HttpRoute()..stickers(id: id.toString());
-
-    final request = BasicRequest(route);
-    final response = await client.httpHandler.executeSafe(request);
-
-    final sticker = parse(response.jsonBody as Map<String, Object?>);
-
-    client.updateCacheWith(sticker);
-    return sticker;
-  }
-
-  Future<StickerPack> fetchStickerPack(Snowflake id) async {
-    final route = HttpRoute()..stickerPacks(id: id.toString());
-
-    final request = BasicRequest(route);
-    final response = (await client.httpHandler.executeSafe(request)).jsonBody as Map<String, Object?>;
-
-    return parseStickerPack(response);
-  }
-
-  Future<List<StickerPack>> fetchNitroStickerPacks() async {
-    final route = HttpRoute()..stickerPacks();
-
-    final request = BasicRequest(route);
-    final response = (await client.httpHandler.executeSafe(request)).jsonBody as Map<String, Object?>;
-
-    return (response['sticker_packs'] as List).map((e) => parseStickerPack(e as Map<String, Object?>)).toList();
+  GlobalSticker parse(Map<String, Object?> raw) {
+    return GlobalSticker(
+      manager: this,
+      id: Snowflake.parse(raw['id']!),
+      packId: Snowflake.parse(raw['pack_id']!),
+      name: raw['name'] as String,
+      description: raw['description'] as String?,
+      tags: raw['tags'] as String,
+      type: StickerType.parse(raw['type'] as int),
+      formatType: StickerFormatType.parse(raw['format_type'] as int),
+      available: raw['available'] as bool? ?? false,
+      user: ((raw['user'] ?? {}) as Map)['id'] != null ? client.users[Snowflake.parse((raw['user'] as Map<String, Object?>)['id']!)] : null,
+      sortValue: raw['sort_value'] as int?,
+    );
   }
 
   StickerItem parseStickerItem(Map<String, Object?> raw) {
@@ -169,19 +153,37 @@ class GlobalStickerManager extends ReadOnlyManager<GlobalSticker> {
   }
 
   @override
-  GlobalSticker parse(Map<String, Object?> raw) {
-    return GlobalSticker(
-      manager: this,
-      id: Snowflake.parse(raw['id']!),
-      packId: Snowflake.parse(raw['pack_id']!),
-      name: raw['name'] as String,
-      description: raw['description'] as String?,
-      tags: raw['tags'] as String,
-      type: StickerType.parse(raw['type'] as int),
-      formatType: StickerFormatType.parse(raw['format_type'] as int),
-      available: raw['available'] as bool? ?? false,
-      user: ((raw['user'] ?? {}) as Map)['id'] != null ? client.users[Snowflake.parse((raw['user'] as Map<String, Object?>)['id']!)] : null,
-      sortValue: raw['sort_value'] as int?,
-    );
+  Future<GlobalSticker> fetch(Snowflake id) async {
+    final route = HttpRoute()..stickers(id: id.toString());
+
+    final request = BasicRequest(route);
+    final response = await client.httpHandler.executeSafe(request);
+
+    final sticker = parse(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(sticker);
+    return sticker;
+  }
+
+  Future<StickerPack> fetchStickerPack(Snowflake id) async {
+    final route = HttpRoute()..stickerPacks(id: id.toString());
+    final request = BasicRequest(route);
+
+    final response = (await client.httpHandler.executeSafe(request)).jsonBody as Map<String, Object?>;
+    final pack = parseStickerPack(response);
+
+    client.updateCacheWith(pack);
+    return pack;
+  }
+
+  Future<List<StickerPack>> fetchNitroStickerPacks() async {
+    final route = HttpRoute()..stickerPacks();
+    final request = BasicRequest(route);
+
+    final response = (await client.httpHandler.executeSafe(request)).jsonBody as Map<String, Object?>;
+    final packs = parseMany(response['sticker_packs'] as List, parseStickerPack);
+
+    packs.forEach(client.updateCacheWith);
+    return packs;
   }
 }

--- a/lib/src/http/managers/user_manager.dart
+++ b/lib/src/http/managers/user_manager.dart
@@ -154,7 +154,7 @@ class UserManager extends ReadOnlyManager<User> {
     final request = BasicRequest(route);
 
     final response = await client.httpHandler.executeSafe(request);
-    return client.guilds[guildId].members.parse(response.jsonBody as Map<String, Object?>);
+    return client.guilds[guildId].members.parse(response.jsonBody as Map<String, Object?>, userId: client.user.id);
   }
 
   /// Leave a guild.

--- a/lib/src/http/managers/user_manager.dart
+++ b/lib/src/http/managers/user_manager.dart
@@ -17,6 +17,7 @@ import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/user/application_role_connection.dart';
 import 'package:nyxx/src/models/user/connection.dart';
 import 'package:nyxx/src/models/user/user.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 /// A manager for [User]s.
@@ -93,7 +94,7 @@ class UserManager extends ReadOnlyManager<User> {
     final response = await client.httpHandler.executeSafe(request);
     final user = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[user.id] = user;
+    client.updateCacheWith(user);
     return user;
   }
 
@@ -105,7 +106,7 @@ class UserManager extends ReadOnlyManager<User> {
     final response = await client.httpHandler.executeSafe(request);
     final user = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[user.id] = user;
+    client.updateCacheWith(user);
     return user;
   }
 
@@ -121,7 +122,7 @@ class UserManager extends ReadOnlyManager<User> {
     final response = await client.httpHandler.executeSafe(request);
     final user = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[user.id] = user;
+    client.updateCacheWith(user);
     return user;
   }
 
@@ -176,7 +177,7 @@ class UserManager extends ReadOnlyManager<User> {
     final response = await client.httpHandler.executeSafe(request);
     final channel = client.channels.parse(response.jsonBody as Map<String, Object?>) as DmChannel;
 
-    client.channels.cache[channel.id] = channel;
+    client.updateCacheWith(channel);
     return channel;
   }
 
@@ -199,7 +200,7 @@ class UserManager extends ReadOnlyManager<User> {
     final response = await client.httpHandler.executeSafe(request);
     final channel = client.channels.parse(response.jsonBody as Map<String, Object?>) as GroupDmChannel;
 
-    client.channels.cache[channel.id] = channel;
+    client.updateCacheWith(channel);
     return channel;
   }
 

--- a/lib/src/http/managers/user_manager.dart
+++ b/lib/src/http/managers/user_manager.dart
@@ -154,7 +154,10 @@ class UserManager extends ReadOnlyManager<User> {
     final request = BasicRequest(route);
 
     final response = await client.httpHandler.executeSafe(request);
-    return client.guilds[guildId].members.parse(response.jsonBody as Map<String, Object?>, userId: client.user.id);
+    final member = client.guilds[guildId].members.parse(response.jsonBody as Map<String, Object?>, userId: client.user.id);
+
+    client.updateCacheWith(member);
+    return member;
   }
 
   /// Leave a guild.

--- a/lib/src/http/managers/voice_manager.dart
+++ b/lib/src/http/managers/voice_manager.dart
@@ -23,13 +23,14 @@ class VoiceManager {
   /// Parse a [VoiceState] from a [Map].
   VoiceState parseVoiceState(Map<String, Object?> raw, {Snowflake? guildId}) {
     guildId ??= maybeParse(raw['guild_id'], Snowflake.parse);
+    final userId = Snowflake.parse(raw['user_id']!);
 
     return VoiceState(
       manager: this,
       guildId: guildId,
       channelId: maybeParse(raw['channel_id'], Snowflake.parse),
-      userId: Snowflake.parse(raw['user_id']!),
-      member: maybeParse(raw['member'], client.guilds[guildId ?? Snowflake.zero].members.parse),
+      userId: userId,
+      member: maybeParse(raw['member'], (Map<String, Object?> raw) => client.guilds[guildId ?? Snowflake.zero].members.parse(raw, userId: userId)),
       sessionId: raw['session_id'] as String,
       isServerDeafened: raw['deaf'] as bool,
       isServerMuted: raw['mute'] as bool,

--- a/lib/src/http/managers/webhook_manager.dart
+++ b/lib/src/http/managers/webhook_manager.dart
@@ -5,7 +5,6 @@ import 'package:http/http.dart' hide MultipartRequest;
 import 'package:nyxx/src/builders/message/message.dart';
 import 'package:nyxx/src/builders/sentinels.dart';
 import 'package:nyxx/src/builders/webhook.dart';
-import 'package:nyxx/src/cache/cache.dart';
 import 'package:nyxx/src/http/managers/manager.dart';
 import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/route.dart';
@@ -15,6 +14,7 @@ import 'package:nyxx/src/models/guild/guild.dart';
 import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/webhook.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
 import 'package:nyxx/src/utils/parsing_helpers.dart';
 
 /// A manager for [Webhook]s.
@@ -76,7 +76,7 @@ class WebhookManager extends Manager<Webhook> {
     final response = await client.httpHandler.executeSafe(request);
     final webhook = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[webhook.id] = webhook;
+    client.updateCacheWith(webhook);
     return webhook;
   }
 
@@ -90,7 +90,7 @@ class WebhookManager extends Manager<Webhook> {
     final response = await client.httpHandler.executeSafe(request);
     final webhook = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[webhook.id] = webhook;
+    client.updateCacheWith(webhook);
     return webhook;
   }
 
@@ -105,7 +105,7 @@ class WebhookManager extends Manager<Webhook> {
     final response = await client.httpHandler.executeSafe(request);
     final webhook = parse(response.jsonBody as Map<String, Object?>);
 
-    cache[webhook.id] = webhook;
+    client.updateCacheWith(webhook);
     return webhook;
   }
 
@@ -132,7 +132,7 @@ class WebhookManager extends Manager<Webhook> {
     final response = await client.httpHandler.executeSafe(request);
     final webhooks = parseMany(response.jsonBody as List, parse);
 
-    cache.addEntities(webhooks);
+    webhooks.forEach(client.updateCacheWith);
     return webhooks;
   }
 
@@ -146,7 +146,7 @@ class WebhookManager extends Manager<Webhook> {
     final response = await client.httpHandler.executeSafe(request);
     final webhooks = parseMany(response.jsonBody as List, parse);
 
-    cache.addEntities(webhooks);
+    webhooks.forEach(client.updateCacheWith);
     return webhooks;
   }
 
@@ -201,7 +201,7 @@ class WebhookManager extends Manager<Webhook> {
     final messageManager = (client.channels[channelId] as PartialTextChannel).messages;
     final message = messageManager.parse(response.jsonBody as Map<String, Object?>);
 
-    messageManager.cache[message.id] = message;
+    client.updateCacheWith(message);
     return message;
   }
 
@@ -222,7 +222,7 @@ class WebhookManager extends Manager<Webhook> {
     final messageManager = (client.channels[channelId] as PartialTextChannel).messages;
     final message = messageManager.parse(response.jsonBody as Map<String, Object?>);
 
-    messageManager.cache[message.id] = message;
+    client.updateCacheWith(message);
     return message;
   }
 
@@ -278,7 +278,7 @@ class WebhookManager extends Manager<Webhook> {
     final messageManager = (client.channels[channelId] as PartialTextChannel).messages;
     final message = messageManager.parse(response.jsonBody as Map<String, Object?>);
 
-    messageManager.cache[message.id] = message;
+    client.updateCacheWith(message);
     return message;
   }
 

--- a/lib/src/models/gateway/events/channel.dart
+++ b/lib/src/models/gateway/events/channel.dart
@@ -116,8 +116,14 @@ class ThreadMemberUpdateEvent extends DispatchEvent {
   /// The updated member.
   final ThreadMember member;
 
+  /// The ID of the guild in which the member was updated.
+  final Snowflake guildId;
+
   /// {@macro thread_member_update_event}
-  ThreadMemberUpdateEvent({required super.gateway, required this.member});
+  ThreadMemberUpdateEvent({required super.gateway, required this.member, required this.guildId});
+
+  /// The guild in which the member was updated.
+  PartialGuild get guild => gateway.client.guilds[guildId];
 }
 
 /// {@template thread_members_update_event}

--- a/lib/src/models/interaction.dart
+++ b/lib/src/models/interaction.dart
@@ -416,7 +416,7 @@ class ApplicationCommandInteractionData with ToStringHelper {
   /// A list of provided options.
   final List<InteractionOption>? options;
 
-  /// The ID of the guild the command was invoked in.
+  /// The ID of the guild the command was registered in, or `null` if it was a global command.
   final Snowflake? guildId;
 
   /// The ID of the entity the command was invoked on.

--- a/lib/src/models/message/message.dart
+++ b/lib/src/models/message/message.dart
@@ -87,7 +87,7 @@ class PartialMessage extends WritableSnowflakeEntity<Message> {
 class Message extends PartialMessage {
   /// The author of this message.
   ///
-  /// This could be a [User] or a [Webhook].
+  /// This could be a [User] or a [WebhookAuthor].
   final MessageAuthor author;
 
   /// The content of the message.

--- a/lib/src/models/voice/voice_state.dart
+++ b/lib/src/models/voice/voice_state.dart
@@ -25,6 +25,7 @@ class VoiceState with ToStringHelper {
   /// The ID of the user this state is for.
   final Snowflake userId;
 
+  /// The member this voice state is for.
   final Member? member;
 
   /// This state's session ID.

--- a/lib/src/utils/cache_helpers.dart
+++ b/lib/src/utils/cache_helpers.dart
@@ -26,16 +26,21 @@ import 'package:nyxx/src/models/gateway/events/voice.dart';
 import 'package:nyxx/src/models/gateway/events/webhook.dart';
 import 'package:nyxx/src/models/guild/audit_log.dart';
 import 'package:nyxx/src/models/guild/auto_moderation.dart';
+import 'package:nyxx/src/models/guild/ban.dart';
 import 'package:nyxx/src/models/guild/guild.dart';
+import 'package:nyxx/src/models/guild/guild_preview.dart';
 import 'package:nyxx/src/models/guild/integration.dart';
 import 'package:nyxx/src/models/guild/member.dart';
 import 'package:nyxx/src/models/guild/scheduled_event.dart';
+import 'package:nyxx/src/models/guild/template.dart';
 import 'package:nyxx/src/models/interaction.dart';
+import 'package:nyxx/src/models/invite/invite.dart';
 import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/presence.dart';
 import 'package:nyxx/src/models/role.dart';
 import 'package:nyxx/src/models/sticker/global_sticker.dart';
 import 'package:nyxx/src/models/sticker/guild_sticker.dart';
+import 'package:nyxx/src/models/sticker/sticker_pack.dart';
 import 'package:nyxx/src/models/user/user.dart';
 import 'package:nyxx/src/models/voice/voice_state.dart';
 import 'package:nyxx/src/models/webhook.dart';
@@ -145,6 +150,23 @@ extension CacheUpdates on NyxxRest {
                 updateCacheWith(resolved);
             }
           }(),
+        Invite(:final inviter, :final targetUser, :final guildScheduledEvent) => () {
+            updateCacheWith(inviter);
+            updateCacheWith(targetUser);
+            updateCacheWith(guildScheduledEvent);
+          }(),
+        GuildPreview(:final emojiList, :final stickerList) => () {
+            emojiList.forEach(updateCacheWith);
+            stickerList.forEach(updateCacheWith);
+          }(),
+        Ban(:final user) => updateCacheWith(user),
+        // Don't update cache for serializedSourceGuild since it is populated with some fake data.
+        GuildTemplate(:final creator) => updateCacheWith(creator),
+        ScheduledEventUser(:final user, :final member) => () {
+            updateCacheWith(user);
+            updateCacheWith(member);
+          }(),
+        StickerPack(:final stickers) => stickers.forEach(updateCacheWith),
 
         // Events
 
@@ -228,7 +250,7 @@ extension CacheUpdates on NyxxRest {
         IntegrationCreateEvent(:final integration) => updateCacheWith(integration),
         IntegrationUpdateEvent(:final integration) => updateCacheWith(integration),
         IntegrationDeleteEvent(:final id, :final guild) => guild.integrations.cache.remove(id),
-        InviteCreateEvent() => null,
+        InviteCreateEvent(:final invite) => updateCacheWith(invite),
         InviteDeleteEvent() => null,
         MessageCreateEvent(:final message, :final mentions) => () {
             updateCacheWith(message);

--- a/lib/src/utils/cache_helpers.dart
+++ b/lib/src/utils/cache_helpers.dart
@@ -143,7 +143,7 @@ extension CacheUpdates on NyxxRest {
             entitlements.forEach(updateCacheWith);
 
             if (data case ApplicationCommandInteractionData(:final resolved) || MessageComponentInteractionData(:final resolved)) {
-                updateCacheWith(resolved);
+              updateCacheWith(resolved);
             }
           }(),
         Invite(:final inviter, :final targetUser, :final guildScheduledEvent) => () {

--- a/lib/src/utils/cache_helpers.dart
+++ b/lib/src/utils/cache_helpers.dart
@@ -1,0 +1,279 @@
+import 'package:nyxx/src/client.dart';
+import 'package:nyxx/src/models/channel/channel.dart';
+import 'package:nyxx/src/models/channel/stage_instance.dart';
+import 'package:nyxx/src/models/channel/thread.dart';
+import 'package:nyxx/src/models/channel/thread_list.dart';
+import 'package:nyxx/src/models/channel/types/dm.dart';
+import 'package:nyxx/src/models/channel/types/group_dm.dart';
+import 'package:nyxx/src/models/commands/application_command.dart';
+import 'package:nyxx/src/models/commands/application_command_permissions.dart';
+import 'package:nyxx/src/models/emoji.dart';
+import 'package:nyxx/src/models/entitlement.dart';
+import 'package:nyxx/src/models/gateway/event.dart';
+import 'package:nyxx/src/models/gateway/events/application_command.dart';
+import 'package:nyxx/src/models/gateway/events/auto_moderation.dart';
+import 'package:nyxx/src/models/gateway/events/channel.dart';
+import 'package:nyxx/src/models/gateway/events/entitlement.dart';
+import 'package:nyxx/src/models/gateway/events/guild.dart';
+import 'package:nyxx/src/models/gateway/events/integration.dart';
+import 'package:nyxx/src/models/gateway/events/interaction.dart';
+import 'package:nyxx/src/models/gateway/events/invite.dart';
+import 'package:nyxx/src/models/gateway/events/message.dart';
+import 'package:nyxx/src/models/gateway/events/presence.dart';
+import 'package:nyxx/src/models/gateway/events/ready.dart';
+import 'package:nyxx/src/models/gateway/events/stage_instance.dart';
+import 'package:nyxx/src/models/gateway/events/voice.dart';
+import 'package:nyxx/src/models/gateway/events/webhook.dart';
+import 'package:nyxx/src/models/guild/audit_log.dart';
+import 'package:nyxx/src/models/guild/auto_moderation.dart';
+import 'package:nyxx/src/models/guild/guild.dart';
+import 'package:nyxx/src/models/guild/integration.dart';
+import 'package:nyxx/src/models/guild/member.dart';
+import 'package:nyxx/src/models/guild/scheduled_event.dart';
+import 'package:nyxx/src/models/interaction.dart';
+import 'package:nyxx/src/models/message/message.dart';
+import 'package:nyxx/src/models/presence.dart';
+import 'package:nyxx/src/models/role.dart';
+import 'package:nyxx/src/models/sticker/global_sticker.dart';
+import 'package:nyxx/src/models/sticker/guild_sticker.dart';
+import 'package:nyxx/src/models/user/user.dart';
+import 'package:nyxx/src/models/voice/voice_state.dart';
+import 'package:nyxx/src/models/webhook.dart';
+
+extension CacheUpdates on NyxxRest {
+  /// Update the caches for this client using [entity] by registering (or removing, if [entity] is a delete event) any cacheable entities reachable from [entity].
+  void updateCacheWith(Object? entity) => switch (entity) {
+        // "Root" types - with their own cache
+
+        VoiceState() => () {
+            // ignore: deprecated_member_use_from_same_package
+            entity.manager.cache[entity.cacheKey] = entity;
+            entity.guild?.voiceStates[entity.userId] = entity;
+
+            updateCacheWith(entity.member);
+          }(),
+        StageInstance() => entity.manager.stageInstanceCache[entity.id] = entity,
+        CommandPermissions() => entity.manager.permissionsCache[entity.id] = entity,
+        AuditLogEntry() => entity.manager.cache[entity.id] = entity,
+        Channel() => () {
+            entity.manager.cache[entity.id] = entity;
+
+            if (entity case DmChannel(:final recipient)) {
+              updateCacheWith(recipient);
+            }
+            if (entity case GroupDmChannel(:final recipients)) {
+              recipients.forEach(updateCacheWith);
+            }
+          }(),
+        Entitlement() => entity.manager.cache[entity.id] = entity,
+        Integration() => () {
+            entity.manager.cache[entity.id] = entity;
+
+            updateCacheWith(entity.user);
+          }(),
+        GlobalSticker() => entity.manager.cache[entity.id] = entity,
+        User() => entity.manager.cache[entity.id] = entity,
+        ApplicationCommand() => entity.manager.cache[entity.id] = entity,
+        AutoModerationRule() => entity.manager.cache[entity.id] = entity,
+        Emoji() => () {
+            entity.manager.cache[entity.id] = entity;
+
+            if (entity case GuildEmoji(:final user?)) {
+              updateCacheWith(user);
+            }
+          }(),
+        Guild() => () {
+            entity.manager.cache[entity.id] = entity;
+
+            entity.roleList.forEach(updateCacheWith);
+            entity.emojiList.forEach(updateCacheWith);
+            entity.stickerList.forEach(updateCacheWith);
+          }(),
+        Member() => () {
+            entity.manager.cache[entity.id] = entity;
+
+            updateCacheWith(entity.user);
+          }(),
+        Message() => () {
+            entity.manager.cache[entity.id] = entity;
+
+            updateCacheWith(entity.author);
+            entity.mentions.forEach(updateCacheWith);
+            updateCacheWith(entity.referencedMessage);
+            updateCacheWith(entity.interaction);
+            updateCacheWith(entity.thread);
+            entity.stickers.forEach(updateCacheWith);
+            updateCacheWith(entity.resolved);
+          }(),
+        Role() => entity.manager.cache[entity.id] = entity,
+        ScheduledEvent(:final creator) => () {
+            entity.manager.cache[entity.id] = entity;
+
+            updateCacheWith(creator);
+          }(),
+        GuildSticker() => entity.manager.cache[entity.id] = entity,
+        Webhook() => () {
+            entity.manager.cache[entity.id] = entity;
+
+            updateCacheWith(entity.user);
+          }(),
+
+        // "Aggregate" types - objects that contain other (potentially root) objects
+
+        ThreadList(:final threads, :final members) => () {
+            threads.forEach(updateCacheWith);
+            members.forEach(updateCacheWith);
+          }(),
+        ThreadMember(:final member) => updateCacheWith(member),
+        MessageInteraction(:final user) => updateCacheWith(user),
+        ResolvedData(:final users, :final roles, :final members) => () {
+            users?.values.forEach(updateCacheWith);
+            roles?.values.forEach(updateCacheWith);
+            members?.values.forEach(updateCacheWith);
+          }(),
+        Activity(:final emoji) => updateCacheWith(emoji),
+        Interaction(:final data, :final member, :final user, :final message, :final entitlements) => () {
+            updateCacheWith(member);
+            updateCacheWith(user);
+            updateCacheWith(message);
+            entitlements.forEach(updateCacheWith);
+
+            switch (data) {
+              case ApplicationCommandInteractionData(:final resolved):
+                updateCacheWith(resolved);
+              case MessageComponentInteractionData(:final resolved):
+                updateCacheWith(resolved);
+            }
+          }(),
+
+        // Events
+
+        ReadyEvent(:final user) => updateCacheWith(user),
+        ResumedEvent() => null,
+        ApplicationCommandPermissionsUpdateEvent(:final permissions) => updateCacheWith(permissions),
+        AutoModerationRuleCreateEvent(:final rule) => updateCacheWith(rule),
+        AutoModerationRuleUpdateEvent(:final rule) => updateCacheWith(rule),
+        AutoModerationRuleDeleteEvent(:final rule) => rule.manager.cache.remove(rule.id),
+        AutoModerationActionExecutionEvent() => null,
+        ChannelCreateEvent(:final channel) => updateCacheWith(channel),
+        ChannelUpdateEvent(:final channel) => updateCacheWith(channel),
+        ChannelDeleteEvent(:final channel) => channel.manager.cache.remove(channel.id),
+        ThreadCreateEvent(:final thread) => updateCacheWith(thread),
+        ThreadUpdateEvent(:final thread) => updateCacheWith(thread),
+        ThreadDeleteEvent(:final thread) => thread.manager.cache.remove(thread.id),
+        ThreadListSyncEvent(:final threads, :final members) => () {
+            threads.forEach(updateCacheWith);
+            members.forEach(updateCacheWith);
+          }(),
+        ThreadMemberUpdateEvent(:final member) => updateCacheWith(member),
+        ThreadMembersUpdateEvent(:final addedMembers) => addedMembers?.forEach(updateCacheWith),
+        ChannelPinsUpdateEvent() => null,
+        UnavailableGuildCreateEvent() => () {
+            if (entity
+                case GuildCreateEvent(
+                  :final guild,
+                  :final voiceStates,
+                  :final members,
+                  :final channels,
+                  :final threads,
+                  :final presences,
+                  :final stageInstances,
+                  :final scheduledEvents,
+                )) {
+              updateCacheWith(guild);
+              voiceStates.forEach(updateCacheWith);
+              members.forEach(updateCacheWith);
+              channels.forEach(updateCacheWith);
+              threads.forEach(updateCacheWith);
+              presences.forEach(updateCacheWith);
+              stageInstances.forEach(updateCacheWith);
+              scheduledEvents.forEach(updateCacheWith);
+            }
+          }(),
+        GuildUpdateEvent(:final guild) => updateCacheWith(guild),
+        GuildDeleteEvent(:final guild) => guild.manager.cache.remove(guild.id),
+        GuildAuditLogCreateEvent(:final entry) => updateCacheWith(entry),
+        GuildBanAddEvent(:final user, :final guild) => () {
+            guild.members.cache.remove(user.id);
+            updateCacheWith(user);
+          }(),
+        GuildBanRemoveEvent(:final user) => updateCacheWith(user),
+        GuildEmojisUpdateEvent(:final emojis, :final guild) => () {
+            guild.emojis.cache.clear();
+            emojis.forEach(updateCacheWith);
+          }(),
+        GuildStickersUpdateEvent(:final stickers, :final guild) => () {
+            guild.stickers.cache.clear();
+            stickers.forEach(updateCacheWith);
+          }(),
+        GuildIntegrationsUpdateEvent() => null,
+        GuildMemberAddEvent(:final member) => updateCacheWith(member),
+        GuildMemberRemoveEvent(:final user, :final guild) => () {
+            guild.members.cache.remove(user.id);
+            updateCacheWith(user);
+          }(),
+        GuildMemberUpdateEvent(:final member) => updateCacheWith(member),
+        GuildMembersChunkEvent(:final members, :final presences) => () {
+            members.forEach(updateCacheWith);
+            presences?.forEach(updateCacheWith);
+          }(),
+        GuildRoleCreateEvent(:final role) => updateCacheWith(role),
+        GuildRoleUpdateEvent(:final role) => updateCacheWith(role),
+        GuildRoleDeleteEvent(:final roleId, :final guild) => guild.roles.cache.remove(roleId),
+        GuildScheduledEventCreateEvent(:final event) => updateCacheWith(event),
+        GuildScheduledEventUpdateEvent(:final event) => updateCacheWith(event),
+        GuildScheduledEventDeleteEvent(:final event) => event.manager.cache.remove(event.id),
+        GuildScheduledEventUserAddEvent() => null,
+        GuildScheduledEventUserRemoveEvent() => null,
+        IntegrationCreateEvent(:final integration) => updateCacheWith(integration),
+        IntegrationUpdateEvent(:final integration) => updateCacheWith(integration),
+        IntegrationDeleteEvent(:final id, :final guild) => guild.integrations.cache.remove(id),
+        InviteCreateEvent() => null,
+        InviteDeleteEvent() => null,
+        MessageCreateEvent(:final message, :final mentions) => () {
+            updateCacheWith(message);
+            mentions.forEach(updateCacheWith);
+          }(),
+        MessageUpdateEvent(:final message, :final mentions) => () {
+            // We only get a partial message, but we know it invalidates the message currently in the cache. So we remove the cached message.
+            message.manager.cache.remove(message.id);
+            mentions?.forEach(updateCacheWith);
+          }(),
+        MessageDeleteEvent(:final id, :final channel) => channel.messages.cache.remove(id),
+        MessageBulkDeleteEvent(:final ids, :final channel) => ids.forEach(channel.messages.cache.remove),
+        MessageReactionAddEvent(:final emoji, :final member) => () {
+            updateCacheWith(emoji);
+            updateCacheWith(member);
+          }(),
+        MessageReactionRemoveEvent(:final emoji) => updateCacheWith(emoji),
+        MessageReactionRemoveAllEvent() => null,
+        MessageReactionRemoveEmojiEvent() => null,
+        PresenceUpdateEvent(:final activities) => activities?.forEach(updateCacheWith),
+        TypingStartEvent(:final member) => updateCacheWith(member),
+        UserUpdateEvent(:final user) => updateCacheWith(user),
+        VoiceStateUpdateEvent(:final state) => updateCacheWith(state),
+        VoiceServerUpdateEvent() => null,
+        WebhooksUpdateEvent() => null,
+        InteractionCreateEvent(:final interaction) => updateCacheWith(interaction),
+        StageInstanceCreateEvent(:final instance) => updateCacheWith(instance),
+        StageInstanceUpdateEvent(:final instance) => updateCacheWith(instance),
+        StageInstanceDeleteEvent(:final instance) => instance.manager.cache.remove(instance.id),
+        EntitlementCreateEvent(:final entitlement) => updateCacheWith(entitlement),
+        EntitlementUpdateEvent(:final entitlement) => updateCacheWith(entitlement),
+        // TODO: Remove entitlement from cache
+        EntitlementDeleteEvent() => null,
+
+        // null and unhandled entity types
+        UnknownDispatchEvent() => null,
+        null => null,
+        _ => () {
+            assert(() {
+              logger
+                ..warning('Tried to update cache for ${entity.runtimeType}, but that type was not handled.')
+                ..info(
+                    'This is a bug, please report it to https://github.com/nyxx-discord/nyxx/issues or on our Discord server. Your client will still work regardless, so you can also ignore this message.');
+              return true;
+            }());
+          }(),
+      };
+}

--- a/lib/src/utils/cache_helpers.dart
+++ b/lib/src/utils/cache_helpers.dart
@@ -107,14 +107,13 @@ extension CacheUpdates on NyxxRest {
             updateCacheWith(entity.referencedMessage);
             updateCacheWith(entity.interaction);
             updateCacheWith(entity.thread);
-            entity.stickers.forEach(updateCacheWith);
             updateCacheWith(entity.resolved);
           }(),
         Role() => entity.manager.cache[entity.id] = entity,
-        ScheduledEvent(:final creator) => () {
+        ScheduledEvent() => () {
             entity.manager.cache[entity.id] = entity;
 
-            updateCacheWith(creator);
+            updateCacheWith(entity.creator);
           }(),
         GuildSticker() => entity.manager.cache[entity.id] = entity,
         Webhook() => () {
@@ -143,10 +142,7 @@ extension CacheUpdates on NyxxRest {
             updateCacheWith(message);
             entitlements.forEach(updateCacheWith);
 
-            switch (data) {
-              case ApplicationCommandInteractionData(:final resolved):
-                updateCacheWith(resolved);
-              case MessageComponentInteractionData(:final resolved):
+            if (data case ApplicationCommandInteractionData(:final resolved) || MessageComponentInteractionData(:final resolved)) {
                 updateCacheWith(resolved);
             }
           }(),
@@ -286,6 +282,7 @@ extension CacheUpdates on NyxxRest {
         EntitlementDeleteEvent() => null,
 
         // null and unhandled entity types
+        WebhookAuthor() => null,
         UnknownDispatchEvent() => null,
         null => null,
         _ => () {

--- a/test/mocks/client.dart
+++ b/test/mocks/client.dart
@@ -7,6 +7,9 @@ import 'gateway.dart';
 class MockNyxx with Mock, ManagerMixin implements NyxxRest {
   @override
   PartialApplication get application => applications[Snowflake.zero];
+
+  @override
+  PartialUser get user => users[Snowflake.zero];
 }
 
 class MockNyxxGateway with Mock, ManagerMixin implements NyxxGateway {

--- a/test/unit/http/managers/member_manager_test.dart
+++ b/test/unit/http/managers/member_manager_test.dart
@@ -4,8 +4,8 @@ import 'package:test/test.dart';
 import '../../../test_manager.dart';
 import 'user_manager_test.dart';
 
-final sampleMember = {
-  "user": sampleUser,
+final sampleMemberNoUser = {
+  "user": null,
   "nick": "NOT API SUPPORT",
   "avatar": null,
   "roles": [],
@@ -17,9 +17,13 @@ final sampleMember = {
   "flags": 0,
 };
 
-void checkMember(Member member) {
-  expect(member.id, equals(Snowflake(80351110224678912)));
-  expect(member.user, isNotNull);
+final sampleMember = {
+  ...sampleMemberNoUser,
+  "user": sampleUser,
+};
+
+void checkMemberNoUser(Member member, {Snowflake expectedUserId = const Snowflake(80351110224678912)}) {
+  expect(member.id, equals(expectedUserId));
   expect(member.nick, equals('NOT API SUPPORT'));
   expect(member.avatarHash, isNull);
   expect(member.roleIds, equals([]));
@@ -31,6 +35,10 @@ void checkMember(Member member) {
   expect(member.isPending, isFalse);
   expect(member.permissions, isNull);
   expect(member.communicationDisabledUntil, isNull);
+}
+
+void checkMember(Member member, {Snowflake expectedUserId = const Snowflake(80351110224678912)}) {
+  checkMemberNoUser(member, expectedUserId: expectedUserId);
 
   expect(member.user, isNotNull);
   checkSampleUser(member.user!);

--- a/test/unit/http/managers/scheduled_event_manager_test.dart
+++ b/test/unit/http/managers/scheduled_event_manager_test.dart
@@ -81,13 +81,13 @@ void checkScheduledEvent2(ScheduledEvent event) {
 final sampleScheduledEventUser = {
   'guild_scheduled_event_id': '0',
   'user': sampleUser,
-  'member': sampleMember,
+  'member': sampleMemberNoUser,
 };
 
 void checkScheduledEventUser(ScheduledEventUser user) {
   expect(user.scheduledEventId, equals(Snowflake.zero));
   checkSampleUser(user.user);
-  checkMember(user.member!);
+  checkMemberNoUser(user.member!);
 }
 
 void main() {

--- a/test/unit/http/managers/user_manager_test.dart
+++ b/test/unit/http/managers/user_manager_test.dart
@@ -1,6 +1,8 @@
+import 'package:mocktail/mocktail.dart';
 import 'package:nyxx/nyxx.dart';
 import 'package:test/test.dart';
 
+import '../../../mocks/client.dart';
 import '../../../test_manager.dart';
 import 'channel_manager_test.dart';
 import 'member_manager_test.dart';
@@ -116,10 +118,15 @@ void main() {
       ),
       EndpointTest<UserManager, Member, Map<String, Object?>>(
         name: 'fetchCurrentUserMember',
-        source: sampleMember,
+        source: sampleMemberNoUser,
         urlMatcher: '/users/@me/guilds/0/member',
         execute: (manager) => manager.fetchCurrentUserMember(Snowflake.zero),
-        check: checkMember,
+        check: (member) {
+          final client = MockNyxx();
+          when(() => client.options).thenReturn(RestClientOptions());
+
+          checkMemberNoUser(member, expectedUserId: client.user.id);
+        },
       ),
       EndpointTest<UserManager, void, void>(
         name: 'leaveGuild',

--- a/test/unit/http/managers/voice_manager_test.dart
+++ b/test/unit/http/managers/voice_manager_test.dart
@@ -5,6 +5,7 @@ import 'package:test/test.dart';
 import '../../../mocks/client.dart';
 import '../../../test_endpoint.dart';
 import '../../../test_manager.dart';
+import 'member_manager_test.dart';
 
 final sampleVoiceState = {
   "channel_id": "157733188964188161",
@@ -16,6 +17,7 @@ final sampleVoiceState = {
   "self_mute": true,
   "suppress": false,
   "request_to_speak_timestamp": "2021-03-31T18:45:31.297561+00:00",
+  "member": sampleMemberNoUser,
 
   // The API reference says this field is always present, but it's missing in the sample
   "self_video": false,
@@ -34,6 +36,8 @@ void checkVoiceState(VoiceState state) {
   expect(state.isVideoEnabled, isFalse);
   expect(state.isSuppressed, isFalse);
   expect(state.requestedToSpeakAt, equals(DateTime.utc(2021, 3, 31, 18, 45, 31, 297, 561)));
+  expect(state.member, isNotNull);
+  checkMemberNoUser(state.member!, expectedUserId: Snowflake(80351110224678912));
 }
 
 final sampleVoiceRegion = {


### PR DESCRIPTION
# Description

Improves caching by caching more entities more often, and reduces the number of places the library uses `Snowflake.zero` as a placeholder for an unknown ID when parsing entities (when the information is available in a parent object).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
