### PR TITLE
Add `bulkBan` to `GuildManager`

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -163,7 +163,7 @@ export 'src/models/message/component.dart'
 export 'src/models/invite/invite.dart' show Invite, TargetType;
 export 'src/models/invite/invite_metadata.dart' show InviteWithMetadata;
 export 'src/models/webhook.dart' show PartialWebhook, Webhook, WebhookType, WebhookAuthor;
-export 'src/models/guild/ban.dart' show Ban;
+export 'src/models/guild/ban.dart' show Ban, BulkBanResponse;
 export 'src/models/guild/guild_preview.dart' show GuildPreview;
 export 'src/models/guild/guild_widget.dart' show GuildWidget, WidgetSettings, WidgetImageStyle;
 export 'src/models/guild/guild.dart'

--- a/lib/src/http/managers/guild_manager.dart
+++ b/lib/src/http/managers/guild_manager.dart
@@ -213,8 +213,8 @@ class GuildManager extends Manager<Guild> {
   /// Parse a [BulkBanResponse] from [raw].
   BulkBanResponse parseBulkBanResponse(Map<String, Object?> raw) {
     return BulkBanResponse(
-      bannedUsers: (raw['banned_users'] as List).cast<Object>().map(Snowflake.parse).toList(),
-      failedUsers: (raw['failed_users'] as List).cast<Object>().map(Snowflake.parse).toList(),
+      bannedUsers: parseMany(raw['banned_users'] as List, Snowflake.parse),
+      failedUsers: parseMany(raw['failed_users'] as List, Snowflake.parse),
     );
   }
 

--- a/lib/src/http/managers/guild_manager.dart
+++ b/lib/src/http/managers/guild_manager.dart
@@ -213,8 +213,8 @@ class GuildManager extends Manager<Guild> {
   /// Parse a [BulkBanResponse] from [raw].
   BulkBanResponse parseBulkBanResponse(Map<String, Object?> raw) {
     return BulkBanResponse(
-      bannedUsers: maybeParseMany(raw['banned_users'], Snowflake.parse),
-      failedUsers: maybeParseMany(raw['failed_users'], Snowflake.parse),
+      bannedUsers: (raw['banned_users'] as List).cast<Object>().map(Snowflake.parse).toList(),
+      failedUsers: (raw['failed_users'] as List).cast<Object>().map(Snowflake.parse).toList(),
     );
   }
 

--- a/lib/src/http/managers/guild_manager.dart
+++ b/lib/src/http/managers/guild_manager.dart
@@ -503,7 +503,7 @@ class GuildManager extends Manager<Guild> {
       method: 'POST',
       auditLogReason: auditLogReason,
       body: jsonEncode({
-        'user_ids': userIds.map((s) => s.toString()),
+        'user_ids': userIds.map((s) => s.toString()).toList(),
         if (deleteMessages != null) 'delete_message_seconds': deleteMessages.inSeconds,
       }),
     );

--- a/lib/src/http/route.dart
+++ b/lib/src/http/route.dart
@@ -314,4 +314,7 @@ extension RouteHelpers on HttpRoute {
 
   /// Adds the [`recipients`](https://discord.com/developers/docs/resources/channel#group-dm-add-recipient) part to this [HttpRoute].
   void recipients({String? id}) => add(HttpRoutePart('recipients', [if (id != null) HttpRouteParam(id)]));
+
+  /// Adds the [`bulk-ban`](https://discord.com/developers/docs/resources/guild#bulk-guild-ban) part to this [HttpRoute].
+  void bulkBan() => add(HttpRoutePart('bulk-ban'));
 }

--- a/lib/src/models/guild/ban.dart
+++ b/lib/src/models/guild/ban.dart
@@ -19,10 +19,10 @@ class Ban with ToStringHelper {
 
 class BulkBanResponse with ToStringHelper {
   /// A list of user IDs, that were succesfully banned.
-  final List<Snowflake>? bannedUsers;
+  final List<Snowflake> bannedUsers;
 
   /// A list of user IDs, that were not banned.
-  final List<Snowflake>? failedUsers;
+  final List<Snowflake> failedUsers;
 
   /// @nodoc
   BulkBanResponse({required this.bannedUsers, required this.failedUsers});

--- a/lib/src/models/guild/ban.dart
+++ b/lib/src/models/guild/ban.dart
@@ -1,3 +1,4 @@
+import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/user/user.dart';
 import 'package:nyxx/src/utils/to_string_helper/to_string_helper.dart';
 
@@ -14,4 +15,15 @@ class Ban with ToStringHelper {
   /// {@macro ban}
   /// @nodoc
   Ban({required this.reason, required this.user});
+}
+
+class BulkBanResponse with ToStringHelper {
+  /// A list of user IDs, that were succesfully banned.
+  final List<Snowflake>? bannedUsers;
+
+  /// A list of user IDs, that were not banned.
+  final List<Snowflake>? failedUsers;
+
+  /// @nodoc
+  BulkBanResponse({required this.bannedUsers, required this.failedUsers});
 }

--- a/lib/src/models/guild/guild.dart
+++ b/lib/src/models/guild/guild.dart
@@ -111,11 +111,15 @@ class PartialGuild extends WritableSnowflakeEntity<Guild> {
   /// List the bans in this guild.
   Future<List<Ban>> listBans({int? limit, Snowflake? after, Snowflake? before}) => manager.listBans(id, limit: limit, after: after, before: before);
 
-  /// Ban a member in this guild.
+  /// Ban a user in this guild.
   Future<void> createBan(Snowflake userId, {Duration? deleteMessages, String? auditLogReason}) =>
       manager.createBan(id, userId, auditLogReason: auditLogReason, deleteMessages: deleteMessages);
 
-  /// Unban a member in this guild.
+  /// Ban up to 200 users from a guild, and optionally delete previous messages sent by the banned users.
+  Future<BulkBanResponse> bulkBan(List<Snowflake> userIds, {Duration? deleteMessages, String? auditLogReason}) =>
+      manager.bulkBan(id, userIds, deleteMessages: deleteMessages, auditLogReason: auditLogReason);
+
+  /// Unban a user in this guild.
   Future<void> deleteBan(Snowflake userId, {String? auditLogReason}) => manager.deleteBan(id, userId, auditLogReason: auditLogReason);
 
   /// Update a guild's MFA level.


### PR DESCRIPTION
# Description

Implement https://github.com/discord/discord-api-docs/pull/6720
In `PartialGuild.createBan`/`PartialGuild.deleteBan` i changed `member` to `user` since discord allows banning users outside of server

## Connected issues & other potential problems

None

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
