### PR TITLE
Fix autocompletion interaction responses

### DIFF
--- a/lib/src/builders/interaction_response.dart
+++ b/lib/src/builders/interaction_response.dart
@@ -49,7 +49,7 @@ class InteractionResponseBuilder extends CreateBuilder<InteractionResponseBuilde
 
   factory InteractionResponseBuilder.autocompleteResult(List<CommandOptionChoiceBuilder<dynamic>> choices) => InteractionResponseBuilder(
         type: InteractionCallbackType.applicationCommandAutocompleteResult,
-        data: choices,
+        data: {'choices': choices},
       );
 
   factory InteractionResponseBuilder.modal(ModalBuilder modal) => InteractionResponseBuilder(type: InteractionCallbackType.modal, data: modal);


### PR DESCRIPTION
# Description

Fixes the builder for autocompletion interaction responses not using the correct type.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
