### PR TITLE
Add bungie/domain/roblox connection types and correct SkuFlags.available

### DIFF
--- a/lib/src/models/sku.dart
+++ b/lib/src/models/sku.dart
@@ -69,7 +69,7 @@ enum SkuType {
 /// Flags applied to an [Sku].
 class SkuFlags extends Flags<SkuFlags> {
   /// The SKU is available for purchase.
-  static const available = Flag<SkuFlags>.fromOffset(0);
+  static const available = Flag<SkuFlags>.fromOffset(2);
 
   /// The SKU is a guild subscription.
   static const guildSubscription = Flag<SkuFlags>.fromOffset(7);

--- a/lib/src/models/user/connection.dart
+++ b/lib/src/models/user/connection.dart
@@ -58,6 +58,8 @@ class Connection with ToStringHelper {
 /// * Discord API Reference: https://discord.com/developers/docs/resources/user#connection-object-services
 enum ConnectionType {
   battleNet._('battlenet', 'Battle.net'),
+  bungieNet._('bungie', 'Bungie.net'),
+  domain._('domain', 'Domain'),
   ebay._('ebay', 'eBay'),
   epicGames._('epicgames', 'Epic Games'),
   facebook._('facebook', 'Facebook'),
@@ -68,6 +70,7 @@ enum ConnectionType {
   playstation._('playstation', 'PlayStation Network'),
   reddit._('reddit', 'Reddit'),
   riotGames._('riotgames', 'Riot Games'),
+  roblox._('roblox', 'ROBLOX'),
   spotify._('spotify', 'Spotify'),
   skype._('skype', 'Skype'),
   steam._('steam', 'Steam'),


### PR DESCRIPTION
# Description

Connection types:
- Bungie.net: https://github.com/discord/discord-api-spec/commit/d1a462342b5b3b021f4962e264eefd82dace9238 and https://github.com/discord/discord-api-docs/pull/6716
- Domain: https://github.com/discord/discord-api-docs/pull/6395
- roblox: https://github.com/discord/discord-api-spec/commit/526e07828d4cdb8e7ce105f2e46b6d7b1916a0db
Sku flags: https://canary.discord.com/developers/docs/monetization/skus#sku-object-sku-flags

## Connected issues & other potential problems

none

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
