### PR TITLE
Add test validating ApiOptions.nyxxVersion

### DIFF
--- a/test/unit/version_matches_test.dart
+++ b/test/unit/version_matches_test.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:nyxx/nyxx.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('package version matches ApiOptions.nyxxVersion', () {
+    final pubspecFile = File('pubspec.yaml');
+
+    expect(pubspecFile.existsSync(), isTrue, reason: 'pubspec.yaml should exist');
+
+    final versionFromPubspec = RegExp(r'version: (.+)\n').firstMatch(pubspecFile.readAsStringSync())?.group(1);
+
+    expect(versionFromPubspec, isNotNull, reason: 'version should be parsed from pubspec');
+
+    expect(versionFromPubspec, equals(ApiOptions.nyxxVersion));
+  });
+}


### PR DESCRIPTION
# Description

Adds a test to ensure `ApiOptions.nyxxVersion` matches the package version in `pubspec.yaml`. Previously developers just had to remember to update one when changing the other.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
