### PR TITLE
Add entitlement delete payload

### DIFF
--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -1011,7 +1011,12 @@ class Gateway extends GatewayManager with EventParser {
 
   /// Parse an [EntitlementDeleteEvent] from [raw].
   EntitlementDeleteEvent parseEntitlementDelete(Map<String, Object?> raw) {
-    return EntitlementDeleteEvent(gateway: this);
+    final applicationId = Snowflake.parse(raw['application_id']!);
+
+    return EntitlementDeleteEvent(
+      gateway: this,
+      entitlement: client.applications[applicationId].entitlements.parse(raw),
+    );
   }
 
   /// Stream all members in a guild that match [query] or [userIds].

--- a/lib/src/models/gateway/events/entitlement.dart
+++ b/lib/src/models/gateway/events/entitlement.dart
@@ -30,8 +30,9 @@ class EntitlementUpdateEvent extends DispatchEvent {
 /// Emitted when an entitlement is deleted.
 /// {@endtemplate}
 class EntitlementDeleteEvent extends DispatchEvent {
-  // TODO: What is the payload here?
+  /// The entitlement that was deleted.
+  final Entitlement entitlement;
 
   /// {@macro entitlement_delete_event}
-  EntitlementDeleteEvent({required super.gateway});
+  EntitlementDeleteEvent({required super.gateway, required this.entitlement});
 }

--- a/lib/src/utils/cache_helpers.dart
+++ b/lib/src/utils/cache_helpers.dart
@@ -278,8 +278,7 @@ extension CacheUpdates on NyxxRest {
         StageInstanceDeleteEvent(:final instance) => instance.manager.cache.remove(instance.id),
         EntitlementCreateEvent(:final entitlement) => updateCacheWith(entitlement),
         EntitlementUpdateEvent(:final entitlement) => updateCacheWith(entitlement),
-        // TODO: Remove entitlement from cache
-        EntitlementDeleteEvent() => null,
+        EntitlementDeleteEvent(:final entitlement) => entitlement.manager.cache.remove(entitlement.id),
 
         // null and unhandled entity types
         WebhookAuthor() => null,


### PR DESCRIPTION
# Description

Adds the payload to the `ENTITLEMENT_DELETE` Gateway payload, which was previously undocumented.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
