### PR TITLE
Fixed hoist attribute in RoleUpdateBuilder

### DIFF
--- a/lib/src/builders/role.dart
+++ b/lib/src/builders/role.dart
@@ -36,7 +36,7 @@ class RoleBuilder extends CreateBuilder<Role> {
         if (name != null) 'name': name,
         if (permissions != null) 'permissions': permissions!.value.toString(),
         if (color != null) 'color': color!.value,
-        if (isHoisted != null) 'hoisted': isHoisted,
+        if (isHoisted != null) 'hoist': isHoisted,
         if (icon != null) 'icon': icon!.buildDataString(),
         if (unicodeEmoji != null) 'unicode_emoji': unicodeEmoji,
         if (isMentionable != null) 'mentionable': isMentionable,


### PR DESCRIPTION
Fix `RoleUpdateBuilder` attribute name

Corrected the attribute name from `hoisted` to `hoist` in the `RoleUpdateBuilder`.

I've tested it and now it's working fine
