### PR TITLE
Enable dartdoc link to source

### DIFF
--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,0 +1,4 @@
+dartdoc:
+  linkToSource:
+    root: .
+    uriTemplate: 'https://github.com/nyxx-discord/nyxx/blob/main/%f%#L%l%'

--- a/lib/src/client_options.dart
+++ b/lib/src/client_options.dart
@@ -122,7 +122,7 @@ class RestClientOptions extends ClientOptions {
   });
 }
 
-/// Options for controlling the behavior of a [NyxxWebsocket] client.
+/// Options for controlling the behavior of a [NyxxGateway] client.
 class GatewayClientOptions extends RestClientOptions {
   /// The minimum number of session starts this client needs to connect.
   ///

--- a/lib/src/http/route.dart
+++ b/lib/src/http/route.dart
@@ -67,7 +67,7 @@ class HttpRoutePart {
 
 /// A parameter in a [HttpRoutePart].
 ///
-/// {@template http_route_part}
+/// {@template http_route_param}
 /// This is not a query parameter, it is a parameter encoded in the path of the request itself, such
 /// as the id of a guild in `/guilds/0123456789`.
 /// {@endtemplate}

--- a/lib/src/models/gateway/event.dart
+++ b/lib/src/models/gateway/event.dart
@@ -66,7 +66,7 @@ class HeartbeatEvent extends GatewayEvent {
 /// Emitted when the client receives a request to reconnect.
 /// {@endtemplate}
 class ReconnectEvent extends GatewayEvent {
-  /// {@macro reconnect_events}
+  /// {@macro reconnect_event}
   ReconnectEvent() : super(opcode: Opcode.reconnect);
 }
 

--- a/lib/src/models/guild/onboarding.dart
+++ b/lib/src/models/guild/onboarding.dart
@@ -9,7 +9,7 @@ import 'package:nyxx/src/utils/to_string_helper/to_string_helper.dart';
 /// The configuration for a [Guild]'s onboarding process.
 /// {@endtemplate}
 class Onboarding with ToStringHelper {
-  /// The manager for this [onboarding].
+  /// The manager for this [Onboarding].
   final GuildManager manager;
 
   /// The ID of the guild this onboarding is for.

--- a/lib/src/models/message/component.dart
+++ b/lib/src/models/message/component.dart
@@ -42,7 +42,7 @@ class ActionRowComponent extends MessageComponent {
   @override
   MessageComponentType get type => MessageComponentType.actionRow;
 
-  /// The children of this [ActionRow].
+  /// The children of this [ActionRowComponent].
   final List<MessageComponent> components;
 
   /// Create a new [ActionRowComponent].
@@ -175,7 +175,7 @@ enum SelectMenuDefaultValueType {
       );
 }
 
-/// A default value in a [SelectMenu].
+/// A default value in a [SelectMenuComponent].
 class SelectMenuDefaultValue {
   /// The ID of this entity.
   final Snowflake id;
@@ -187,7 +187,7 @@ class SelectMenuDefaultValue {
   SelectMenuDefaultValue({required this.id, required this.type});
 }
 
-/// An option in a [SelectMenu].
+/// An option in a [SelectMenuComponent].
 class SelectMenuOption with ToStringHelper {
   /// The label shown to the user.
   final String label;


### PR DESCRIPTION
# Description

Enables the `linkToSource` dartdoc option which adds a button to jump to the source definition in the generated API documentation. This makes it easier for new contributors to find types in the library, and shortens the time spent looking for API elements for regular developers.

Also corrects some invalid documentation references.

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
