### PR TITLE
Handle missing command permissions error

### DIFF
--- a/test/integration/rest_integration_test.dart
+++ b/test/integration/rest_integration_test.dart
@@ -334,5 +334,33 @@ void main() {
         }
       }
     });
+
+    test('commands', () async {
+      late ApplicationCommand command;
+
+      await expectLater(
+        () async => command = await client.commands.create(ApplicationCommandBuilder.chatInput(name: 'test', description: 'A test command', options: [])),
+        completes,
+      );
+
+      await expectLater(command.fetch(), completes);
+      await expectLater(command.update(ApplicationCommandUpdateBuilder.chatInput(name: 'new_name')), completes);
+      await expectLater(client.commands.list(), completion(isNotEmpty));
+      await expectLater(
+        () async => command =
+            (await client.commands.bulkOverride([ApplicationCommandBuilder.chatInput(name: 'test_2', description: 'A test command', options: [])])).single,
+        completes,
+      );
+
+      if (testGuild != null) {
+        final testGuildId = Snowflake.parse(testGuild);
+        final guild = client.guilds[testGuildId];
+
+        await expectLater(guild.commands.listPermissions(), completes);
+        await expectLater(guild.commands.fetchPermissions(command.id), completes);
+      }
+
+      await expectLater(command.delete(), completes);
+    });
   });
 }


### PR DESCRIPTION
# Description

Handles errors from the fetch command permissions endpoint that indicate no permission overrides were set by returning an empty list of permissions instead of errorring.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
