### PR TITLE
Correctly build autocompletion responses

### DIFF
--- a/lib/src/builders/interaction_response.dart
+++ b/lib/src/builders/interaction_response.dart
@@ -49,7 +49,7 @@ class InteractionResponseBuilder extends CreateBuilder<InteractionResponseBuilde
 
   factory InteractionResponseBuilder.autocompleteResult(List<CommandOptionChoiceBuilder<dynamic>> choices) => InteractionResponseBuilder(
         type: InteractionCallbackType.applicationCommandAutocompleteResult,
-        data: {'choices': choices},
+        data: {'choices': choices.map((e) => e.build()).toList()},
       );
 
   factory InteractionResponseBuilder.modal(ModalBuilder modal) => InteractionResponseBuilder(type: InteractionCallbackType.modal, data: modal);

--- a/test/unit/builders/interaction_response_test.dart
+++ b/test/unit/builders/interaction_response_test.dart
@@ -1,0 +1,20 @@
+import 'package:nyxx/nyxx.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('InteractionResponseBuilder', () {
+    test('autocompleteResult', () {
+      expect(
+        InteractionResponseBuilder.autocompleteResult([CommandOptionChoiceBuilder(name: 'foo', value: 'bar')]).build(),
+        equals({
+          'type': 8,
+          'data': {
+            'choices': [
+              {'name': 'foo', 'value': 'bar'},
+            ]
+          }
+        }),
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Description

Fixes an issue where autocompletion interaction responses were only partially built.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
