### PR TITLE
Add `enforceNonce` field to `MessageBuilder`

### DIFF
--- a/lib/src/builders/message/message.dart
+++ b/lib/src/builders/message/message.dart
@@ -32,6 +32,8 @@ class MessageBuilder extends CreateBuilder<Message> {
 
   bool? suppressNotifications;
 
+  bool? enforceNonce;
+
   MessageBuilder({
     this.content,
     this.nonce,
@@ -45,6 +47,7 @@ class MessageBuilder extends CreateBuilder<Message> {
     this.attachments,
     this.suppressEmbeds,
     this.suppressNotifications,
+    this.enforceNonce,
   });
 
   @override
@@ -65,6 +68,7 @@ class MessageBuilder extends CreateBuilder<Message> {
         if (suppressEmbeds != null || suppressNotifications != null)
           'flags':
               (suppressEmbeds == true ? MessageFlags.suppressEmbeds.value : 0) | (suppressNotifications == true ? MessageFlags.suppressNotifications.value : 0),
+        if (enforceNonce != null) 'enforce_nonce': enforceNonce,
       };
 }
 

--- a/lib/src/builders/message/message.dart
+++ b/lib/src/builders/message/message.dart
@@ -32,6 +32,8 @@ class MessageBuilder extends CreateBuilder<Message> {
 
   bool? suppressNotifications;
 
+  /// If true and nonce is present, it will be checked for uniqueness in the past few minutes. If another message was created by the same author with the same nonce,
+  /// that message will be returned and no new message will be created.
   bool? enforceNonce;
 
   MessageBuilder({


### PR DESCRIPTION
# Description

Implements https://github.com/discord/discord-api-docs/pull/6647

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (TODO, see https://github.com/discord/discord-api-docs/pull/6647#issuecomment-1934896444)
