### PR TITLE
Allow plugins to intercept HTTP requests and Gateway events

### DIFF
--- a/lib/src/gateway/shard.dart
+++ b/lib/src/gateway/shard.dart
@@ -24,8 +24,13 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
   /// The stream on which events from the runner are received.
   final Stream<dynamic> receiveStream;
 
+  final StreamController<ShardMessage> _rawReceiveController = StreamController();
+  final StreamController<ShardMessage> _transformedReceiveController = StreamController.broadcast();
+
   /// The port on which events are sent to the runner.
   final SendPort sendPort;
+
+  final StreamController<GatewayMessage> _sendController = StreamController();
 
   /// The client this [Shard] is for.
   final NyxxGateway client;
@@ -44,6 +49,22 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
 
   /// Create a new [Shard].
   Shard(this.id, this.isolate, this.receiveStream, this.sendPort, this.client) {
+    client.initialized.then((_) {
+      final sendStream = client.options.plugins.fold(
+        _sendController.stream,
+        (previousValue, plugin) => plugin.interceptGatewayMessages(this, previousValue),
+      );
+      sendStream.listen(sendPort.send, cancelOnError: false, onDone: close);
+
+      final transformedReceiveStream = client.options.plugins.fold(
+        _rawReceiveController.stream,
+        (previousValue, plugin) => plugin.interceptShardMessages(this, previousValue),
+      );
+      transformedReceiveStream.pipe(_transformedReceiveController);
+    });
+
+    receiveStream.cast<ShardMessage>().pipe(_rawReceiveController);
+
     final subscription = listen((message) {
       if (message is Sent) {
         logger
@@ -156,7 +177,8 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
     } else if (event is Identify) {
       logger.info('Connecting to Gateway');
     }
-    sendPort.send(event);
+
+    _sendController.add(event);
   }
 
   @override
@@ -166,7 +188,7 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
     void Function()? onDone,
     bool? cancelOnError,
   }) {
-    return receiveStream.cast<ShardMessage>().listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    return _transformedReceiveController.stream.listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 
   @override
@@ -177,6 +199,10 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
 
     Future<void> doClose() async {
       add(Dispose());
+
+      _sendController.close();
+      // _rawReceiveController and _transformedReceiveController are closed by the piped
+      // receive port stream being closed.
 
       // Give the isolate time to shut down cleanly, but kill it if it takes too long.
       try {

--- a/lib/src/plugin/plugin.dart
+++ b/lib/src/plugin/plugin.dart
@@ -58,21 +58,31 @@ abstract class NyxxPlugin<ClientType extends Nyxx> {
   /// instances of the plugin attached to other clients.
   FutureOr<NyxxPluginState<ClientType, NyxxPlugin<ClientType>>> createState() => NyxxPluginState(this);
 
+  /// {@template before_connect}
   /// Called before each client this plugin is added to connects.
+  /// {@endtemplate}
   FutureOr<void> beforeConnect(ApiOptions apiOptions, ClientOptions clientOptions) {}
 
+  /// {@template after_connect}
   /// Called after each client this plugin is added to connects.
+  /// {@endtemplate}
   FutureOr<void> afterConnect(ClientType client) {}
 
+  /// {@template before_close}
   /// Called before each client this plugin is added to closes.
+  /// {@endtemplate}
   FutureOr<void> beforeClose(ClientType client) {}
 
+  /// {@template after_close}
   /// Called after each client this plugin is added to closes.
+  /// {@endtemplate}
   FutureOr<void> afterClose() {}
 
+  /// {@template intercept_request}
   /// Called whenever a request is made using a client's [HttpHandler].
   ///
   /// Plugins that implement this method are not required to call the [next] method.
+  /// {@endtemplate}
   @mustCallSuper
   Future<HttpResponse> interceptRequest(ClientType client, HttpRequest request, Future<HttpResponse> Function(HttpRequest) next) {
     final state = _states[client];
@@ -91,24 +101,22 @@ class NyxxPluginState<ClientType extends Nyxx, PluginType extends NyxxPlugin<Cli
   /// Create a new plugin state.
   NyxxPluginState(this.plugin);
 
-  /// Called before each client this plugin is added to connects.
+  /// {@macro before_connect}
   @mustCallSuper
   FutureOr<void> beforeConnect(ApiOptions apiOptions, ClientOptions clientOptions) => plugin.beforeConnect(apiOptions, clientOptions);
 
-  /// Called after each client this plugin is added to connects.
+  /// {@macro after_connect}
   @mustCallSuper
   FutureOr<void> afterConnect(ClientType client) => plugin.afterConnect(client);
 
-  /// Called before each client this plugin is added to closes.
+  /// {@macro before_close}
   @mustCallSuper
   FutureOr<void> beforeClose(ClientType client) => plugin.beforeClose(client);
 
-  /// Called after each client this plugin is added to closes.
+  /// {@macro after_close}
   @mustCallSuper
   FutureOr<void> afterClose() => plugin.afterClose();
 
-  /// Called whenever a request is made using a client's [HttpHandler].
-  ///
-  /// Plugins that implement this method are not required to call the [next] method.
+  /// {@macro intercept_request}
   Future<HttpResponse> interceptRequest(ClientType client, HttpRequest request, Future<HttpResponse> Function(HttpRequest) next) => next(request);
 }

--- a/lib/src/plugin/plugin.dart
+++ b/lib/src/plugin/plugin.dart
@@ -5,6 +5,8 @@ import 'package:meta/meta.dart';
 import 'package:nyxx/src/api_options.dart';
 import 'package:nyxx/src/client.dart';
 import 'package:nyxx/src/client_options.dart';
+import 'package:nyxx/src/gateway/message.dart';
+import 'package:nyxx/src/gateway/shard.dart';
 import 'package:nyxx/src/http/handler.dart';
 import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/response.dart';
@@ -88,6 +90,20 @@ abstract class NyxxPlugin<ClientType extends Nyxx> {
     final state = _states[client];
     return state?.interceptRequest(client, request, next) ?? next(request);
   }
+
+  /// {@template intercept_shard_messages}
+  /// Intercept [ShardMessage]s by transforming the [messages] stream.
+  /// {@endtemplate}
+  @mustCallSuper
+  Stream<ShardMessage> interceptShardMessages(Shard shard, Stream<ShardMessage> messages) =>
+      _states[shard.client]?.interceptShardMessages(shard, messages) ?? messages;
+
+  /// {@template intercept_gateway_messages}
+  /// Intercept [GatewayMessage]s by transforming the [messages] stream.
+  /// {@endtemplate}
+  @mustCallSuper
+  Stream<GatewayMessage> interceptGatewayMessages(Shard shard, Stream<GatewayMessage> messages) =>
+      _states[shard.client]?.interceptGatewayMessages(shard, messages) ?? messages;
 }
 
 /// Holds the state of a plugin added to a client.
@@ -119,4 +135,10 @@ class NyxxPluginState<ClientType extends Nyxx, PluginType extends NyxxPlugin<Cli
 
   /// {@macro intercept_request}
   Future<HttpResponse> interceptRequest(ClientType client, HttpRequest request, Future<HttpResponse> Function(HttpRequest) next) => next(request);
+
+  /// {@macro intercept_shard_messages}
+  Stream<ShardMessage> interceptShardMessages(Shard shard, Stream<ShardMessage> messages) => messages;
+
+  /// {@macro intercept_gateway_messages}
+  Stream<GatewayMessage> interceptGatewayMessages(Shard shard, Stream<GatewayMessage> messages) => messages;
 }

--- a/test/integration/gateway_integration_test.dart
+++ b/test/integration/gateway_integration_test.dart
@@ -14,7 +14,7 @@ void main() {
       late NyxxGateway client;
 
       await expectLater(() async => client = await Nyxx.connectGatewayWithOptions(options), completes);
-      expect(client.gateway.messages.where((event) => event is ErrorReceived), emitsDone);
+      expect(client.gateway.messages, neverEmits(isA<ErrorReceived>()));
       await expectLater(client.onEvent, emits(isA<ReadyEvent>()));
       await expectLater(client.close(), completes);
     }


### PR DESCRIPTION
# Description

This PR adds methods to NyxxPlugin that gives plugins more control over the client after it is created. Specifically plugins can now completely customize how HTTP requests are executed and filter sent and received gateway events.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
