### PR TITLE
Add missing bool fields to RoleTags

### DIFF
--- a/lib/src/http/managers/role_manager.dart
+++ b/lib/src/http/managers/role_manager.dart
@@ -46,7 +46,10 @@ class RoleManager extends Manager<Role> {
     return RoleTags(
       botId: maybeParse(raw['bot_id'], Snowflake.parse),
       integrationId: maybeParse(raw['integration_id'], Snowflake.parse),
+      isPremiumSubscriber: raw.containsKey('premium_subscriber'),
       subscriptionListingId: maybeParse(raw['subscription_listing_id'], Snowflake.parse),
+      isAvailableForPurchase: raw.containsKey('available_for_purchase'),
+      isLinkedRole: raw.containsKey('guild_connections'),
     );
   }
 

--- a/lib/src/models/role.dart
+++ b/lib/src/models/role.dart
@@ -112,15 +112,27 @@ class RoleTags with ToStringHelper {
   /// The ID of the integration this role belongs to.
   final Snowflake? integrationId;
 
+  /// Whether this is the guild's Booster role.
+  final bool isPremiumSubscriber;
+
   /// The ID of this role's subscription sku and listing.
   final Snowflake? subscriptionListingId;
+
+  /// Whether this role is available for purchase.
+  final bool isAvailableForPurchase;
+
+  /// Whether this role is a guild's linked role
+  final bool isLinkedRole;
 
   /// {@macro role_tags}
   /// @nodoc
   RoleTags({
     required this.botId,
     required this.integrationId,
+    required this.isPremiumSubscriber,
     required this.subscriptionListingId,
+    required this.isAvailableForPurchase,
+    required this.isLinkedRole,
   });
 }
 


### PR DESCRIPTION
# Description

Add missing fields from https://canary.discord.com/developers/docs/topics/permissions#role-object-role-tags-structure

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
