### PR TITLE
Fix parsing role flags in guild templates

### DIFF
--- a/lib/src/http/managers/guild_manager.dart
+++ b/lib/src/http/managers/guild_manager.dart
@@ -298,6 +298,7 @@ class GuildManager extends Manager<Guild> {
           for (final role in ((raw['serialized_source_guild'] as Map<String, Object?>)['roles'] as List).cast<Map<String, Object?>>())
             {
               'position': 0,
+              'flags': 0,
               ...role,
             },
         ],


### PR DESCRIPTION
# Description

Adds a mock `flags` field to roles in guild templates so they are not missing attributes when parsed as a full guild.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
