### PR TITLE
fix: Intialize logging sooner to prevent missed logs

### DIFF
--- a/lib/src/plugin/logging.dart
+++ b/lib/src/plugin/logging.dart
@@ -50,7 +50,9 @@ class Logging extends NyxxPlugin {
     StringSink? stdout,
     StringSink? stderr,
   })  : stdout = stdout ?? io.stdout,
-        stderr = stderr ?? io.stderr;
+        stderr = stderr ?? io.stderr {
+    _listenIfNeeded();
+  }
 
   static int _clients = 0;
 
@@ -130,7 +132,6 @@ class Logging extends NyxxPlugin {
     }
 
     _clients++;
-    _listenIfNeeded();
   }
 
   @override


### PR DESCRIPTION
# Description
Fixes logs that were ignored because of the late call of `_listenIfNeeded`

## Connected issues & other potential problems
None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
