### PR TITLE
Prevent events from being dropped during the connection process

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -6,7 +6,7 @@ void main() async {
   final client = await Nyxx.connectGateway(
     Platform.environment['TOKEN']!,
     GatewayIntents.allUnprivileged,
-    options: GatewayClientOptions(plugins: [logging, cliIntegration]),
+    options: GatewayClientOptions(plugins: [Logging(logLevel: Level.ALL), cliIntegration]),
   );
 
   await for (final MessageCreateEvent(:message) in client.onMessageCreate) {

--- a/example/example.dart
+++ b/example/example.dart
@@ -6,7 +6,7 @@ void main() async {
   final client = await Nyxx.connectGateway(
     Platform.environment['TOKEN']!,
     GatewayIntents.allUnprivileged,
-    options: GatewayClientOptions(plugins: [Logging(logLevel: Level.ALL), cliIntegration]),
+    options: GatewayClientOptions(plugins: [logging, cliIntegration]),
   );
 
   await for (final MessageCreateEvent(:message) in client.onMessageCreate) {

--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -100,7 +100,8 @@ export 'src/http/managers/interaction_manager.dart' show InteractionManager;
 export 'src/http/managers/entitlement_manager.dart' show EntitlementManager;
 
 export 'src/gateway/gateway.dart' show Gateway;
-export 'src/gateway/message.dart' show Disconnecting, Dispose, ErrorReceived, EventReceived, GatewayMessage, Send, Sent, ShardData, ShardMessage;
+export 'src/gateway/message.dart'
+    show Disconnecting, Dispose, ErrorReceived, EventReceived, GatewayMessage, Send, Sent, ShardData, ShardMessage, Identify, RequestingIdentify, StartShard;
 export 'src/gateway/shard.dart' show Shard;
 
 export 'src/models/discord_color.dart' show DiscordColor;

--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -115,6 +115,8 @@ class Gateway extends GatewayManager with EventParser {
           if (event is RequestingIdentify) {
             final currentLock = identifyLocks[rateLimitKey] ?? Future.value();
             identifyLocks[rateLimitKey] = currentLock.then((_) {
+              if (_closing) return null;
+
               shard.add(Identify());
               return Future.delayed(identifyDelay);
             });

--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -109,7 +109,7 @@ class Gateway extends GatewayManager with EventParser {
       final rateLimitKey = shard.id % maxConcurrency;
 
       // Delay the shard starting until it is (approximately) also ready to identify.
-      Timer(identifyDelay * rateLimitKey, () {
+      Timer(identifyDelay * (shard.id ~/ maxConcurrency), () {
         logger.fine('Starting shard ${shard.id}');
         shard.add(StartShard());
       });

--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -84,7 +84,7 @@ class Gateway extends GatewayManager with EventParser {
       client.updateCacheWith(parsedEvent);
       yield parsedEvent;
     }
-  }));
+  })).asBroadcastStream();
 
   bool _closing = false;
 

--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -109,7 +109,10 @@ class Gateway extends GatewayManager with EventParser {
       final rateLimitKey = shard.id % maxConcurrency;
 
       // Delay the shard starting until it is (approximately) also ready to identify.
-      Timer(identifyDelay * rateLimitKey, () => shard.add(StartShard()));
+      Timer(identifyDelay * rateLimitKey, () {
+        logger.fine('Starting shard ${shard.id}');
+        shard.add(StartShard());
+      });
 
       shard.listen(
         (event) {

--- a/lib/src/gateway/message.dart
+++ b/lib/src/gateway/message.dart
@@ -70,6 +70,9 @@ class Sent extends ShardMessage {
   Sent({required this.payload});
 }
 
+/// A shard message sent when the shard is waiting to identify on the Gateway.
+class RequestingIdentify extends ShardMessage {}
+
 /// The base class for all control messages sent from the client to the shard.
 abstract class GatewayMessage with ToStringHelper {}
 
@@ -84,6 +87,12 @@ class Send extends GatewayMessage {
   /// Create a new [Send].
   Send({required this.opcode, required this.data});
 }
+
+/// A gateway message sent when the [Gateway] instance is ready for the shard to start.
+class StartShard extends GatewayMessage {}
+
+/// A gateway message sent as a response to [RequestingIdentify] to allow the shard to identify.
+class Identify extends GatewayMessage {}
 
 /// A gateway message sent to instruct the shard to disconnect & stop handling any further messages.
 ///

--- a/lib/src/gateway/shard.dart
+++ b/lib/src/gateway/shard.dart
@@ -108,6 +108,8 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
     final receivePort = ReceivePort('Shard #$id message stream (main)');
     final receiveStream = receivePort.asBroadcastStream();
 
+    logger.fine('Spawning shard runner');
+
     final isolate = await Isolate.spawn(
       _isolateMain,
       _IsolateSpawnData(
@@ -129,6 +131,8 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
     });
 
     final sendPort = await receiveStream.first as SendPort;
+
+    logger.fine('Shard runner ready');
 
     return Shard(id, isolate, receiveStream, sendPort, client);
   }

--- a/lib/src/gateway/shard.dart
+++ b/lib/src/gateway/shard.dart
@@ -87,6 +87,8 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
             logger.info('Reconnected to Gateway');
           }
         }
+      } else if (message is RequestingIdentify) {
+        logger.fine('Ready to identify');
       }
     });
 
@@ -102,8 +104,6 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
   /// Connect to the Gateway using the provided parameters.
   static Future<Shard> connect(int id, int totalShards, GatewayApiOptions apiOptions, Uri connectionUri, NyxxGateway client) async {
     final logger = Logger('${client.options.loggerName}.Shards[$id]');
-
-    logger.info('Connecting to Gateway');
 
     final receivePort = ReceivePort('Shard #$id message stream (main)');
     final receiveStream = receivePort.asBroadcastStream();

--- a/lib/src/gateway/shard.dart
+++ b/lib/src/gateway/shard.dart
@@ -174,12 +174,10 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
     Future<void> doClose() async {
       add(Dispose());
 
-      // Wait for disconnection confirmation
-      await firstWhere((message) => message is Disconnecting);
-
       // Give the isolate time to shut down cleanly, but kill it if it takes too long.
       try {
-        await drain().timeout(const Duration(seconds: 5));
+        // Wait for disconnection confirmation
+        await firstWhere((message) => message is Disconnecting).then(drain).timeout(const Duration(seconds: 5));
       } on TimeoutException {
         logger.warning('Isolate took too long to shut down, killing it');
         isolate.kill(priority: Isolate.immediate);

--- a/lib/src/gateway/shard.dart
+++ b/lib/src/gateway/shard.dart
@@ -149,6 +149,8 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
         ..finer('Opcode: ${event.opcode.value}, Data: ${event.data}');
     } else if (event is Dispose) {
       logger.info('Disposing');
+    } else if (event is Identify) {
+      logger.info('Connecting to Gateway');
     }
     sendPort.send(event);
   }

--- a/lib/src/gateway/shard_runner.dart
+++ b/lib/src/gateway/shard_runner.dart
@@ -79,6 +79,13 @@ class ShardRunner {
       } else if (message is Dispose) {
         disposing = true;
         connection!.close();
+
+        // We might get a dispose request while we are waiting to identify.
+        // Add an error to the identify stream so we break out of the wait.
+        identifyController.addError(
+          Exception('Out of remaining session starts'),
+          StackTrace.current,
+        );
       } else if (message is StartShard) {
         if (startCompleter.isCompleted) {
           controller.add(ErrorReceived(

--- a/test/integration/gateway_integration_test.dart
+++ b/test/integration/gateway_integration_test.dart
@@ -68,6 +68,28 @@ void main() {
         payloadFormat: GatewayPayloadFormat.etf,
       )),
     );
+
+    test('Multiple shards', () async {
+      const shardCount = 5;
+
+      late NyxxGateway client;
+
+      await expectLater(
+        () async => client = await Nyxx.connectGatewayWithOptions(
+          GatewayApiOptions(
+            token: testToken!,
+            intents: GatewayIntents.none,
+            totalShards: shardCount,
+          ),
+        ),
+        completes,
+      );
+      expect(client.gateway.messages.where((event) => event is ErrorReceived), emitsDone);
+      for (int i = 0; i < shardCount; i++) {
+        await expectLater(client.onEvent, emits(isA<ReadyEvent>()));
+      }
+      await expectLater(client.close(), completes);
+    });
   });
 
   group('NyxxGateway', skip: testToken != null ? false : 'No test token provided', () {


### PR DESCRIPTION
# Description

Prevents events from being added to broadcast streams before the client is returned from `Nyxx.connectGateway` (or, at least, until the user is able to access the event streams e.g via plugins).

Also fixes an issue where using getters and `Stream.map` caused every gateway event to be parsed multiple times, scaling with the number of listeners on the client's event streams.

Also fixes an issue where `IDENTIFY` calls were not rate limited if they were not made as part of the initial Gateway connection (e.g during a reconnect).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
