### PR TITLE
Hide model constructors in generated dartdocs

### DIFF
--- a/lib/src/models/application.dart
+++ b/lib/src/models/application.dart
@@ -26,6 +26,7 @@ class PartialApplication with ToStringHelper {
   EntitlementManager get entitlements => EntitlementManager(manager.client.options.entitlementConfig, manager.client, applicationId: id);
 
   /// Create a new [PartialApplication].
+  /// @nodoc
   PartialApplication({required this.id, required this.manager});
 
   /// Fetch this application's role connection metadata.
@@ -120,6 +121,7 @@ class Application extends PartialApplication {
   final Uri? roleConnectionsVerificationUrl;
 
   /// {@macro application}
+  /// @nodoc
   Application({
     required super.id,
     required super.manager,
@@ -246,6 +248,7 @@ class InstallationParameters with ToStringHelper {
   final Permissions permissions;
 
   /// {@macro installation_parameters}
+  /// @nodoc
   InstallationParameters({
     required this.scopes,
     required this.permissions,
@@ -275,6 +278,7 @@ class ApplicationRoleConnectionMetadata with ToStringHelper {
   final Map<Locale, String>? localizedDescriptions;
 
   /// {@macro application_role_connection_metadata}
+  /// @nodoc
   ApplicationRoleConnectionMetadata({
     required this.type,
     required this.key,

--- a/lib/src/models/channel/channel.dart
+++ b/lib/src/models/channel/channel.dart
@@ -10,6 +10,7 @@ class PartialChannel extends ManagedSnowflakeEntity<Channel> {
   final ChannelManager manager;
 
   /// Create a new [PartialChannel].
+  /// @nodoc
   PartialChannel({required super.id, required this.manager});
 
   /// Update this channel.
@@ -42,6 +43,7 @@ abstract class Channel extends PartialChannel {
   ChannelType get type;
 
   /// {@macro channel}
+  /// @nodoc
   Channel({required super.id, required super.manager});
 }
 

--- a/lib/src/models/channel/followed_channel.dart
+++ b/lib/src/models/channel/followed_channel.dart
@@ -18,6 +18,7 @@ class FollowedChannel with ToStringHelper {
   final Snowflake webhookId;
 
   /// {@macro followed_channel}
+  /// @nodoc
   FollowedChannel({required this.manager, required this.channelId, required this.webhookId});
 
   /// The followed channel.

--- a/lib/src/models/channel/stage_instance.dart
+++ b/lib/src/models/channel/stage_instance.dart
@@ -30,6 +30,7 @@ class StageInstance extends SnowflakeEntity<StageInstance> {
   final Snowflake? scheduledEventId;
 
   /// {@macro stage_instance}
+  /// @nodoc
   StageInstance({
     required super.id,
     required this.manager,

--- a/lib/src/models/channel/text_channel.dart
+++ b/lib/src/models/channel/text_channel.dart
@@ -10,6 +10,7 @@ class PartialTextChannel extends PartialChannel {
   MessageManager get messages => MessageManager(manager.client.options.messageCacheConfig, manager.client, channelId: id);
 
   /// Create a new [PartialTextChannel].
+  /// @nodoc
   PartialTextChannel({required super.id, required super.manager});
 
   /// Send a message to this channel.
@@ -46,6 +47,7 @@ abstract class TextChannel extends PartialTextChannel implements Channel {
   /// The time at which the last message was pinned, or `null` if no messages have been pinned.
   DateTime? get lastPinTimestamp;
 
+  /// @nodoc
   TextChannel({required super.id, required super.manager});
 
   /// The last message sent in this channel, or `null` if no messages have been sent.

--- a/lib/src/models/channel/thread.dart
+++ b/lib/src/models/channel/thread.dart
@@ -92,6 +92,7 @@ class PartialThreadMember {
   final Flags<Never> flags;
 
   /// {@macro partial_thread_member}
+  /// @nodoc
   PartialThreadMember({required this.joinTimestamp, required this.flags});
 }
 
@@ -111,6 +112,7 @@ class ThreadMember extends PartialThreadMember {
   final Member? member;
 
   /// {@macro thread_member}
+  /// @nodoc
   ThreadMember({
     required super.joinTimestamp,
     required super.flags,

--- a/lib/src/models/channel/thread_list.dart
+++ b/lib/src/models/channel/thread_list.dart
@@ -15,6 +15,7 @@ class ThreadList with ToStringHelper {
   final bool hasMore;
 
   /// {@macro thread_list}
+  /// @nodoc
   ThreadList({
     required this.threads,
     required this.members,

--- a/lib/src/models/channel/types/announcement_thread.dart
+++ b/lib/src/models/channel/types/announcement_thread.dart
@@ -77,6 +77,7 @@ class AnnouncementThread extends TextChannel implements Thread {
   @override
   ChannelType get type => ChannelType.announcementThread;
 
+  /// @nodoc
   AnnouncementThread({
     required super.id,
     required super.manager,

--- a/lib/src/models/channel/types/directory.dart
+++ b/lib/src/models/channel/types/directory.dart
@@ -8,5 +8,6 @@ class DirectoryChannel extends Channel {
   ChannelType get type => ChannelType.guildDirectory;
 
   /// {@macro directory_channel}
+  /// @nodoc
   DirectoryChannel({required super.id, required super.manager});
 }

--- a/lib/src/models/channel/types/dm.dart
+++ b/lib/src/models/channel/types/dm.dart
@@ -24,6 +24,7 @@ class DmChannel extends TextChannel {
   ChannelType get type => ChannelType.dm;
 
   /// {@macro dm_channel}
+  /// @nodoc
   DmChannel({
     required super.id,
     required super.manager,

--- a/lib/src/models/channel/types/forum.dart
+++ b/lib/src/models/channel/types/forum.dart
@@ -73,6 +73,7 @@ class ForumChannel extends Channel implements GuildChannel, ThreadsOnlyChannel {
   ChannelType get type => ChannelType.guildForum;
 
   /// {@macro forum_channel}
+  /// @nodoc
   ForumChannel({
     required super.id,
     required super.manager,
@@ -157,6 +158,7 @@ class ForumTag with ToStringHelper {
   final String? emojiName;
 
   /// {@macro forum_tag}
+  /// @nodoc
   ForumTag({
     required this.id,
     required this.name,
@@ -177,6 +179,7 @@ class DefaultReaction with ToStringHelper {
   final String? emojiName;
 
   /// {@macro default_reaction}
+  /// @nodoc
   DefaultReaction({required this.emojiId, required this.emojiName});
 }
 

--- a/lib/src/models/channel/types/group_dm.dart
+++ b/lib/src/models/channel/types/group_dm.dart
@@ -40,6 +40,7 @@ class GroupDmChannel extends TextChannel {
   ChannelType get type => ChannelType.groupDm;
 
   /// {@macro group_dm_channel}
+  /// @nodoc
   GroupDmChannel({
     required super.id,
     required super.manager,

--- a/lib/src/models/channel/types/guild_announcement.dart
+++ b/lib/src/models/channel/types/guild_announcement.dart
@@ -59,6 +59,7 @@ class GuildAnnouncementChannel extends TextChannel implements GuildChannel, HasT
   ChannelType get type => ChannelType.guildAnnouncement;
 
   /// {@macro guild_announcement_channel}
+  /// @nodoc
   GuildAnnouncementChannel({
     required super.id,
     required super.manager,

--- a/lib/src/models/channel/types/guild_category.dart
+++ b/lib/src/models/channel/types/guild_category.dart
@@ -35,6 +35,7 @@ class GuildCategory extends Channel implements GuildChannel {
   ChannelType get type => ChannelType.guildCategory;
 
   /// {@macro guild_category}
+  /// @nodoc
   GuildCategory({
     required super.id,
     required super.manager,

--- a/lib/src/models/channel/types/guild_media.dart
+++ b/lib/src/models/channel/types/guild_media.dart
@@ -70,6 +70,7 @@ class GuildMediaChannel extends Channel implements GuildChannel, ThreadsOnlyChan
   ChannelType get type => ChannelType.guildForum;
 
   /// {@macro guild_media_channel}
+  /// @nodoc
   GuildMediaChannel({
     required super.id,
     required super.manager,

--- a/lib/src/models/channel/types/guild_stage.dart
+++ b/lib/src/models/channel/types/guild_stage.dart
@@ -59,6 +59,7 @@ class GuildStageChannel extends TextChannel implements VoiceChannel, GuildChanne
   ChannelType get type => ChannelType.guildStageVoice;
 
   /// {@macro guild_stage_channel}
+  /// @nodoc
   GuildStageChannel({
     required super.id,
     required super.manager,

--- a/lib/src/models/channel/types/guild_text.dart
+++ b/lib/src/models/channel/types/guild_text.dart
@@ -59,6 +59,7 @@ class GuildTextChannel extends TextChannel implements GuildChannel, HasThreadsCh
   ChannelType get type => ChannelType.guildText;
 
   /// {@macro guild_text_channel}
+  /// @nodoc
   GuildTextChannel({
     required super.id,
     required super.manager,

--- a/lib/src/models/channel/types/guild_voice.dart
+++ b/lib/src/models/channel/types/guild_voice.dart
@@ -59,6 +59,7 @@ class GuildVoiceChannel extends TextChannel implements GuildChannel, VoiceChanne
   ChannelType get type => ChannelType.guildVoice;
 
   /// {@macro guild_voice_channel}
+  /// @nodoc
   GuildVoiceChannel({
     required super.id,
     required super.manager,

--- a/lib/src/models/channel/types/private_thread.dart
+++ b/lib/src/models/channel/types/private_thread.dart
@@ -83,6 +83,7 @@ class PrivateThread extends TextChannel implements Thread {
   ChannelType get type => ChannelType.privateThread;
 
   /// {@macro private_thread}
+  /// @nodoc
   PrivateThread({
     required super.id,
     required super.manager,

--- a/lib/src/models/channel/types/public_thread.dart
+++ b/lib/src/models/channel/types/public_thread.dart
@@ -81,6 +81,7 @@ class PublicThread extends TextChannel implements Thread {
   ChannelType get type => ChannelType.publicThread;
 
   /// {@macro public_thread}
+  /// @nodoc
   PublicThread({
     required super.id,
     required super.manager,

--- a/lib/src/models/commands/application_command.dart
+++ b/lib/src/models/commands/application_command.dart
@@ -14,6 +14,7 @@ class PartialApplicationCommand extends WritableSnowflakeEntity<ApplicationComma
   final ApplicationCommandManager manager;
 
   /// Create a new [PartialApplicationCommand].
+  /// @nodoc
   PartialApplicationCommand({required super.id, required this.manager});
 
   /// Fetch the permissions for this command in a given guild.
@@ -63,6 +64,7 @@ class ApplicationCommand extends PartialApplicationCommand {
   final Snowflake version;
 
   /// {@macro application_command}
+  /// @nodoc
   ApplicationCommand({
     required super.id,
     required super.manager,

--- a/lib/src/models/commands/application_command_option.dart
+++ b/lib/src/models/commands/application_command_option.dart
@@ -50,6 +50,7 @@ class CommandOption with ToStringHelper {
   final bool? hasAutocomplete;
 
   /// {@macro command_option}
+  /// @nodoc
   CommandOption({
     required this.type,
     required this.name,
@@ -113,6 +114,7 @@ class CommandOptionChoice {
   final dynamic value;
 
   /// {@macro command_option_choice}
+  /// @nodoc
   CommandOptionChoice({required this.name, required this.nameLocalizations, required this.value});
 }
 

--- a/lib/src/models/commands/application_command_permissions.dart
+++ b/lib/src/models/commands/application_command_permissions.dart
@@ -23,6 +23,7 @@ class CommandPermissions extends SnowflakeEntity<CommandPermissions> {
   final List<CommandPermission> permissions;
 
   /// {@macro command_permissions}
+  /// @nodoc
   CommandPermissions({
     required this.manager,
     required super.id,
@@ -68,6 +69,7 @@ class CommandPermission with ToStringHelper {
   final bool hasPermission;
 
   /// {@macro command_permission}
+  /// @nodoc
   CommandPermission({required this.id, required this.type, required this.hasPermission});
 }
 

--- a/lib/src/models/emoji.dart
+++ b/lib/src/models/emoji.dart
@@ -12,6 +12,7 @@ class PartialEmoji extends WritableSnowflakeEntity<Emoji> {
   final EmojiManager manager;
 
   /// Create a new [PartialEmoji].
+  /// @nodoc
   PartialEmoji({required super.id, required this.manager});
 }
 
@@ -20,6 +21,7 @@ abstract class Emoji extends PartialEmoji {
   /// The emoji's name. Can be `dartlang` for a custom emoji, or `❤️` for a text emoji.
   String? get name;
 
+  /// @nodoc
   Emoji({
     required super.id,
     required super.manager,
@@ -31,6 +33,7 @@ class TextEmoji extends Emoji {
   @override
   final String name;
 
+  /// @nodoc
   TextEmoji({
     required super.id,
     required super.manager,
@@ -65,6 +68,7 @@ class GuildEmoji extends Emoji {
   /// Whether this emoji can be used, may be false due to loss of Server Boosts.
   final bool? isAvailable;
 
+  /// @nodoc
   GuildEmoji({
     required super.id,
     required super.manager,

--- a/lib/src/models/entitlement.dart
+++ b/lib/src/models/entitlement.dart
@@ -11,6 +11,7 @@ class PartialEntitlement extends ManagedSnowflakeEntity<Entitlement> {
   final EntitlementManager manager;
 
   /// Create a new [PartialEntitlement].
+  /// @nodoc
   PartialEntitlement({required this.manager, required super.id});
 }
 
@@ -43,6 +44,7 @@ class Entitlement extends PartialEntitlement {
   final DateTime? endsAt;
 
   /// {@macro entitlement}
+  /// @nodoc
   Entitlement({
     required super.manager,
     required super.id,

--- a/lib/src/models/gateway/event.dart
+++ b/lib/src/models/gateway/event.dart
@@ -10,6 +10,7 @@ abstract class GatewayEvent with ToStringHelper {
   final Opcode opcode;
 
   /// {@macro gateway_event}
+  /// @nodoc
   GatewayEvent({required this.opcode});
 }
 
@@ -27,6 +28,7 @@ class RawDispatchEvent extends GatewayEvent {
   final Map<String, Object?> payload;
 
   /// {@macro raw_dispatch_event}
+  /// @nodoc
   RawDispatchEvent({required this.seq, required this.name, required this.payload}) : super(opcode: Opcode.dispatch);
 }
 
@@ -38,6 +40,7 @@ abstract class DispatchEvent extends GatewayEvent {
   final Gateway gateway;
 
   /// {@macro dispatch_event}
+  /// @nodoc
   DispatchEvent({required this.gateway}) : super(opcode: Opcode.dispatch);
 }
 
@@ -51,6 +54,7 @@ class UnknownDispatchEvent extends DispatchEvent {
   final RawDispatchEvent raw;
 
   /// {@macro unknown_dispatch_event}
+  /// @nodoc
   UnknownDispatchEvent({required super.gateway, required this.raw});
 }
 
@@ -78,6 +82,7 @@ class InvalidSessionEvent extends GatewayEvent {
   final bool isResumable;
 
   /// {@macro invalid_session_event}
+  /// @nodoc
   InvalidSessionEvent({required this.isResumable}) : super(opcode: Opcode.invalidSession);
 }
 
@@ -89,6 +94,7 @@ class HelloEvent extends GatewayEvent {
   final Duration heartbeatInterval;
 
   /// {@macro hello_event}
+  /// @nodoc
   HelloEvent({required this.heartbeatInterval}) : super(opcode: Opcode.hello);
 }
 
@@ -100,5 +106,6 @@ class HeartbeatAckEvent extends GatewayEvent {
   final Duration latency;
 
   /// {@macro heartbeat_ack_event}
+  /// @nodoc
   HeartbeatAckEvent({required this.latency}) : super(opcode: Opcode.heartbeatAck);
 }

--- a/lib/src/models/gateway/events/application_command.dart
+++ b/lib/src/models/gateway/events/application_command.dart
@@ -12,5 +12,6 @@ class ApplicationCommandPermissionsUpdateEvent extends DispatchEvent {
   final CommandPermissions? oldPermissions;
 
   /// {@macro application_command_permissions_update_event}
+  /// @nodoc
   ApplicationCommandPermissionsUpdateEvent({required super.gateway, required this.permissions, required this.oldPermissions});
 }

--- a/lib/src/models/gateway/events/auto_moderation.dart
+++ b/lib/src/models/gateway/events/auto_moderation.dart
@@ -16,6 +16,7 @@ class AutoModerationRuleCreateEvent extends DispatchEvent {
   final AutoModerationRule rule;
 
   /// {@macro auto_moderation_rule_create_event}
+  /// @nodoc
   AutoModerationRuleCreateEvent({required super.gateway, required this.rule});
 }
 
@@ -30,6 +31,7 @@ class AutoModerationRuleUpdateEvent extends DispatchEvent {
   final AutoModerationRule rule;
 
   /// {@macro auto_moderation_rule_update_event}
+  /// @nodoc
   AutoModerationRuleUpdateEvent({required super.gateway, required this.oldRule, required this.rule});
 }
 
@@ -41,6 +43,7 @@ class AutoModerationRuleDeleteEvent extends DispatchEvent {
   final AutoModerationRule rule;
 
   /// {@macro auto_moderation_rule_delete_event}
+  /// @nodoc
   AutoModerationRuleDeleteEvent({required super.gateway, required this.rule});
 }
 
@@ -82,6 +85,7 @@ class AutoModerationActionExecutionEvent extends DispatchEvent {
   final String? matchedContent;
 
   /// {@macro auto_moderation_action_execution_event}
+  /// @nodoc
   AutoModerationActionExecutionEvent({
     required super.gateway,
     required this.guildId,

--- a/lib/src/models/gateway/events/channel.dart
+++ b/lib/src/models/gateway/events/channel.dart
@@ -13,6 +13,7 @@ class ChannelCreateEvent extends DispatchEvent {
   final Channel channel;
 
   /// {@macro channel_create_event}
+  /// @nodoc
   ChannelCreateEvent({required super.gateway, required this.channel});
 }
 
@@ -27,6 +28,7 @@ class ChannelUpdateEvent extends DispatchEvent {
   final Channel channel;
 
   /// {@macro channel_update_event}
+  /// @nodoc
   ChannelUpdateEvent({required super.gateway, required this.oldChannel, required this.channel});
 }
 
@@ -38,6 +40,7 @@ class ChannelDeleteEvent extends DispatchEvent {
   final Channel channel;
 
   /// {@macro channel_delete_event}
+  /// @nodoc
   ChannelDeleteEvent({required super.gateway, required this.channel});
 }
 
@@ -49,6 +52,7 @@ class ThreadCreateEvent extends DispatchEvent {
   final Thread thread;
 
   /// {@macro thread_create_event}
+  /// @nodoc
   ThreadCreateEvent({required super.gateway, required this.thread});
 }
 
@@ -63,6 +67,7 @@ class ThreadUpdateEvent extends DispatchEvent {
   final Thread thread;
 
   /// {@macro thread_update_event}
+  /// @nodoc
   ThreadUpdateEvent({required super.gateway, required this.oldThread, required this.thread});
 }
 
@@ -74,6 +79,7 @@ class ThreadDeleteEvent extends DispatchEvent {
   final PartialChannel thread;
 
   /// {@macro thread_delete_event}
+  /// @nodoc
   ThreadDeleteEvent({required super.gateway, required this.thread});
 }
 
@@ -94,6 +100,7 @@ class ThreadListSyncEvent extends DispatchEvent {
   final List<ThreadMember> members;
 
   /// {@macro thread_list_sync_event}
+  /// @nodoc
   ThreadListSyncEvent({
     required super.gateway,
     required this.guildId,
@@ -120,6 +127,7 @@ class ThreadMemberUpdateEvent extends DispatchEvent {
   final Snowflake guildId;
 
   /// {@macro thread_member_update_event}
+  /// @nodoc
   ThreadMemberUpdateEvent({required super.gateway, required this.member, required this.guildId});
 
   /// The guild in which the member was updated.
@@ -146,6 +154,7 @@ class ThreadMembersUpdateEvent extends DispatchEvent {
   final List<Snowflake>? removedMemberIds;
 
   /// {@macro thread_members_update_event}
+  /// @nodoc
   ThreadMembersUpdateEvent({
     required super.gateway,
     required this.id,
@@ -176,6 +185,7 @@ class ChannelPinsUpdateEvent extends DispatchEvent {
   final DateTime? lastPinTimestamp;
 
   /// {@macro channel_pins_update_event}
+  /// @nodoc
   ChannelPinsUpdateEvent({required super.gateway, required this.guildId, required this.channelId, required this.lastPinTimestamp});
 
   /// The guild the channel is in.

--- a/lib/src/models/gateway/events/entitlement.dart
+++ b/lib/src/models/gateway/events/entitlement.dart
@@ -9,6 +9,7 @@ class EntitlementCreateEvent extends DispatchEvent {
   final Entitlement entitlement;
 
   /// {@macro entitlement_create_event}
+  /// @nodoc
   EntitlementCreateEvent({required super.gateway, required this.entitlement});
 }
 
@@ -23,6 +24,7 @@ class EntitlementUpdateEvent extends DispatchEvent {
   final Entitlement? oldEntitlement;
 
   /// {@macro entitlement_update_event}
+  /// @nodoc
   EntitlementUpdateEvent({required super.gateway, required this.entitlement, required this.oldEntitlement});
 }
 
@@ -34,5 +36,6 @@ class EntitlementDeleteEvent extends DispatchEvent {
   final Entitlement entitlement;
 
   /// {@macro entitlement_delete_event}
+  /// @nodoc
   EntitlementDeleteEvent({required super.gateway, required this.entitlement});
 }

--- a/lib/src/models/gateway/events/guild.dart
+++ b/lib/src/models/gateway/events/guild.dart
@@ -22,6 +22,7 @@ class UnavailableGuildCreateEvent extends DispatchEvent {
   final PartialGuild guild;
 
   /// {@macro unavailable_guild_create_event}
+  /// @nodoc
   UnavailableGuildCreateEvent({required super.gateway, required this.guild});
 }
 
@@ -63,6 +64,7 @@ class GuildCreateEvent extends DispatchEvent implements UnavailableGuildCreateEv
   final List<ScheduledEvent> scheduledEvents;
 
   /// {@macro guild_create_event}
+  /// @nodoc
   GuildCreateEvent({
     required super.gateway,
     required this.guild,
@@ -90,6 +92,7 @@ class GuildUpdateEvent extends DispatchEvent {
   final Guild guild;
 
   /// {@macro guild_update_event}
+  /// @nodoc
   GuildUpdateEvent({required super.gateway, required this.oldGuild, required this.guild});
 }
 
@@ -104,6 +107,7 @@ class GuildDeleteEvent extends DispatchEvent {
   final bool isUnavailable;
 
   /// {@macro guild_delete_event}
+  /// @nodoc
   GuildDeleteEvent({required super.gateway, required this.guild, required this.isUnavailable});
 }
 
@@ -118,6 +122,7 @@ class GuildAuditLogCreateEvent extends DispatchEvent {
   final Snowflake guildId;
 
   /// {@macro guild_audit_log_create_event}
+  /// @nodoc
   GuildAuditLogCreateEvent({required super.gateway, required this.entry, required this.guildId});
 
   /// The guild in which the entry was created.
@@ -135,6 +140,7 @@ class GuildBanAddEvent extends DispatchEvent {
   final User user;
 
   /// {@macro guild_ban_add_event}
+  /// @nodoc
   GuildBanAddEvent({required super.gateway, required this.guildId, required this.user});
 
   /// The guild in which the user was banned.
@@ -152,6 +158,7 @@ class GuildBanRemoveEvent extends DispatchEvent {
   final User user;
 
   /// {@macro guild_ban_remove_event}
+  /// @nodoc
   GuildBanRemoveEvent({required super.gateway, required this.guildId, required this.user});
 
   /// The guild in which the user was unbanned.
@@ -169,6 +176,7 @@ class GuildEmojisUpdateEvent extends DispatchEvent {
   final List<Emoji> emojis;
 
   /// {@macro guild_emojis_update_event}
+  /// @nodoc
   GuildEmojisUpdateEvent({required super.gateway, required this.guildId, required this.emojis});
 
   /// The guild in which emojis were updated.
@@ -186,6 +194,7 @@ class GuildStickersUpdateEvent extends DispatchEvent {
   final List<GuildSticker> stickers;
 
   /// {@macro guild_stickers_update_event}
+  /// @nodoc
   GuildStickersUpdateEvent({required super.gateway, required this.guildId, required this.stickers});
 
   /// The guild in which the stickers were updated.
@@ -200,6 +209,7 @@ class GuildIntegrationsUpdateEvent extends DispatchEvent {
   final Snowflake guildId;
 
   /// {@macro guild_integrations_update_event}
+  /// @nodoc
   GuildIntegrationsUpdateEvent({required super.gateway, required this.guildId});
 
   /// The guild in which the integrations were updated.
@@ -217,6 +227,7 @@ class GuildMemberAddEvent extends DispatchEvent {
   final Member member;
 
   /// {@macro guild_member_add_event}
+  /// @nodoc
   GuildMemberAddEvent({required super.gateway, required this.guildId, required this.member});
 
   /// The guild in which the member was added.
@@ -234,6 +245,7 @@ class GuildMemberRemoveEvent extends DispatchEvent {
   final User user;
 
   /// {@macro guild_member_remove_event}
+  /// @nodoc
   GuildMemberRemoveEvent({required super.gateway, required this.guildId, required this.user});
 
   /// The guild in which the member was removed.
@@ -254,6 +266,7 @@ class GuildMemberUpdateEvent extends DispatchEvent {
   final Snowflake guildId;
 
   /// {@macro guild_member_update_event}
+  /// @nodoc
   GuildMemberUpdateEvent({required super.gateway, required this.oldMember, required this.member, required this.guildId});
 
   /// The guild in which the member was updated.
@@ -286,6 +299,7 @@ class GuildMembersChunkEvent extends DispatchEvent {
   final String? nonce;
 
   /// {@macro guild_members_chunk_event}
+  /// @nodoc
   GuildMembersChunkEvent({
     required super.gateway,
     required this.guildId,
@@ -312,6 +326,7 @@ class GuildRoleCreateEvent extends DispatchEvent {
   final Role role;
 
   /// {@macro guild_role_create_event}
+  /// @nodoc
   GuildRoleCreateEvent({required super.gateway, required this.guildId, required this.role});
 
   /// The guild in which the role was created.
@@ -332,6 +347,7 @@ class GuildRoleUpdateEvent extends DispatchEvent {
   final Role role;
 
   /// {@macro guild_role_update_event}
+  /// @nodoc
   GuildRoleUpdateEvent({required super.gateway, required this.guildId, required this.oldRole, required this.role});
 
   /// The guild in which the role was updated.
@@ -349,6 +365,7 @@ class GuildRoleDeleteEvent extends DispatchEvent {
   final Snowflake roleId;
 
   /// {@macro guild_role_delete_event}
+  /// @nodoc
   GuildRoleDeleteEvent({required super.gateway, required this.roleId, required this.guildId});
 
   /// The guild in which the role was deleted.
@@ -363,6 +380,7 @@ class GuildScheduledEventCreateEvent extends DispatchEvent {
   final ScheduledEvent event;
 
   /// {@macro guild_scheduled_event_create_event}
+  /// @nodoc
   GuildScheduledEventCreateEvent({required super.gateway, required this.event});
 }
 
@@ -377,6 +395,7 @@ class GuildScheduledEventUpdateEvent extends DispatchEvent {
   final ScheduledEvent event;
 
   /// {@macro guild_scheduled_event_update_event}
+  /// @nodoc
   GuildScheduledEventUpdateEvent({required super.gateway, required this.oldEvent, required this.event});
 }
 
@@ -388,6 +407,7 @@ class GuildScheduledEventDeleteEvent extends DispatchEvent {
   final ScheduledEvent event;
 
   /// {@macro guild_scheduled_event_delete_event}
+  /// @nodoc
   GuildScheduledEventDeleteEvent({required super.gateway, required this.event});
 }
 
@@ -405,6 +425,7 @@ class GuildScheduledEventUserAddEvent extends DispatchEvent {
   final Snowflake guildId;
 
   /// {@macro guild_scheduled_event_user_add_event}
+  /// @nodoc
   GuildScheduledEventUserAddEvent({required super.gateway, required this.scheduledEventId, required this.userId, required this.guildId});
 
   /// The guild that the scheduled event is in.
@@ -434,6 +455,7 @@ class GuildScheduledEventUserRemoveEvent extends DispatchEvent {
   final Snowflake guildId;
 
   /// {@macro guild_scheduled_event_user_remove_event}
+  /// @nodoc
   GuildScheduledEventUserRemoveEvent({required super.gateway, required this.scheduledEventId, required this.userId, required this.guildId});
 
   /// The guild that the scheduled event is in.

--- a/lib/src/models/gateway/events/integration.dart
+++ b/lib/src/models/gateway/events/integration.dart
@@ -15,6 +15,7 @@ class IntegrationCreateEvent extends DispatchEvent {
   final Integration integration;
 
   /// {@macro integration_create_event}
+  /// @nodoc
   IntegrationCreateEvent({required super.gateway, required this.guildId, required this.integration});
 
   /// The guild the integration was created in.
@@ -35,6 +36,7 @@ class IntegrationUpdateEvent extends DispatchEvent {
   final Integration integration;
 
   /// {@macro integration_update_event}
+  /// @nodoc
   IntegrationUpdateEvent({required super.gateway, required this.guildId, required this.oldIntegration, required this.integration});
 
   /// The guild the integration was updated in.
@@ -55,6 +57,7 @@ class IntegrationDeleteEvent extends DispatchEvent {
   final Snowflake? applicationId;
 
   /// {@macro integration_delete_event}
+  /// @nodoc
   IntegrationDeleteEvent({required super.gateway, required this.id, required this.guildId, required this.applicationId});
 
   /// The guild the integration was deleted from.

--- a/lib/src/models/gateway/events/interaction.dart
+++ b/lib/src/models/gateway/events/interaction.dart
@@ -9,5 +9,6 @@ class InteractionCreateEvent<T extends Interaction<dynamic>> extends DispatchEve
   final T interaction;
 
   /// {@macro interaction_create_event}
+  /// @nodoc
   InteractionCreateEvent({required super.gateway, required this.interaction});
 }

--- a/lib/src/models/gateway/events/invite.dart
+++ b/lib/src/models/gateway/events/invite.dart
@@ -12,6 +12,7 @@ class InviteCreateEvent extends DispatchEvent {
   final InviteWithMetadata invite;
 
   /// {@macro invite_create_event}
+  /// @nodoc
   InviteCreateEvent({required super.gateway, required this.invite});
 }
 
@@ -29,6 +30,7 @@ class InviteDeleteEvent extends DispatchEvent {
   final String code;
 
   /// {@macro invite_delete_event}
+  /// @nodoc
   InviteDeleteEvent({required super.gateway, required this.channelId, required this.guildId, required this.code});
 
   /// The channel the invite was for.

--- a/lib/src/models/gateway/events/message.dart
+++ b/lib/src/models/gateway/events/message.dart
@@ -24,6 +24,7 @@ class MessageCreateEvent extends DispatchEvent {
   final Message message;
 
   /// {@macro message_create_event}
+  /// @nodoc
   MessageCreateEvent({required super.gateway, required this.guildId, required this.member, required this.mentions, required this.message});
 
   /// The guild the message was sent in.
@@ -50,6 +51,7 @@ class MessageUpdateEvent extends DispatchEvent {
   final Message? oldMessage;
 
   /// {@macro message_update_event}
+  /// @nodoc
   MessageUpdateEvent({
     required super.gateway,
     required this.guildId,
@@ -77,6 +79,7 @@ class MessageDeleteEvent extends DispatchEvent {
   final Snowflake? guildId;
 
   /// {@macro message_delete_event}
+  /// @nodoc
   MessageDeleteEvent({required super.gateway, required this.id, required this.channelId, required this.guildId});
 
   /// The guild the message was deleted in.
@@ -100,6 +103,7 @@ class MessageBulkDeleteEvent extends DispatchEvent {
   final Snowflake? guildId;
 
   /// {@macro message_bulk_delete_event}
+  /// @nodoc
   MessageBulkDeleteEvent({required super.gateway, required this.ids, required this.channelId, required this.guildId});
 
   /// The guild the messages were deleted in.
@@ -135,6 +139,7 @@ class MessageReactionAddEvent extends DispatchEvent {
   final Snowflake? messageAuthorId;
 
   /// {@macro message_reaction_add_event}
+  /// @nodoc
   MessageReactionAddEvent({
     required super.gateway,
     required this.userId,
@@ -182,6 +187,7 @@ class MessageReactionRemoveEvent extends DispatchEvent {
   final Emoji emoji;
 
   /// {@macro message_reaction_remove_event}
+  /// @nodoc
   MessageReactionRemoveEvent({
     required super.gateway,
     required this.userId,
@@ -218,6 +224,7 @@ class MessageReactionRemoveAllEvent extends DispatchEvent {
   final Snowflake? guildId;
 
   /// {@macro message_reaction_remove_all_event}
+  /// @nodoc
   MessageReactionRemoveAllEvent({
     required super.gateway,
     required this.channelId,
@@ -251,6 +258,7 @@ class MessageReactionRemoveEmojiEvent extends DispatchEvent {
   final PartialEmoji emoji;
 
   /// {@macro message_reaction_remove_emoji_event}
+  /// @nodoc
   MessageReactionRemoveEmojiEvent({
     required super.gateway,
     required this.channelId,

--- a/lib/src/models/gateway/events/presence.dart
+++ b/lib/src/models/gateway/events/presence.dart
@@ -26,6 +26,7 @@ class PresenceUpdateEvent extends DispatchEvent {
   final ClientStatus? clientStatus;
 
   /// {@macro presence_update_event}
+  /// @nodoc
   PresenceUpdateEvent({
     required super.gateway,
     required this.user,
@@ -59,6 +60,7 @@ class TypingStartEvent extends DispatchEvent {
   final Member? member;
 
   /// {@macro typing_start_event}
+  /// @nodoc
   TypingStartEvent({
     required super.gateway,
     required this.channelId,
@@ -89,5 +91,6 @@ class UserUpdateEvent extends DispatchEvent {
   final User user;
 
   /// {@macro user_update_event}
+  /// @nodoc
   UserUpdateEvent({required super.gateway, required this.oldUser, required this.user});
 }

--- a/lib/src/models/gateway/events/ready.dart
+++ b/lib/src/models/gateway/events/ready.dart
@@ -32,6 +32,7 @@ class ReadyEvent extends DispatchEvent {
   final PartialApplication application;
 
   /// {@macro ready_event}
+  /// @nodoc
   ReadyEvent({
     required super.gateway,
     required this.version,
@@ -50,5 +51,6 @@ class ReadyEvent extends DispatchEvent {
 /// {@endtemplate}
 class ResumedEvent extends DispatchEvent {
   /// {@macro resumed_event}
+  /// @nodoc
   ResumedEvent({required super.gateway});
 }

--- a/lib/src/models/gateway/events/stage_instance.dart
+++ b/lib/src/models/gateway/events/stage_instance.dart
@@ -9,6 +9,7 @@ class StageInstanceCreateEvent extends DispatchEvent {
   final StageInstance instance;
 
   /// {@macro stage_instance_create_event}
+  /// @nodoc
   StageInstanceCreateEvent({required super.gateway, required this.instance});
 }
 
@@ -23,6 +24,7 @@ class StageInstanceUpdateEvent extends DispatchEvent {
   final StageInstance instance;
 
   /// {@macro stage_instance_update_event}
+  /// @nodoc
   StageInstanceUpdateEvent({required super.gateway, required this.oldInstance, required this.instance});
 }
 
@@ -34,5 +36,6 @@ class StageInstanceDeleteEvent extends DispatchEvent {
   final StageInstance instance;
 
   /// {@macro stage_instance_delete_event}
+  /// @nodoc
   StageInstanceDeleteEvent({required super.gateway, required this.instance});
 }

--- a/lib/src/models/gateway/events/voice.dart
+++ b/lib/src/models/gateway/events/voice.dart
@@ -14,6 +14,7 @@ class VoiceStateUpdateEvent extends DispatchEvent {
   final VoiceState? oldState;
 
   /// {@macro voice_state_update_event}
+  /// @nodoc
   VoiceStateUpdateEvent({required super.gateway, required this.oldState, required this.state});
 }
 
@@ -31,6 +32,7 @@ class VoiceServerUpdateEvent extends DispatchEvent {
   final String? endpoint;
 
   /// {@macro voice_server_update_event}
+  /// @nodoc
   VoiceServerUpdateEvent({required super.gateway, required this.token, required this.guildId, required this.endpoint});
 
   /// The guild.

--- a/lib/src/models/gateway/events/webhook.dart
+++ b/lib/src/models/gateway/events/webhook.dart
@@ -14,6 +14,7 @@ class WebhooksUpdateEvent extends DispatchEvent {
   final Snowflake channelId;
 
   /// {@macro webhooks_update_event}
+  /// @nodoc
   WebhooksUpdateEvent({required super.gateway, required this.guildId, required this.channelId});
 
   /// The guild the webhook was updated in.

--- a/lib/src/models/gateway/gateway.dart
+++ b/lib/src/models/gateway/gateway.dart
@@ -8,6 +8,7 @@ class GatewayConfiguration with ToStringHelper {
   final Uri url;
 
   /// {@macro gateway_configuration}
+  /// @nodoc
   GatewayConfiguration({required this.url});
 }
 
@@ -22,6 +23,7 @@ class GatewayBot extends GatewayConfiguration {
   final SessionStartLimit sessionStartLimit;
 
   /// {@macro gateway_bot}
+  /// @nodoc
   GatewayBot({
     required super.url,
     required this.shards,
@@ -46,6 +48,7 @@ class SessionStartLimit with ToStringHelper {
   final int maxConcurrency;
 
   /// {@macro session_start_limit}
+  /// @nodoc
   SessionStartLimit({
     required this.total,
     required this.remaining,

--- a/lib/src/models/guild/audit_log.dart
+++ b/lib/src/models/guild/audit_log.dart
@@ -15,6 +15,7 @@ class PartialAuditLogEntry extends ManagedSnowflakeEntity<AuditLogEntry> {
   final AuditLogManager manager;
 
   /// Create a new [PartialAuditLogEntry].
+  /// @nodoc
   PartialAuditLogEntry({required super.id, required this.manager});
 }
 
@@ -41,6 +42,7 @@ class AuditLogEntry extends PartialAuditLogEntry {
   final String? reason;
 
   /// {@macro audit_log_entry}
+  /// @nodoc
   AuditLogEntry({
     required super.id,
     required super.manager,
@@ -70,6 +72,7 @@ class AuditLogChange with ToStringHelper {
   final String key;
 
   /// {@macro audit_log_change}
+  /// @nodoc
   AuditLogChange({
     required this.oldValue,
     required this.newValue,
@@ -197,6 +200,7 @@ class AuditLogEntryInfo with ToStringHelper {
   final String? integrationType;
 
   /// {@macro audit_log_entry_info}
+  /// @nodoc
   AuditLogEntryInfo({
     required this.manager,
     required this.applicationId,

--- a/lib/src/models/guild/auto_moderation.dart
+++ b/lib/src/models/guild/auto_moderation.dart
@@ -15,6 +15,7 @@ class PartialAutoModerationRule extends WritableSnowflakeEntity<AutoModerationRu
   final AutoModerationManager manager;
 
   /// Create a new [PartialAutoModerationRule].
+  /// @nodoc
   PartialAutoModerationRule({required super.id, required this.manager});
 }
 
@@ -53,6 +54,7 @@ class AutoModerationRule extends PartialAutoModerationRule {
   final List<Snowflake> exemptChannelIds;
 
   /// {@macro auto_moderation_rule}
+  /// @nodoc
   AutoModerationRule({
     required super.id,
     required super.manager,
@@ -148,6 +150,7 @@ class TriggerMetadata with ToStringHelper {
   final bool? isMentionRaidProtectionEnabled;
 
   /// {@macro trigger_metadata}
+  /// @nodoc
   TriggerMetadata({
     required this.keywordFilter,
     required this.regexPatterns,
@@ -192,6 +195,7 @@ class AutoModerationAction with ToStringHelper {
   final ActionMetadata? metadata;
 
   /// {@macro auto_moderation_action}
+  /// @nodoc
   AutoModerationAction({
     required this.type,
     required this.metadata,
@@ -237,6 +241,7 @@ class ActionMetadata with ToStringHelper {
   final String? customMessage;
 
   /// {@macro action_metadata}
+  /// @nodoc
   ActionMetadata({
     required this.manager,
     required this.channelId,

--- a/lib/src/models/guild/ban.dart
+++ b/lib/src/models/guild/ban.dart
@@ -12,5 +12,6 @@ class Ban with ToStringHelper {
   final User user;
 
   /// {@macro ban}
+  /// @nodoc
   Ban({required this.reason, required this.user});
 }

--- a/lib/src/models/guild/guild.dart
+++ b/lib/src/models/guild/guild.dart
@@ -86,6 +86,7 @@ class PartialGuild extends WritableSnowflakeEntity<Guild> {
       );
 
   /// Create a new [PartialGuild].
+  /// @nodoc
   PartialGuild({required super.id, required this.manager});
 
   @override
@@ -338,6 +339,7 @@ class Guild extends PartialGuild {
   final Snowflake? safetyAlertsChannelId;
 
   /// {@macro guild}
+  /// @nodoc
   Guild({
     required super.id,
     required super.manager,

--- a/lib/src/models/guild/guild_preview.dart
+++ b/lib/src/models/guild/guild_preview.dart
@@ -37,6 +37,7 @@ class GuildPreview extends PartialGuild {
   final List<GuildSticker> stickerList;
 
   /// {@macro guild_preview}
+  /// @nodoc
   GuildPreview({
     required super.id,
     required super.manager,

--- a/lib/src/models/guild/guild_widget.dart
+++ b/lib/src/models/guild/guild_widget.dart
@@ -31,6 +31,7 @@ class GuildWidget with ToStringHelper {
   final int presenceCount;
 
   /// {@macro guild_widget}
+  /// @nodoc
   GuildWidget({
     required this.manager,
     required this.guildId,
@@ -59,6 +60,7 @@ class WidgetSettings with ToStringHelper {
   final Snowflake? channelId;
 
   /// {@macro widget_settings}
+  /// @nodoc
   WidgetSettings({
     required this.manager,
     required this.isEnabled,

--- a/lib/src/models/guild/integration.dart
+++ b/lib/src/models/guild/integration.dart
@@ -11,6 +11,7 @@ class PartialIntegration extends ManagedSnowflakeEntity<Integration> {
   final IntegrationManager manager;
 
   /// Create a new [PartialIntegration].
+  /// @nodoc
   PartialIntegration({required super.id, required this.manager});
 
   /// Delete this integration.
@@ -67,6 +68,7 @@ class Integration extends PartialIntegration {
   final List<String>? scopes;
 
   /// {@macro integration}
+  /// @nodoc
   Integration({
     required super.id,
     required super.manager,
@@ -124,6 +126,7 @@ class IntegrationAccount with ToStringHelper {
   final String name;
 
   /// {@macro integration_account}
+  /// @nodoc
   IntegrationAccount({required this.id, required this.name});
 }
 
@@ -147,6 +150,7 @@ class IntegrationApplication with ToStringHelper {
   final User? bot;
 
   /// {@macro integration_application}
+  /// @nodoc
   IntegrationApplication({
     required this.id,
     required this.name,

--- a/lib/src/models/guild/member.dart
+++ b/lib/src/models/guild/member.dart
@@ -14,6 +14,7 @@ class PartialMember extends WritableSnowflakeEntity<Member> {
   final MemberManager manager;
 
   /// Create a new [PartialMember].
+  /// @nodoc
   PartialMember({required super.id, required this.manager});
 
   /// Add a role to this member.
@@ -70,6 +71,7 @@ class Member extends PartialMember {
   final DateTime? communicationDisabledUntil;
 
   /// {@macro member}
+  /// @nodoc
   Member({
     required super.id,
     required super.manager,

--- a/lib/src/models/guild/onboarding.dart
+++ b/lib/src/models/guild/onboarding.dart
@@ -25,6 +25,7 @@ class Onboarding with ToStringHelper {
   final bool isEnabled;
 
   /// {@macro onboarding}
+  /// @nodoc
   Onboarding({
     required this.manager,
     required this.guildId,
@@ -68,6 +69,7 @@ class OnboardingPrompt with ToStringHelper {
   final bool isInOnboarding;
 
   /// {@macro onboarding_prompt}
+  /// @nodoc
   OnboardingPrompt({
     required this.id,
     required this.type,
@@ -127,6 +129,7 @@ class OnboardingPromptOption with ToStringHelper {
   final String? description;
 
   /// {@macro onboarding_prompt_option}
+  /// @nodoc
   OnboardingPromptOption({
     required this.manager,
     required this.id,

--- a/lib/src/models/guild/scheduled_event.dart
+++ b/lib/src/models/guild/scheduled_event.dart
@@ -16,6 +16,7 @@ class PartialScheduledEvent extends WritableSnowflakeEntity<ScheduledEvent> {
   final ScheduledEventManager manager;
 
   /// Create a new [PartialScheduledEvent].
+  /// @nodoc
   PartialScheduledEvent({required super.id, required this.manager});
 
   /// List the users that have followed this event.
@@ -75,6 +76,7 @@ class ScheduledEvent extends PartialScheduledEvent {
   final String? coverImageHash;
 
   /// {@macro scheduled_event}
+  /// @nodoc
   ScheduledEvent({
     required super.id,
     required super.manager,
@@ -169,6 +171,7 @@ class EntityMetadata with ToStringHelper {
   final String? location;
 
   /// {@macro entity_metadata}
+  /// @nodoc
   EntityMetadata({required this.location});
 }
 
@@ -188,6 +191,7 @@ class ScheduledEventUser with ToStringHelper {
   final Member? member;
 
   /// {@macro scheduled_event_user}
+  /// @nodoc
   ScheduledEventUser({
     required this.manager,
     required this.scheduledEventId,

--- a/lib/src/models/guild/template.dart
+++ b/lib/src/models/guild/template.dart
@@ -47,6 +47,7 @@ class GuildTemplate with ToStringHelper {
   final bool? isDirty;
 
   /// {@macro guild_template}
+  /// @nodoc
   GuildTemplate({
     required this.code,
     required this.manager,

--- a/lib/src/models/guild/welcome_screen.dart
+++ b/lib/src/models/guild/welcome_screen.dart
@@ -14,6 +14,7 @@ class WelcomeScreen with ToStringHelper {
   final List<WelcomeScreenChannel> channels;
 
   /// {@macro welcome_screen}
+  /// @nodoc
   WelcomeScreen({required this.description, required this.channels});
 }
 
@@ -37,6 +38,7 @@ class WelcomeScreenChannel with ToStringHelper {
   final String? emojiName;
 
   /// {@macro welcome_screen_channel}
+  /// @nodoc
   WelcomeScreenChannel({
     required this.manager,
     required this.channelId,

--- a/lib/src/models/interaction.dart
+++ b/lib/src/models/interaction.dart
@@ -77,6 +77,7 @@ abstract class Interaction<T> with ToStringHelper {
   final List<Entitlement> entitlements;
 
   /// {@macro interaction}
+  /// @nodoc
   Interaction({
     required this.manager,
     required this.id,
@@ -181,6 +182,7 @@ mixin ModalResponse<T> on Interaction<T> {
 /// {@endtemplate}
 class PingInteraction extends Interaction<void> {
   /// {@macro ping_interaction}
+  /// @nodoc
   PingInteraction({
     required super.manager,
     required super.id,
@@ -210,6 +212,7 @@ class PingInteraction extends Interaction<void> {
 class ApplicationCommandInteraction extends Interaction<ApplicationCommandInteractionData>
     with MessageResponse<ApplicationCommandInteractionData>, ModalResponse<ApplicationCommandInteractionData> {
   /// {@macro application_command_interaction}
+  /// @nodoc
   ApplicationCommandInteraction({
     required super.manager,
     required super.id,
@@ -237,6 +240,7 @@ class ApplicationCommandInteraction extends Interaction<ApplicationCommandIntera
 class MessageComponentInteraction extends Interaction<MessageComponentInteractionData>
     with MessageResponse<MessageComponentInteractionData>, ModalResponse<MessageComponentInteractionData> {
   /// {@macro message_component_interaction}
+  /// @nodoc
   MessageComponentInteraction({
     required super.manager,
     required super.id,
@@ -319,6 +323,7 @@ class MessageComponentInteraction extends Interaction<MessageComponentInteractio
 /// {@endtemplate}
 class ModalSubmitInteraction extends Interaction<ModalSubmitInteractionData> with MessageResponse<ModalSubmitInteractionData> {
   /// {@macro modal_submit_interaction}
+  /// @nodoc
   ModalSubmitInteraction({
     required super.manager,
     required super.id,
@@ -345,6 +350,7 @@ class ModalSubmitInteraction extends Interaction<ModalSubmitInteractionData> wit
 /// {@endtemplate}
 class ApplicationCommandAutocompleteInteraction extends Interaction<ApplicationCommandInteractionData> {
   /// {@macro application_command_autocomplete_interaction}
+  /// @nodoc
   ApplicationCommandAutocompleteInteraction({
     required super.manager,
     required super.id,
@@ -421,6 +427,7 @@ class ApplicationCommandInteractionData with ToStringHelper {
   final Snowflake? targetId;
 
   /// {@macro application_command_interaction_data}
+  /// @nodoc
   ApplicationCommandInteractionData({
     required this.id,
     required this.name,
@@ -455,6 +462,7 @@ class ResolvedData with ToStringHelper {
   final Map<Snowflake, Attachment>? attachments;
 
   /// {@macro resolved_data}
+  /// @nodoc
   ResolvedData({
     required this.users,
     required this.members,
@@ -485,6 +493,7 @@ class InteractionOption with ToStringHelper {
   final bool? isFocused;
 
   /// {@macro interaction_option}
+  /// @nodoc
   InteractionOption({
     required this.name,
     required this.type,
@@ -511,6 +520,7 @@ class MessageComponentInteractionData with ToStringHelper {
   final ResolvedData? resolved;
 
   /// {@macro message_component_interaction_data}
+  /// @nodoc
   MessageComponentInteractionData({required this.customId, required this.type, required this.values, required this.resolved});
 }
 
@@ -525,5 +535,6 @@ class ModalSubmitInteractionData with ToStringHelper {
   final List<MessageComponent> components;
 
   /// {@macro modal_submit_interaction_data}
+  /// @nodoc
   ModalSubmitInteractionData({required this.customId, required this.components});
 }

--- a/lib/src/models/invite/invite.dart
+++ b/lib/src/models/invite/invite.dart
@@ -52,6 +52,7 @@ class Invite with ToStringHelper {
   final ScheduledEvent? guildScheduledEvent;
 
   /// {@macro invite}
+  /// @nodoc
   Invite({
     required this.code,
     required this.guild,

--- a/lib/src/models/invite/invite_metadata.dart
+++ b/lib/src/models/invite/invite_metadata.dart
@@ -16,6 +16,7 @@ class InviteWithMetadata extends Invite {
   /// When this invite was created.
   final DateTime createdAt;
 
+  /// @nodoc
   InviteWithMetadata({
     required super.code,
     required super.guild,

--- a/lib/src/models/message/activity.dart
+++ b/lib/src/models/message/activity.dart
@@ -14,6 +14,7 @@ class MessageActivity with ToStringHelper {
   final String? partyId;
 
   /// {@macro message_activity}
+  /// @nodoc
   MessageActivity({
     required this.type,
     required this.partyId,

--- a/lib/src/models/message/attachment.dart
+++ b/lib/src/models/message/attachment.dart
@@ -77,6 +77,7 @@ class Attachment with ToStringHelper implements CdnAsset {
   bool get isAnimated => false;
 
   /// {@macro attachment}
+  /// @nodoc
   Attachment({
     required this.id,
     required this.manager,

--- a/lib/src/models/message/channel_mention.dart
+++ b/lib/src/models/message/channel_mention.dart
@@ -19,6 +19,7 @@ class ChannelMention extends PartialChannel {
   final String name;
 
   /// {@macro channel_mention}
+  /// @nodoc
   ChannelMention({
     required super.id,
     required super.manager,

--- a/lib/src/models/message/component.dart
+++ b/lib/src/models/message/component.dart
@@ -46,6 +46,7 @@ class ActionRowComponent extends MessageComponent {
   final List<MessageComponent> components;
 
   /// Create a new [ActionRowComponent].
+  /// @nodoc
   ActionRowComponent({required this.components});
 }
 
@@ -73,6 +74,7 @@ class ButtonComponent extends MessageComponent {
   final bool? isDisabled;
 
   /// Create a new [ButtonComponent].
+  /// @nodoc
   ButtonComponent({
     required this.style,
     required this.label,
@@ -142,6 +144,7 @@ class SelectMenuComponent extends MessageComponent {
   final bool? isDisabled;
 
   /// Create a new [SelectMenuComponent].
+  /// @nodoc
   SelectMenuComponent({
     required this.type,
     required this.customId,
@@ -184,6 +187,7 @@ class SelectMenuDefaultValue {
   final SelectMenuDefaultValueType type;
 
   /// Create a new [SelectMenuDefaultValue].
+  /// @nodoc
   SelectMenuDefaultValue({required this.id, required this.type});
 }
 
@@ -205,6 +209,7 @@ class SelectMenuOption with ToStringHelper {
   final bool? isDefault;
 
   /// Create a new [SelectMenuOption].
+  /// @nodoc
   SelectMenuOption({
     required this.label,
     required this.value,
@@ -244,6 +249,7 @@ class TextInputComponent extends MessageComponent {
   final String? placeholder;
 
   /// Create a new [TextInputComponent].
+  /// @nodoc
   TextInputComponent({
     required this.customId,
     required this.style,

--- a/lib/src/models/message/embed.dart
+++ b/lib/src/models/message/embed.dart
@@ -45,6 +45,7 @@ class Embed {
   final List<EmbedField>? fields;
 
   /// {@macro embed}
+  /// @nodoc
   Embed({
     required this.title,
     required this.description,
@@ -78,6 +79,7 @@ class EmbedFooter with ToStringHelper {
   final Uri? proxiedIconUrl;
 
   /// {@macro embed_footer}
+  /// @nodoc
   EmbedFooter({
     required this.text,
     required this.iconUrl,
@@ -105,6 +107,7 @@ class EmbedImage with ToStringHelper {
   final int? width;
 
   /// {@macro embed_image}
+  /// @nodoc
   EmbedImage({
     required this.url,
     required this.proxiedUrl,
@@ -133,6 +136,7 @@ class EmbedThumbnail with ToStringHelper {
   final int? width;
 
   /// {@macro embed_thumbnail}
+  /// @nodoc
   EmbedThumbnail({
     required this.url,
     required this.proxiedUrl,
@@ -161,6 +165,7 @@ class EmbedVideo with ToStringHelper {
   final int? width;
 
   /// {@macro embed_video}
+  /// @nodoc
   EmbedVideo({
     required this.url,
     required this.proxiedUrl,
@@ -183,6 +188,7 @@ class EmbedProvider with ToStringHelper {
   final Uri? url;
 
   /// {@macro embed_provider}
+  /// @nodoc
   EmbedProvider({
     required this.name,
     required this.url,
@@ -209,6 +215,7 @@ class EmbedAuthor with ToStringHelper {
   final Uri? proxyIconUrl;
 
   /// {@macro embed_author}
+  /// @nodoc
   EmbedAuthor({
     required this.name,
     required this.url,
@@ -234,6 +241,7 @@ class EmbedField with ToStringHelper {
   final bool inline;
 
   /// {@macro embed_field}
+  /// @nodoc
   EmbedField({
     required this.name,
     required this.value,

--- a/lib/src/models/message/message.dart
+++ b/lib/src/models/message/message.dart
@@ -34,6 +34,7 @@ class PartialMessage extends WritableSnowflakeEntity<Message> {
   Snowflake get channelId => manager.channelId;
 
   /// {@macro partial_message}
+  /// @nodoc
   PartialMessage({required super.id, required this.manager});
 
   /// The channel this message was sent in.
@@ -186,6 +187,7 @@ class Message extends PartialMessage {
   final ResolvedData? resolved;
 
   /// {@macro message}
+  /// @nodoc
   Message({
     required super.id,
     required super.manager,
@@ -379,6 +381,7 @@ class MessageInteraction with ToStringHelper {
   final PartialMember? member;
 
   /// {@macro message_interaction}
+  /// @nodoc
   MessageInteraction({
     required this.id,
     required this.type,

--- a/lib/src/models/message/reaction.dart
+++ b/lib/src/models/message/reaction.dart
@@ -28,6 +28,7 @@ class Reaction with ToStringHelper {
   final List<DiscordColor> burstColors;
 
   /// {@macro reaction}
+  /// @nodoc
   Reaction({
     required this.count,
     required this.countDetails,
@@ -49,5 +50,6 @@ class ReactionCountDetails with ToStringHelper {
   final int normal;
 
   /// {@macro reaction_count_details}
+  /// @nodoc
   ReactionCountDetails({required this.burst, required this.normal});
 }

--- a/lib/src/models/message/reference.dart
+++ b/lib/src/models/message/reference.dart
@@ -58,6 +58,7 @@ class MessageReference with ToStringHelper {
   final Snowflake? guildId;
 
   /// {@macro message_reference}
+  /// @nodoc
   MessageReference({
     required this.manager,
     required this.messageId,

--- a/lib/src/models/message/role_subscription_data.dart
+++ b/lib/src/models/message/role_subscription_data.dart
@@ -20,6 +20,7 @@ class RoleSubscriptionData {
   final bool isRenewal;
 
   /// {@macro role_subscription_data}
+  /// @nodoc
   RoleSubscriptionData({
     required this.listingId,
     required this.tierName,

--- a/lib/src/models/permission_overwrite.dart
+++ b/lib/src/models/permission_overwrite.dart
@@ -32,6 +32,7 @@ class PermissionOverwrite with ToStringHelper {
   final Permissions deny;
 
   /// {@macro permission_overwrite}
+  /// @nodoc
   PermissionOverwrite({
     required this.id,
     required this.type,

--- a/lib/src/models/presence.dart
+++ b/lib/src/models/presence.dart
@@ -17,6 +17,7 @@ class ClientStatus with ToStringHelper {
   final UserStatus? web;
 
   /// {@macro client_status}
+  /// @nodoc
   ClientStatus({required this.desktop, required this.mobile, required this.web});
 }
 
@@ -94,6 +95,7 @@ class Activity with ToStringHelper {
   final List<ActivityButton>? buttons;
 
   /// {@macro activity}
+  /// @nodoc
   Activity({
     required this.name,
     required this.type,
@@ -150,6 +152,7 @@ class ActivityTimestamps with ToStringHelper {
   final DateTime? end;
 
   /// {@macro activity_timestamps}
+  /// @nodoc
   ActivityTimestamps({required this.start, required this.end});
 }
 
@@ -167,6 +170,7 @@ class ActivityParty with ToStringHelper {
   final int? maxSize;
 
   /// {@macro activity_party}
+  /// @nodoc
   ActivityParty({required this.id, required this.currentSize, required this.maxSize});
 }
 
@@ -189,6 +193,7 @@ class ActivityAssets with ToStringHelper {
   final String? smallText;
 
   /// {@macro activity_assets}
+  /// @nodoc
   ActivityAssets({
     required this.largeImage,
     required this.largeText,
@@ -211,6 +216,7 @@ class ActivitySecrets with ToStringHelper {
   final String? match;
 
   /// {@macro activity_secrets}
+  /// @nodoc
   ActivitySecrets({required this.join, required this.spectate, required this.match});
 }
 
@@ -275,5 +281,6 @@ class ActivityButton with ToStringHelper {
   final Uri url;
 
   /// {@macro activity_button}
+  /// @nodoc
   ActivityButton({required this.label, required this.url});
 }

--- a/lib/src/models/role.dart
+++ b/lib/src/models/role.dart
@@ -15,6 +15,7 @@ class PartialRole extends WritableSnowflakeEntity<Role> {
   final RoleManager manager;
 
   /// Create a new [PartialRole].
+  /// @nodoc
   PartialRole({required super.id, required this.manager});
 }
 
@@ -58,6 +59,7 @@ class Role extends PartialRole implements CommandOptionMentionable<Role> {
   final RoleFlags flags;
 
   /// {@macro role}
+  /// @nodoc
   Role({
     required super.id,
     required super.manager,
@@ -97,6 +99,7 @@ class RoleTags with ToStringHelper {
   final Snowflake? subscriptionListingId;
 
   /// {@macro role_tags}
+  /// @nodoc
   RoleTags({
     required this.botId,
     required this.integrationId,

--- a/lib/src/models/sku.dart
+++ b/lib/src/models/sku.dart
@@ -30,6 +30,7 @@ class Sku with ToStringHelper {
   final SkuFlags flags;
 
   /// {@macro sku}
+  /// @nodoc
   Sku({
     required this.manager,
     required this.id,

--- a/lib/src/models/snowflake_entity/snowflake_entity.dart
+++ b/lib/src/models/snowflake_entity/snowflake_entity.dart
@@ -11,6 +11,7 @@ abstract class SnowflakeEntity<T extends SnowflakeEntity<T>> with ToStringHelper
   final Snowflake id;
 
   /// Create a new [SnowflakeEntity].
+  /// @nodoc
   SnowflakeEntity({required this.id});
 
   /// If this entity exists in the manager's cache, return the cached instance. Otherwise, [fetch]
@@ -36,6 +37,7 @@ abstract class ManagedSnowflakeEntity<T extends ManagedSnowflakeEntity<T>> exten
   ReadOnlyManager<T> get manager;
 
   /// Create a new [ManagedSnowflakeEntity];
+  /// @nodoc
   ManagedSnowflakeEntity({required super.id});
 
   @override
@@ -51,6 +53,7 @@ abstract class WritableSnowflakeEntity<T extends WritableSnowflakeEntity<T>> ext
   Manager<T> get manager;
 
   /// Create a new [WritableSnowflakeEntity].
+  /// @nodoc
   WritableSnowflakeEntity({required super.id});
 
   /// Update this entity using the provided builder and return the updated entity.

--- a/lib/src/models/sticker/global_sticker.dart
+++ b/lib/src/models/sticker/global_sticker.dart
@@ -8,6 +8,7 @@ class PartialGlobalSticker extends ManagedSnowflakeEntity<GlobalSticker> {
   @override
   final GlobalStickerManager manager;
 
+  /// @nodoc
   PartialGlobalSticker({required super.id, required this.manager});
 }
 
@@ -51,6 +52,7 @@ class GlobalSticker extends PartialGlobalSticker with Sticker {
   final Snowflake packId;
 
   /// {@macro global_sticker}
+  /// @nodoc
   GlobalSticker({
     required super.id,
     required super.manager,

--- a/lib/src/models/sticker/guild_sticker.dart
+++ b/lib/src/models/sticker/guild_sticker.dart
@@ -8,6 +8,7 @@ class PartialGuildSticker extends WritableSnowflakeEntity<GuildSticker> {
   @override
   final GuildStickerManager manager;
 
+  /// @nodoc
   PartialGuildSticker({required super.id, required this.manager});
 }
 
@@ -51,6 +52,7 @@ class GuildSticker extends PartialGuildSticker with Sticker {
   final int? sortValue;
 
   /// {@macro guild_sticker}
+  /// @nodoc
   GuildSticker({
     required super.id,
     required super.manager,

--- a/lib/src/models/sticker/sticker.dart
+++ b/lib/src/models/sticker/sticker.dart
@@ -86,6 +86,7 @@ class StickerItem extends SnowflakeEntity<StickerItem> {
   final StickerFormatType formatType;
 
   /// {@macro sticker_item}
+  /// @nodoc
   StickerItem({required super.id, required this.name, required this.formatType});
 
   @override

--- a/lib/src/models/team.dart
+++ b/lib/src/models/team.dart
@@ -31,6 +31,7 @@ class Team with ToStringHelper {
   final Snowflake ownerId;
 
   /// {@macro team}
+  /// @nodoc
   Team({
     required this.manager,
     required this.iconHash,
@@ -70,6 +71,7 @@ class TeamMember with ToStringHelper {
   final TeamMemberRole role;
 
   /// {@macro team_member}
+  /// @nodoc
   TeamMember({
     required this.membershipState,
     required this.teamId,

--- a/lib/src/models/user/application_role_connection.dart
+++ b/lib/src/models/user/application_role_connection.dart
@@ -17,6 +17,7 @@ class ApplicationRoleConnection with ToStringHelper {
   final Map<String, String> metadata;
 
   /// {@macro application_role_connection}
+  /// @nodoc
   ApplicationRoleConnection({
     required this.platformName,
     required this.platformUsername,

--- a/lib/src/models/user/connection.dart
+++ b/lib/src/models/user/connection.dart
@@ -37,6 +37,7 @@ class Connection with ToStringHelper {
   final ConnectionVisibility visibility;
 
   /// Create a new [Connection].
+  /// @nodoc
   Connection({
     required this.id,
     required this.name,

--- a/lib/src/models/user/user.dart
+++ b/lib/src/models/user/user.dart
@@ -14,6 +14,7 @@ class PartialUser extends ManagedSnowflakeEntity<User> {
   final UserManager manager;
 
   /// Create a new [PartialUser].
+  /// @nodoc
   PartialUser({required super.id, required this.manager});
 }
 
@@ -72,6 +73,7 @@ class User extends PartialUser implements MessageAuthor, CommandOptionMentionabl
   final String? avatarDecorationHash;
 
   /// {@macro user}
+  /// @nodoc
   User({
     required super.manager,
     required super.id,

--- a/lib/src/models/voice/voice_region.dart
+++ b/lib/src/models/voice/voice_region.dart
@@ -25,6 +25,7 @@ class VoiceRegion with ToStringHelper {
   final bool isCustom;
 
   /// {@macro voice_region}
+  /// @nodoc
   VoiceRegion({
     required this.id,
     required this.name,

--- a/lib/src/models/voice/voice_state.dart
+++ b/lib/src/models/voice/voice_state.dart
@@ -56,6 +56,7 @@ class VoiceState with ToStringHelper {
   final DateTime? requestedToSpeakAt;
 
   /// {@macro voice_state}
+  /// @nodoc
   VoiceState({
     required this.manager,
     required this.guildId,

--- a/lib/src/models/webhook.dart
+++ b/lib/src/models/webhook.dart
@@ -18,6 +18,7 @@ class PartialWebhook extends WritableSnowflakeEntity<Webhook> {
   final WebhookManager manager;
 
   /// Create a new [PartialWebhook].
+  /// @nodoc
   PartialWebhook({required super.id, required this.manager});
 
   /// Update this webhook, returning the updated webhook.
@@ -90,6 +91,7 @@ class WebhookAuthor extends PartialWebhook implements MessageAuthor {
   final String username;
 
   /// Create a new [WebhookAuthor].
+  /// @nodoc
   WebhookAuthor({required super.id, required super.manager, required this.avatarHash, required this.username});
 
   @override
@@ -142,6 +144,7 @@ class Webhook extends PartialWebhook {
   final Uri? url;
 
   /// {@macro webhook}
+  /// @nodoc
   Webhook({
     required super.id,
     required super.manager,

--- a/test/unit/models/snowflake_entity/snowflake_entity_test.dart
+++ b/test/unit/models/snowflake_entity/snowflake_entity_test.dart
@@ -6,10 +6,12 @@ class PartialMockSnowflakeEntity extends WritableSnowflakeEntity<MockSnowflakeEn
   @override
   final MockSnowflakeEntityManager manager = MockSnowflakeEntityManager();
 
+  /// @nodoc
   PartialMockSnowflakeEntity({required super.id});
 }
 
 class MockSnowflakeEntity extends PartialMockSnowflakeEntity {
+  /// @nodoc
   MockSnowflakeEntity({required super.id});
 }
 


### PR DESCRIPTION
# Description

Hides constructors for models in generated `dartdoc`s. These are not useful to end users and developers can use their IDE to view the constructor documentation (which is in most cases the same as the class documentation anyway).
