### PR TITLE
Rate limit outgoing gateway events

### DIFF
--- a/lib/src/gateway/event_parser.dart
+++ b/lib/src/gateway/event_parser.dart
@@ -11,7 +11,7 @@ mixin class EventParser {
       Opcode.reconnect.value: parseReconnect,
       Opcode.invalidSession.value: parseInvalidSession,
       Opcode.hello.value: parseHello,
-      Opcode.heartbeatAck.value: (Map<String, Object?> raw) => parseHeartbeatAck(raw, heartbeatLatency: heartbeatLatency!),
+      Opcode.heartbeatAck.value: (Map<String, Object?> raw) => parseHeartbeatAck(raw, heartbeatLatency: heartbeatLatency ?? Duration.zero),
     };
 
     return mapping[raw['op'] as int]!(raw);

--- a/lib/src/gateway/shard.dart
+++ b/lib/src/gateway/shard.dart
@@ -180,7 +180,7 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
 
       // Give the isolate time to shut down cleanly, but kill it if it takes too long.
       try {
-        // Wait for disconnection confirmation
+        // Wait for disconnection confirmation.
         await firstWhere((message) => message is Disconnecting).then(drain).timeout(const Duration(seconds: 5));
       } on TimeoutException {
         logger.warning('Isolate took too long to shut down, killing it');

--- a/lib/src/gateway/shard.dart
+++ b/lib/src/gateway/shard.dart
@@ -112,6 +112,7 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
 
     final isolate = await Isolate.spawn(
       _isolateMain,
+      debugName: 'Shard #$id runner',
       _IsolateSpawnData(
         totalShards: totalShards,
         id: id,

--- a/lib/src/gateway/shard_runner.dart
+++ b/lib/src/gateway/shard_runner.dart
@@ -193,7 +193,7 @@ class ShardRunner {
             canResume = resumableCodes.contains(connection!.remoteCloseCode);
 
             controller.add(ErrorReceived(
-              error: 'Connection was closed with cde ${connection!.remoteCloseCode}',
+              error: 'Connection was closed with code ${connection!.remoteCloseCode}',
               stackTrace: StackTrace.current,
             ));
           }
@@ -237,7 +237,6 @@ class ShardRunner {
 
     connection!.add(Send(opcode: Opcode.heartbeat, data: seq));
     lastHeartbeatAcked = false;
-    heartbeatStopwatch = Stopwatch()..start();
   }
 
   void startHeartbeat(Duration heartbeatInterval) {
@@ -335,6 +334,10 @@ class ShardConnection extends Stream<GatewayEvent> implements StreamSink<Send> {
       GatewayPayloadFormat.json => jsonEncode(payload),
       GatewayPayloadFormat.etf => eterl.pack(payload),
     };
+
+    if (event.opcode == Opcode.heartbeat) {
+      runner.heartbeatStopwatch = Stopwatch()..start();
+    }
 
     websocket.add(encoded);
     _sentController.add(Sent(payload: event));


### PR DESCRIPTION
# Description

Adds rate limiting and buffering of outgoing Gateway events as described [here](https://discord.com/developers/docs/topics/gateway#rate-limiting).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
