### PR TITLE
Add banner to UserUpdateBuilder, and `SkuFlags.available`

### DIFF
--- a/lib/src/builders/user.dart
+++ b/lib/src/builders/user.dart
@@ -1,16 +1,24 @@
 import 'package:nyxx/src/builders/builder.dart';
 import 'package:nyxx/src/builders/image.dart';
+import 'package:nyxx/src/builders/sentinels.dart';
 import 'package:nyxx/src/models/user/user.dart';
 
 class UserUpdateBuilder extends UpdateBuilder<User> {
+  /// New user's username.
   String? username;
+
+  /// New user's avatar.
   ImageBuilder? avatar;
 
-  UserUpdateBuilder({this.username, this.avatar});
+  /// New user's banner.
+  ImageBuilder? banner;
+
+  UserUpdateBuilder({this.username, this.avatar = sentinelImageBuilder, this.banner = sentinelImageBuilder});
 
   @override
   Map<String, Object?> build() => {
         if (username != null) 'username': username!,
-        if (avatar != null) 'avatar': avatar!.buildDataString(),
+        if (!identical(avatar, sentinelImageBuilder)) 'avatar': avatar?.buildDataString(),
+        if (!identical(banner, sentinelImageBuilder)) 'banner': banner?.buildDataString(),
       };
 }

--- a/lib/src/models/sku.dart
+++ b/lib/src/models/sku.dart
@@ -68,6 +68,9 @@ enum SkuType {
 
 /// Flags applied to an [Sku].
 class SkuFlags extends Flags<SkuFlags> {
+  /// The SKU is available for purchase.
+  static const available = Flag<SkuFlags>.fromOffset(0);
+
   /// The SKU is a guild subscription.
   static const guildSubscription = Flag<SkuFlags>.fromOffset(7);
 
@@ -76,6 +79,9 @@ class SkuFlags extends Flags<SkuFlags> {
 
   /// Create a new [SkuFlags].
   SkuFlags(super.value);
+
+  /// Whether this set of flags has the [available] flag set.
+  bool get isAvailable => has(available);
 
   /// Whether this set of flags has the [guildSubscription] flag set.
   bool get isGuildSubscription => has(guildSubscription);

--- a/test/unit/builders/user_test.dart
+++ b/test/unit/builders/user_test.dart
@@ -21,6 +21,9 @@ void main() {
 
       final builder4 = UserUpdateBuilder();
       expect(builder4.build(), equals({}));
+
+      final builder5 = UserUpdateBuilder(banner: ImageBuilder.png([]));
+      expect(builder5.build(), equals({'banner': 'data:image/png;base64,'}));
     });
   });
 }


### PR DESCRIPTION
# Description

Implement https://github.com/discord/discord-api-docs/pull/6710 and add missing `SkuFlags.available`

## Connected issues & other potential problems

none

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
