### PR TITLE
Correct serialization of request body in MessageManager.bulkDelete

### DIFF
--- a/lib/src/http/managers/message_manager.dart
+++ b/lib/src/http/managers/message_manager.dart
@@ -458,12 +458,17 @@ class MessageManager extends Manager<Message> {
   /// Bulk delete many messages at once
   ///
   /// This will throw an error if any of [ids] is not a valid message ID or if any of the messages are from before [Snowflake.bulkDeleteLimit].
-  Future<void> bulkDelete(Iterable<Snowflake> ids) async {
+  Future<void> bulkDelete(Iterable<Snowflake> ids, {String? auditLogReason}) async {
     final route = HttpRoute()
       ..channels(id: channelId.toString())
       ..messages()
       ..bulkDelete();
-    final request = BasicRequest(route, method: 'POST', body: jsonEncode({'messages': ids.map((e) => e.toString()).toList()}));
+    final request = BasicRequest(
+      route,
+      method: 'POST',
+      body: jsonEncode({'messages': ids.map((e) => e.toString()).toList()}),
+      auditLogReason: auditLogReason,
+    );
 
     await client.httpHandler.executeSafe(request);
   }

--- a/lib/src/http/managers/message_manager.dart
+++ b/lib/src/http/managers/message_manager.dart
@@ -463,7 +463,7 @@ class MessageManager extends Manager<Message> {
       ..channels(id: channelId.toString())
       ..messages()
       ..bulkDelete();
-    final request = BasicRequest(route, method: 'POST', body: jsonEncode(ids.map((e) => e.toString()).toList()));
+    final request = BasicRequest(route, method: 'POST', body: jsonEncode({'messages': ids.map((e) => e.toString()).toList()}));
 
     await client.httpHandler.executeSafe(request);
   }

--- a/test/integration/rest_integration_test.dart
+++ b/test/integration/rest_integration_test.dart
@@ -130,7 +130,7 @@ void main() {
       await expectLater(message.attachments.first.fetch(), completes);
       await expectLater(message.attachments.first.fetchStreamed().drain(), completes);
 
-      await expectLater(message.delete(), completes);
+      await expectLater(channel.messages.bulkDelete([message.id]), completes);
 
       await expectLater(
         () async => message = await channel.sendMessage(

--- a/test/integration/rest_integration_test.dart
+++ b/test/integration/rest_integration_test.dart
@@ -130,7 +130,18 @@ void main() {
       await expectLater(message.attachments.first.fetch(), completes);
       await expectLater(message.attachments.first.fetchStreamed().drain(), completes);
 
-      await expectLater(channel.messages.bulkDelete([message.id]), completes);
+      late Message message2;
+      await expectLater(
+        () async => message2 = await channel.sendMessage(MessageBuilder(
+          attachments: [
+            await AttachmentBuilder.fromFile(File('test/files/2.png')),
+            await AttachmentBuilder.fromFile(File('test/files/3.png')),
+          ],
+        )),
+        completes,
+      );
+
+      await expectLater(channel.messages.bulkDelete([message.id, message2.id]), completes);
 
       await expectLater(
         () async => message = await channel.sendMessage(


### PR DESCRIPTION
# Description

As the title says.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
