### PR TITLE
Export Credentials from package:oauth2

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -316,3 +316,4 @@ export 'package:http/http.dart'
         StreamedResponse;
 export 'package:logging/logging.dart' show Logger, Level;
 export 'package:runtime_type/runtime_type.dart' show RuntimeType;
+export 'package:oauth2/oauth2.dart' show Credentials;


### PR DESCRIPTION
# Description

We usually export types from other packages we use in our own API, but we didn't export `Credentials`. This PR adds that export.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
