### PR TITLE
Correct the user agent used by default

### DIFF
--- a/lib/src/api_options.dart
+++ b/lib/src/api_options.dart
@@ -12,7 +12,7 @@ abstract class ApiOptions {
   static const nyxxRepositoryUrl = 'https://github.com/nyxx-discord/nyxx';
 
   /// The default value for the `User-Agent` header for bots made with nyxx.
-  static const defaultUserAgent = 'Nyxx ($nyxxRepositoryUrl, $nyxxVersion)';
+  static const defaultUserAgent = 'DiscordBot ($nyxxRepositoryUrl, $nyxxVersion)';
 
   /// The host at which the API can be found.
   ///


### PR DESCRIPTION
# Description

Nyxx's default user agent doesn't match Discord's documentation. This PR fixes that.

See https://discord.com/developers/docs/reference#user-agent. Other libraries (I checked discord.js, discord.py and JDA) all use the `DiscordBot` prefix, so this is likely a misinterpretation on our end.

Thanks to @MCausc78 for finding this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
