### PR TITLE
Implement `username`/`avatarUrl` params for `WebhookManager#execute`

### DIFF
--- a/lib/src/http/managers/webhook_manager.dart
+++ b/lib/src/http/managers/webhook_manager.dart
@@ -152,7 +152,7 @@ class WebhookManager extends Manager<Webhook> {
 
   /// Execute a webhook.
   Future<Message?> execute(Snowflake id, MessageBuilder builder,
-      {required String token, bool? wait, Snowflake? threadId, String? threadName, List<Snowflake>? appliedTags}) async {
+      {required String token, bool? wait, Snowflake? threadId, String? threadName, List<Snowflake>? appliedTags, String? username, String? avatarUrl}) async {
     final route = HttpRoute()
       ..webhooks(id: id.toString())
       ..add(HttpRoutePart(token));
@@ -165,6 +165,8 @@ class WebhookManager extends Manager<Webhook> {
         ...builder.build(),
         if (threadName != null) 'thread_name': threadName,
         if (appliedTags != null) 'applied_tags': appliedTags.map((e) => e.toString()),
+        if (username != null) 'username': username,
+        if (avatarUrl != null) 'avatar_url': avatarUrl,
       };
 
       final files = <MultipartFile>[];

--- a/lib/src/models/webhook.dart
+++ b/lib/src/models/webhook.dart
@@ -45,8 +45,10 @@ class PartialWebhook extends WritableSnowflakeEntity<Webhook> {
   /// External references:
   /// * [WebhookManager.execute]
   /// * Discord API Reference: https://discord.com/developers/docs/resources/webhook#execute-webhook
-  Future<Message?> execute(MessageBuilder builder, {required String token, bool? wait, Snowflake? threadId}) =>
-      manager.execute(id, builder, token: token, wait: wait, threadId: threadId);
+  Future<Message?> execute(MessageBuilder builder,
+          {required String token, bool? wait, Snowflake? threadId, String? threadName, List<Snowflake>? appliedTags, String? username, String? avatarUrl}) =>
+      manager.execute(id, builder,
+          token: token, wait: wait, threadId: threadId, threadName: threadName, appliedTags: appliedTags, username: username, avatarUrl: avatarUrl);
 
   /// Fetch a message sent by this webhook using its [token].
   ///


### PR DESCRIPTION
# Description

Present only in [nyxx-5.1.1](https://github.com/nyxx-discord/nyxx/blob/531bcd004bdf6faf57432fd4edff13eddc44187d/lib/src/core/guild/webhook.dart#L79)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
