### PR TITLE
Parse GuildDeleteEvent.isUnavailable even when unavailable is not present

### DIFF
--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -529,7 +529,7 @@ class Gateway extends GatewayManager with EventParser {
     return GuildDeleteEvent(
       gateway: this,
       guild: PartialGuild(id: Snowflake.parse(raw['id']!), manager: client.guilds),
-      isUnavailable: raw['unavailable'] as bool,
+      isUnavailable: raw['unavailable'] as bool? ?? false,
     );
   }
 


### PR DESCRIPTION
# Description

As the title says.
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
