### PR TITLE
Fix OAuth2 requiring `identify` scope, and add ability to quickly list guilds with `Nyxx.connectRest`

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -300,6 +300,7 @@ export 'src/models/interaction.dart'
         PingInteraction;
 export 'src/models/entitlement.dart' show Entitlement, PartialEntitlement, EntitlementType;
 export 'src/models/sku.dart' show Sku, SkuType, SkuFlags;
+export 'src/models/oauth2.dart' show OAuth2Information;
 
 export 'src/utils/flags.dart' show Flag, Flags;
 export 'src/intents.dart' show GatewayIntents;

--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -176,7 +176,8 @@ export 'src/models/guild/guild.dart'
         MfaLevel,
         NsfwLevel,
         PremiumTier,
-        VerificationLevel;
+        VerificationLevel,
+        UserGuild;
 export 'src/models/guild/integration.dart' show PartialIntegration, Integration, IntegrationAccount, IntegrationApplication, IntegrationExpireBehavior;
 export 'src/models/guild/member.dart' show Member, MemberFlags, PartialMember;
 export 'src/models/guild/onboarding.dart' show Onboarding, OnboardingPrompt, OnboardingPromptOption, OnboardingPromptType;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -10,19 +10,15 @@ import 'package:nyxx/src/event_mixin.dart';
 import 'package:nyxx/src/gateway/gateway.dart';
 import 'package:nyxx/src/http/handler.dart';
 import 'package:nyxx/src/http/managers/gateway_manager.dart';
-import 'package:nyxx/src/http/request.dart';
-import 'package:nyxx/src/http/route.dart';
 import 'package:nyxx/src/intents.dart';
 import 'package:nyxx/src/manager_mixin.dart';
 import 'package:nyxx/src/api_options.dart';
 import 'package:nyxx/src/models/application.dart';
 import 'package:nyxx/src/models/guild/guild.dart';
-import 'package:nyxx/src/models/oauth2.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/user/user.dart';
 import 'package:nyxx/src/plugin/plugin.dart';
 import 'package:nyxx/src/utils/flags.dart';
-import 'package:nyxx/src/utils/parsing_helpers.dart';
 import 'package:oauth2/oauth2.dart';
 import 'package:runtime_type/runtime_type.dart';
 
@@ -118,7 +114,7 @@ abstract class Nyxx {
 
     return _doConnect(apiOptions, clientOptions, () async {
       final client = NyxxOAuth2._(apiOptions, clientOptions);
-      final information = await client.fetchCurrentOAuth2Information();
+      final information = await client.users.fetchCurrentOAuth2Information();
 
       return client
         .._application = information.application
@@ -257,20 +253,6 @@ class NyxxOAuth2 with ManagerMixin implements NyxxRest {
   @override
   Future<List<UserGuild>> listGuilds({Snowflake? before, Snowflake? after, int? limit}) =>
       users.listCurrentUserGuilds(before: before, after: after, limit: limit);
-
-  Future<OAuth2Information> fetchCurrentOAuth2Information() async {
-    final route = HttpRoute()
-      ..oauth2()
-      ..add(HttpRoutePart('@me'));
-    final request = BasicRequest(route);
-    final response = await httpHandler.executeSafe(request);
-    final body = response.jsonBody as Map<String, Object?>;
-    return OAuth2Information(
-        application: PartialApplication(manager: applications, id: Snowflake.parse((body['application'] as Map<String, Object?>)['id']!)),
-        scopes: (body['scopes'] as List).cast(),
-        expiresOn: DateTime.parse(body['expires'] as String),
-        user: maybeParse(body['user'], users.parse));
-  }
 
   @override
   Future<void> close() {

--- a/lib/src/http/managers/application_manager.dart
+++ b/lib/src/http/managers/application_manager.dart
@@ -159,6 +159,17 @@ class ApplicationManager {
     return parse(response.jsonBody as Map<String, Object?>);
   }
 
+  /// Fetch the current OAuth2 application.
+  Future<Application> fetchOAuth2CurrentApplication() async {
+    final route = HttpRoute()
+      ..oauth2()
+      ..applications(id: '@me');
+    final request = BasicRequest(route);
+
+    final response = await client.httpHandler.executeSafe(request);
+    return parse(response.jsonBody as Map<String, Object?>);
+  }
+
   /// Update the current application.
   Future<Application> updateCurrentApplication(ApplicationUpdateBuilder builder) async {
     final route = HttpRoute()..applications(id: '@me');

--- a/lib/src/http/managers/guild_manager.dart
+++ b/lib/src/http/managers/guild_manager.dart
@@ -94,7 +94,7 @@ class GuildManager extends Manager<Guild> {
   /// Parse [UserGuild] from [raw].
   UserGuild parseUserGuild(Map<String, Object?> raw) {
     final id = Snowflake.parse(raw['id']!);
-
+    print(raw);
     return UserGuild(
       id: id,
       manager: this,

--- a/lib/src/http/managers/guild_manager.dart
+++ b/lib/src/http/managers/guild_manager.dart
@@ -94,7 +94,6 @@ class GuildManager extends Manager<Guild> {
   /// Parse [UserGuild] from [raw].
   UserGuild parseUserGuild(Map<String, Object?> raw) {
     final id = Snowflake.parse(raw['id']!);
-    print(raw);
     return UserGuild(
       id: id,
       manager: this,

--- a/lib/src/http/managers/guild_manager.dart
+++ b/lib/src/http/managers/guild_manager.dart
@@ -91,6 +91,23 @@ class GuildManager extends Manager<Guild> {
     );
   }
 
+  /// Parse [UserGuild] from [raw].
+  UserGuild parseUserGuild(Map<String, Object?> raw) {
+    final id = Snowflake.parse(raw['id']!);
+
+    return UserGuild(
+      id: id,
+      manager: this,
+      name: raw['name'] as String,
+      iconHash: raw['icon'] as String?,
+      isOwnedByCurrentUser: raw['owner'] as bool,
+      currentUserPermissions: Permissions(int.parse(raw['permissions'] as String)),
+      features: parseGuildFeatures(raw['features'] as List),
+      approximateMemberCount: raw['approximate_member_count'] as int?,
+      approximatePresenceCount: raw['approximate_presence_count'] as int?,
+    );
+  }
+
   static final Map<String, Flag<GuildFeatures>> _nameToGuildFeature = {
     'ANIMATED_BANNER': GuildFeatures.animatedBanner,
     'ANIMATED_ICON': GuildFeatures.animatedIcon,

--- a/lib/src/http/managers/user_manager.dart
+++ b/lib/src/http/managers/user_manager.dart
@@ -129,7 +129,7 @@ class UserManager extends ReadOnlyManager<User> {
   }
 
   /// List the guilds the current user is a member of.
-  Future<List<PartialGuild>> listCurrentUserGuilds({Snowflake? after, Snowflake? before, int? limit, bool? withCounts}) async {
+  Future<List<UserGuild>> listCurrentUserGuilds({Snowflake? after, Snowflake? before, int? limit, bool? withCounts}) async {
     final route = HttpRoute()
       ..users(id: '@me')
       ..guilds();
@@ -143,7 +143,7 @@ class UserManager extends ReadOnlyManager<User> {
     final response = await client.httpHandler.executeSafe(request);
     return parseMany(
       response.jsonBody as List,
-      (Map<String, Object?> raw) => PartialGuild(id: Snowflake.parse(raw['id']!), manager: client.guilds),
+      (Map<String, Object?> raw) => client.guilds.parseUserGuild(raw),
     );
   }
 

--- a/lib/src/http/managers/user_manager.dart
+++ b/lib/src/http/managers/user_manager.dart
@@ -6,6 +6,7 @@ import 'package:nyxx/src/builders/user.dart';
 import 'package:nyxx/src/http/managers/manager.dart';
 import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/route.dart';
+import 'package:nyxx/src/models/application.dart';
 import 'package:nyxx/src/models/channel/types/dm.dart';
 import 'package:nyxx/src/models/channel/types/group_dm.dart';
 import 'package:nyxx/src/models/discord_color.dart';
@@ -13,6 +14,7 @@ import 'package:nyxx/src/models/guild/guild.dart';
 import 'package:nyxx/src/models/guild/integration.dart';
 import 'package:nyxx/src/models/guild/member.dart';
 import 'package:nyxx/src/models/locale.dart';
+import 'package:nyxx/src/models/oauth2.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/user/application_role_connection.dart';
 import 'package:nyxx/src/models/user/connection.dart';
@@ -247,5 +249,19 @@ class UserManager extends ReadOnlyManager<User> {
 
     final response = await client.httpHandler.executeSafe(request);
     return parseApplicationRoleConnection(response.jsonBody as Map<String, Object?>);
+  }
+
+  Future<OAuth2Information> fetchCurrentOAuth2Information() async {
+    final route = HttpRoute()
+      ..oauth2()
+      ..add(HttpRoutePart('@me'));
+    final request = BasicRequest(route);
+    final response = await client.httpHandler.executeSafe(request);
+    final body = response.jsonBody as Map<String, Object?>;
+    return OAuth2Information(
+        application: PartialApplication(manager: client.applications, id: Snowflake.parse((body['application'] as Map<String, Object?>)['id']!)),
+        scopes: (body['scopes'] as List).cast(),
+        expiresOn: DateTime.parse(body['expires'] as String),
+        user: maybeParse(body['user'], client.users.parse));
   }
 }

--- a/lib/src/models/guild/guild.dart
+++ b/lib/src/models/guild/guild.dart
@@ -109,7 +109,7 @@ class PartialGuild extends WritableSnowflakeEntity<Guild> {
   Future<ThreadList> listActiveThreads() => manager.listActiveThreads(id);
 
   /// List the bans in this guild.
-  Future<List<Ban>> listBans() => manager.listBans(id);
+  Future<List<Ban>> listBans({int? limit, Snowflake? after, Snowflake? before}) => manager.listBans(id, limit: limit, after: after, before: before);
 
   /// Ban a member in this guild.
   Future<void> createBan(Snowflake userId, {Duration? deleteMessages, String? auditLogReason}) =>
@@ -195,6 +195,63 @@ class PartialGuild extends WritableSnowflakeEntity<Guild> {
 
   /// Fetch this guild's vanity invite code.
   Future<String?> fetchVanityCode() => manager.fetchVanityCode(id);
+}
+
+/// {@template guild}
+/// A collection of channels & users.
+///
+/// Guilds are often referred to as servers.
+/// {@endtemplate}
+class UserGuild extends PartialGuild {
+  /// This guild's name.
+  final String name;
+
+  /// The hash of this guild's icon.
+  final String? iconHash;
+
+  /// Whether this guild is owned by the current user.
+  final bool isOwnedByCurrentUser;
+
+  /// The current user's permissions.
+  final Permissions? currentUserPermissions;
+
+  /// A set of features enabled in this guild.
+  final GuildFeatures features;
+
+  /// An approximate number of members in this guild.
+  ///
+  /// {@template fetch_with_counts_only}
+  /// This is only returned when fetching this guild with `withCounts` set to `true`.
+  /// {@endtemplate}
+  final int? approximateMemberCount;
+
+  /// An approximate number of presences in this guild.
+  ///
+  /// {@macro fetch_with_counts_only}
+  final int? approximatePresenceCount;
+
+  /// {@macro guild}
+  /// @nodoc
+  UserGuild({
+    required super.id,
+    required super.manager,
+    required this.name,
+    required this.iconHash,
+    required this.isOwnedByCurrentUser,
+    required this.currentUserPermissions,
+    required this.features,
+    required this.approximateMemberCount,
+    required this.approximatePresenceCount,
+  });
+
+  /// This guild's icon.
+  CdnAsset? get icon => iconHash == null
+      ? null
+      : CdnAsset(
+          client: manager.client,
+          base: HttpRoute()..icons(id: id.toString()),
+          hash: iconHash!,
+        );
 }
 
 /// {@template guild}

--- a/lib/src/models/guild/guild.dart
+++ b/lib/src/models/guild/guild.dart
@@ -213,7 +213,7 @@ class UserGuild extends PartialGuild {
   final bool isOwnedByCurrentUser;
 
   /// The current user's permissions.
-  final Permissions? currentUserPermissions;
+  final Permissions currentUserPermissions;
 
   /// A set of features enabled in this guild.
   final GuildFeatures features;

--- a/lib/src/models/guild/guild.dart
+++ b/lib/src/models/guild/guild.dart
@@ -197,11 +197,7 @@ class PartialGuild extends WritableSnowflakeEntity<Guild> {
   Future<String?> fetchVanityCode() => manager.fetchVanityCode(id);
 }
 
-/// {@template guild}
-/// A collection of channels & users.
-///
-/// Guilds are often referred to as servers.
-/// {@endtemplate}
+/// {@macro guild}
 class UserGuild extends PartialGuild {
   /// This guild's name.
   final String name;
@@ -210,10 +206,10 @@ class UserGuild extends PartialGuild {
   final String? iconHash;
 
   /// Whether this guild is owned by the current user.
-  final bool isOwnedByCurrentUser;
+  final bool? isOwnedByCurrentUser;
 
   /// The current user's permissions.
-  final Permissions currentUserPermissions;
+  final Permissions? currentUserPermissions;
 
   /// A set of features enabled in this guild.
   final GuildFeatures features;
@@ -259,33 +255,15 @@ class UserGuild extends PartialGuild {
 ///
 /// Guilds are often referred to as servers.
 /// {@endtemplate}
-class Guild extends PartialGuild {
-  /// This guild's name.
-  final String name;
-
-  /// The hash of this guild's icon.
-  final String? iconHash;
-
+class Guild extends UserGuild {
   /// The hash of this guild's splash image.
   final String? splashHash;
 
   /// The hash of this guild's discovery splash image.
   final String? discoverySplashHash;
 
-  /// Whether this guild is owned by the current user.
-  ///
-  /// {@template get_current_user_guilds_only}
-  /// This field is only present when fetching the current user's guilds.
-  /// {@endtemplate}
-  final bool? isOwnedByCurrentUser;
-
   /// The ID of this guild's owner.
   final Snowflake ownerId;
-
-  /// The current user's permissions.
-  ///
-  /// {@macro get_current_user_guilds_only}
-  final Permissions? currentUserPermissions;
 
   /// The ID of this guild's AFK channel.
   final Snowflake? afkChannelId;
@@ -315,9 +293,6 @@ class Guild extends PartialGuild {
   /// A list of emojis in this guild.
   // Renamed to avoid conflict with the emojis manager.
   final List<Emoji> emojiList;
-
-  /// A set of features enabled in this guild.
-  final GuildFeatures features;
 
   /// This guild's MFA level.
   final MfaLevel mfaLevel;
@@ -367,18 +342,6 @@ class Guild extends PartialGuild {
   /// The maximum number of users in a stage video channel.
   final int? maxStageChannelUsers;
 
-  /// An approximate number of members in this guild.
-  ///
-  /// {@template fetch_with_counts_only}
-  /// This is only returned when fetching this guild with `withCounts` set to `true`.
-  /// {@endtemplate}
-  final int? approximateMemberCount;
-
-  /// An approximate number of presences in this guild.
-  ///
-  /// {@macro fetch_with_counts_only}
-  final int? approximatePresenceCount;
-
   /// This guild's welcome screen.
   final WelcomeScreen? welcomeScreen;
 
@@ -400,13 +363,13 @@ class Guild extends PartialGuild {
   Guild({
     required super.id,
     required super.manager,
-    required this.name,
-    required this.iconHash,
+    required super.name,
+    required super.iconHash,
     required this.splashHash,
     required this.discoverySplashHash,
-    required this.isOwnedByCurrentUser,
+    required super.isOwnedByCurrentUser,
     required this.ownerId,
-    required this.currentUserPermissions,
+    required super.currentUserPermissions,
     required this.afkChannelId,
     required this.afkTimeout,
     required this.isWidgetEnabled,
@@ -415,7 +378,7 @@ class Guild extends PartialGuild {
     required this.defaultMessageNotificationLevel,
     required this.explicitContentFilterLevel,
     required this.roleList,
-    required this.features,
+    required super.features,
     required this.mfaLevel,
     required this.applicationId,
     required this.systemChannelId,
@@ -432,8 +395,8 @@ class Guild extends PartialGuild {
     required this.publicUpdatesChannelId,
     required this.maxVideoChannelUsers,
     required this.maxStageChannelUsers,
-    required this.approximateMemberCount,
-    required this.approximatePresenceCount,
+    required super.approximateMemberCount,
+    required super.approximatePresenceCount,
     required this.welcomeScreen,
     required this.nsfwLevel,
     required this.hasPremiumProgressBarEnabled,
@@ -469,15 +432,6 @@ class Guild extends PartialGuild {
 
   /// The channel safety alerts are sent to.
   PartialTextChannel? get safetyAlertsChannel => safetyAlertsChannelId == null ? null : manager.client.channels[safetyAlertsChannelId!] as PartialTextChannel;
-
-  /// This guild's icon.
-  CdnAsset? get icon => iconHash == null
-      ? null
-      : CdnAsset(
-          client: manager.client,
-          base: HttpRoute()..icons(id: id.toString()),
-          hash: iconHash!,
-        );
 
   /// This guild's splash image.
   CdnAsset? get splash => splashHash == null

--- a/lib/src/models/oauth2.dart
+++ b/lib/src/models/oauth2.dart
@@ -1,0 +1,18 @@
+import 'package:nyxx/src/models/application.dart';
+import 'package:nyxx/src/models/user/user.dart';
+
+class OAuth2Information {
+  /// The current application.
+  final PartialApplication application;
+
+  /// The scopes the user has authorized the application for.
+  final List<String> scopes;
+
+  /// When the access token expires.
+  final DateTime expiresOn;
+
+  /// The user who has authorized, if the user has authorized with the `identify` scope.
+  final User? user;
+
+  OAuth2Information({required this.application, required this.scopes, required this.expiresOn, this.user});
+}

--- a/test/unit/builders/permission_overwrite_test.dart
+++ b/test/unit/builders/permission_overwrite_test.dart
@@ -3,8 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('PermissionOverwriteBuilder', () {
-    final builder = PermissionOverwriteBuilder(
-        id: Snowflake.zero, type: PermissionOverwriteType.member);
+    final builder = PermissionOverwriteBuilder(id: Snowflake.zero, type: PermissionOverwriteType.member);
 
     expect(
       builder.build(),

--- a/test/unit/http/managers/user_manager_test.dart
+++ b/test/unit/http/managers/user_manager_test.dart
@@ -1,6 +1,5 @@
 import 'package:mocktail/mocktail.dart';
 import 'package:nyxx/nyxx.dart';
-import 'package:nyxx/src/models/guild/guild.dart';
 import 'package:test/test.dart';
 
 import '../../../mocks/client.dart';

--- a/test/unit/http/managers/user_manager_test.dart
+++ b/test/unit/http/managers/user_manager_test.dart
@@ -1,5 +1,6 @@
 import 'package:mocktail/mocktail.dart';
 import 'package:nyxx/nyxx.dart';
+import 'package:nyxx/src/models/guild/guild.dart';
 import 'package:test/test.dart';
 
 import '../../../mocks/client.dart';
@@ -104,16 +105,36 @@ void main() {
         execute: (manager) => manager.updateCurrentUser(UserUpdateBuilder()),
         check: checkSampleUser,
       ),
-      EndpointTest<UserManager, List<PartialGuild>, List<Object?>>(
+      EndpointTest<UserManager, List<UserGuild>, List<Object?>>(
         name: 'listCurrentUserGuilds',
         source: [
-          {'id': '0'}
+          {
+            'id': '1',
+            'name': 'nyxx',
+            'icon': null,
+            'owner': false,
+            'permissions': '533130099674816',
+            'features': ['COMMUNITY', 'INVITE_SPLASH', 'DISCOVERABLE', 'WELCOME_SCREEN_ENABLED', 'VERIFIED', 'VANITY_URL', 'NEWS']
+          }
         ],
         urlMatcher: '/users/@me/guilds',
         execute: (manager) => manager.listCurrentUserGuilds(),
         check: (list) {
           expect(list, hasLength(1));
-          expect(list.single.id, equals(Snowflake.zero));
+          final guild = list.single;
+          expect(guild.id, equals(Snowflake(1)));
+          expect(guild.name, 'nyxx');
+          expect(guild.icon, isNull);
+          expect(guild.isOwnedByCurrentUser, isFalse);
+          expect(guild.currentUserPermissions, isNotNull);
+          final features = guild.features;
+          expect(features.hasCommunity, isTrue);
+          expect(features.hasInviteSplash, isTrue);
+          expect(features.isDiscoverable, isTrue);
+          expect(features.hasWelcomeScreenEnabled, isTrue);
+          expect(features.isVerified, isTrue);
+          expect(features.hasVanityUrl, isTrue);
+          expect(features.hasNews, isTrue);
         },
       ),
       EndpointTest<UserManager, Member, Map<String, Object?>>(


### PR DESCRIPTION
1. Add ability to quickly list guilds with `Nyxx.connectRest`/`Nyxx.connectOAuth2` (fix https://github.com/nyxx-discord/nyxx/issues/630) ([UserGuild structure](https://discord.com/channels/846136758470443069/846137774495367249/1205232540487651418))
2. Make `Nyxx.connectOAuth2` no longer throw if `identify` scope is missing

I could make `OAuth2Manager` class and put `fetchCurrentOAuth2Information` to it, but its seems overkill 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) (`Nyxx.connectOAuth2`/`Nyxx.connectOAuth2WithOptions` no longer throws if there no `identify` scope)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
