### PR TITLE
Provide guild ID when parsing message interactions

### DIFF
--- a/lib/src/http/managers/message_manager.dart
+++ b/lib/src/http/managers/message_manager.dart
@@ -79,7 +79,7 @@ class MessageManager extends Manager<Message> {
       referencedMessage: maybeParse(raw['referenced_message'], parse),
       interaction: maybeParse(
         raw['interaction'],
-        (Map<String, Object?> raw) => parseMessageInteraction(raw),
+        (Map<String, Object?> raw) => parseMessageInteraction(raw, guildId: guildId),
       ),
       thread: maybeParse(raw['thread'], client.channels.parse) as Thread?,
       components: maybeParseMany(raw['components'], parseMessageComponent),
@@ -291,7 +291,7 @@ class MessageManager extends Manager<Message> {
     );
   }
 
-  MessageInteraction parseMessageInteraction(Map<String, Object?> raw) {
+  MessageInteraction parseMessageInteraction(Map<String, Object?> raw, {Snowflake? guildId}) {
     final user = client.users.parse(raw['user'] as Map<String, Object?>);
 
     return MessageInteraction(
@@ -299,10 +299,9 @@ class MessageManager extends Manager<Message> {
       type: InteractionType.parse(raw['type'] as int),
       name: raw['name'] as String,
       user: user,
-      // TODO: Find a way to get the guild ID.
       member: maybeParse(
         raw['member'],
-        (Map<String, Object?> raw) => client.guilds[Snowflake.zero].members[user.id],
+        (Map<String, Object?> raw) => client.guilds[guildId ?? Snowflake.zero].members[user.id],
       ),
     );
   }


### PR DESCRIPTION
# Description

Forwards the `guildId` parameter from `MesageManager.parse` to `MessageManager.parseMessageInteraction`. Not sure why we didn't pass this, as it was always available in the call to `MessageManager.parse`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
