### PR TITLE
Add user apps

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -68,7 +68,7 @@ export 'src/builders/application_command.dart'
     show ApplicationCommandBuilder, ApplicationCommandUpdateBuilder, CommandOptionBuilder, CommandOptionChoiceBuilder;
 export 'src/builders/interaction_response.dart' show InteractionResponseBuilder, ModalBuilder, InteractionCallbackType;
 export 'src/builders/entitlement.dart' show TestEntitlementBuilder, TestEntitlementType;
-export 'src/builders/application.dart' show ApplicationUpdateBuilder;
+export 'src/builders/application.dart' show ApplicationUpdateBuilder, ApplicationIntegrationTypeConfigurationBuilder;
 
 export 'src/cache/cache.dart' show Cache, CacheConfig;
 

--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -143,7 +143,8 @@ export 'src/models/message/attachment.dart' show Attachment, AttachmentFlags;
 export 'src/models/message/author.dart' show MessageAuthor;
 export 'src/models/message/channel_mention.dart' show ChannelMention;
 export 'src/models/message/embed.dart' show Embed, EmbedAuthor, EmbedField, EmbedFooter, EmbedImage, EmbedProvider, EmbedThumbnail, EmbedVideo;
-export 'src/models/message/message.dart' show Message, MessageFlags, PartialMessage, MessageType, MessageInteraction;
+// ignore: deprecated_member_use_from_same_package
+export 'src/models/message/message.dart' show Message, MessageFlags, PartialMessage, MessageType, MessageInteraction, MessageInteractionMetadata;
 export 'src/models/message/reaction.dart' show Reaction, ReactionCountDetails;
 export 'src/models/message/reference.dart' show MessageReference;
 export 'src/models/message/role_subscription_data.dart' show RoleSubscriptionData;
@@ -186,7 +187,14 @@ export 'src/models/guild/welcome_screen.dart' show WelcomeScreen, WelcomeScreenC
 export 'src/models/guild/scheduled_event.dart' show EntityMetadata, PartialScheduledEvent, ScheduledEvent, ScheduledEventUser, EventStatus, ScheduledEntityType;
 export 'src/models/guild/audit_log.dart' show AuditLogChange, AuditLogEntry, AuditLogEntryInfo, PartialAuditLogEntry, AuditLogEvent;
 export 'src/models/application.dart'
-    show Application, ApplicationFlags, InstallationParameters, PartialApplication, ApplicationRoleConnectionMetadata, ConnectionMetadataType;
+    show
+        Application,
+        ApplicationFlags,
+        InstallationParameters,
+        PartialApplication,
+        ApplicationRoleConnectionMetadata,
+        ConnectionMetadataType,
+        ApplicationIntegrationType;
 export 'src/models/guild/template.dart' show GuildTemplate;
 export 'src/models/guild/auto_moderation.dart'
     show
@@ -299,7 +307,8 @@ export 'src/models/interaction.dart'
         ApplicationCommandInteraction,
         MessageComponentInteraction,
         ModalSubmitInteraction,
-        PingInteraction;
+        PingInteraction,
+        InteractionContextType;
 export 'src/models/entitlement.dart' show Entitlement, PartialEntitlement, EntitlementType;
 export 'src/models/sku.dart' show Sku, SkuType, SkuFlags;
 export 'src/models/oauth2.dart' show OAuth2Information;

--- a/lib/src/builders/application.dart
+++ b/lib/src/builders/application.dart
@@ -50,10 +50,11 @@ class ApplicationUpdateBuilder extends UpdateBuilder<Application> {
           },
         if (integrationTypesConfig != null)
           'integration_types_config': integrationTypesConfig!.map((key, value) => MapEntry(key.value.toString(), {
-                'oauth2_install_params': {
-                  'scopes': value.oauth2InstallParameters.scopes,
-                  'permissions': value.oauth2InstallParameters.permissions.value.toString(),
-                },
+                if (value.oauth2InstallParameters != null)
+                  'oauth2_install_params': {
+                    'scopes': value.oauth2InstallParameters!.scopes,
+                    'permissions': value.oauth2InstallParameters!.permissions.value.toString(),
+                  },
               })),
         if (flags != null) 'flags': flags!.value,
         if (!identical(icon, sentinelImageBuilder)) 'icon': icon?.buildDataString(),

--- a/lib/src/builders/application.dart
+++ b/lib/src/builders/application.dart
@@ -4,6 +4,22 @@ import 'package:nyxx/src/builders/sentinels.dart';
 import 'package:nyxx/src/models/application.dart';
 import 'package:nyxx/src/utils/flags.dart';
 
+class ApplicationIntegrationTypeConfigurationBuilder extends CreateBuilder<ApplicationIntegrationTypeConfiguration> {
+  /// Install params for each installation context's default in-app authorization link.
+  final InstallationParameters? oauth2InstallParameters;
+
+  ApplicationIntegrationTypeConfigurationBuilder({this.oauth2InstallParameters});
+
+  @override
+  Map<String, Object?> build() => {
+        if (oauth2InstallParameters != null)
+          'oauth2_install_params': {
+            'scopes': oauth2InstallParameters!.scopes,
+            'permissions': oauth2InstallParameters!.permissions.value.toString(),
+          },
+      };
+}
+
 class ApplicationUpdateBuilder extends UpdateBuilder<Application> {
   Uri? customInstallUrl;
 
@@ -23,7 +39,7 @@ class ApplicationUpdateBuilder extends UpdateBuilder<Application> {
 
   List<String>? tags;
 
-  Map<ApplicationIntegrationType, ApplicationIntegrationTypeConfiguration>? integrationTypesConfig;
+  Map<ApplicationIntegrationType, ApplicationIntegrationTypeConfigurationBuilder>? integrationTypesConfig;
 
   ApplicationUpdateBuilder({
     this.customInstallUrl,
@@ -49,13 +65,9 @@ class ApplicationUpdateBuilder extends UpdateBuilder<Application> {
             'permissions': installationParameters!.permissions.value.toString(),
           },
         if (integrationTypesConfig != null)
-          'integration_types_config': integrationTypesConfig!.map((key, value) => MapEntry(key.value.toString(), {
-                if (value.oauth2InstallParameters != null)
-                  'oauth2_install_params': {
-                    'scopes': value.oauth2InstallParameters!.scopes,
-                    'permissions': value.oauth2InstallParameters!.permissions.value.toString(),
-                  },
-              })),
+          'integration_types_config': {
+            for (final MapEntry(:key, :value) in integrationTypesConfig!.entries) key.value.toString(): value.build(),
+          },
         if (flags != null) 'flags': flags!.value,
         if (!identical(icon, sentinelImageBuilder)) 'icon': icon?.buildDataString(),
         if (!identical(coverImage, sentinelImageBuilder)) 'cover_image': coverImage?.buildDataString(),

--- a/lib/src/builders/application.dart
+++ b/lib/src/builders/application.dart
@@ -23,6 +23,8 @@ class ApplicationUpdateBuilder extends UpdateBuilder<Application> {
 
   List<String>? tags;
 
+  Map<ApplicationIntegrationType, ApplicationIntegrationTypeConfiguration>? integrationTypesConfig;
+
   ApplicationUpdateBuilder({
     this.customInstallUrl,
     this.description,
@@ -33,6 +35,7 @@ class ApplicationUpdateBuilder extends UpdateBuilder<Application> {
     this.coverImage = sentinelImageBuilder,
     this.interactionsEndpointUrl = sentinelUri,
     this.tags,
+    this.integrationTypesConfig,
   });
 
   @override
@@ -43,8 +46,15 @@ class ApplicationUpdateBuilder extends UpdateBuilder<Application> {
         if (installationParameters != null)
           'install_params': {
             'scopes': installationParameters!.scopes,
-            'permissions': installationParameters!.permissions.toString(),
+            'permissions': installationParameters!.permissions.value.toString(),
           },
+        if (integrationTypesConfig != null)
+          'integration_types_config': integrationTypesConfig!.map((key, value) => MapEntry(key.value.toString(), {
+                'oauth2_install_params': {
+                  'scopes': value.oauth2InstallParameters.scopes,
+                  'permissions': value.oauth2InstallParameters.permissions.value.toString(),
+                },
+              })),
         if (flags != null) 'flags': flags!.value,
         if (!identical(icon, sentinelImageBuilder)) 'icon': icon?.buildDataString(),
         if (!identical(coverImage, sentinelImageBuilder)) 'cover_image': coverImage?.buildDataString(),

--- a/lib/src/builders/application_command.dart
+++ b/lib/src/builders/application_command.dart
@@ -1,8 +1,10 @@
 import 'package:nyxx/src/builders/builder.dart';
 import 'package:nyxx/src/builders/sentinels.dart';
+import 'package:nyxx/src/models/application.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/commands/application_command.dart';
 import 'package:nyxx/src/models/commands/application_command_option.dart';
+import 'package:nyxx/src/models/interaction.dart';
 import 'package:nyxx/src/models/locale.dart';
 import 'package:nyxx/src/models/permissions.dart';
 import 'package:nyxx/src/utils/flags.dart';
@@ -20,11 +22,18 @@ class ApplicationCommandBuilder extends CreateBuilder<ApplicationCommand> {
 
   Flags<Permissions>? defaultMemberPermissions;
 
+  @Deprecated('Use `contexts`')
   bool? hasDmPermission;
 
   ApplicationCommandType type;
 
   bool? isNsfw;
+
+  /// Installation context(s) where the command is available, only for globally-scoped commands. Defaults to [ApplicationIntegrationType.guildInstall].
+  List<ApplicationIntegrationType>? integrationTypes;
+
+  /// Interaction context(s) where the command can be used, only for globally-scoped commands. By default, all interaction context types included.
+  List<InteractionContextType>? contexts;
 
   ApplicationCommandBuilder({
     required this.name,
@@ -36,6 +45,8 @@ class ApplicationCommandBuilder extends CreateBuilder<ApplicationCommand> {
     this.defaultMemberPermissions,
     this.hasDmPermission,
     this.isNsfw,
+    this.integrationTypes,
+    this.contexts,
   });
 
   ApplicationCommandBuilder.chatInput({
@@ -47,6 +58,8 @@ class ApplicationCommandBuilder extends CreateBuilder<ApplicationCommand> {
     this.defaultMemberPermissions,
     this.hasDmPermission,
     this.isNsfw,
+    this.integrationTypes,
+    this.contexts,
   }) : type = ApplicationCommandType.chatInput;
 
   ApplicationCommandBuilder.message({
@@ -55,6 +68,8 @@ class ApplicationCommandBuilder extends CreateBuilder<ApplicationCommand> {
     this.defaultMemberPermissions,
     this.hasDmPermission,
     this.isNsfw,
+    this.integrationTypes,
+    this.contexts,
   })  : type = ApplicationCommandType.message,
         description = null,
         descriptionLocalizations = null,
@@ -66,6 +81,8 @@ class ApplicationCommandBuilder extends CreateBuilder<ApplicationCommand> {
     this.defaultMemberPermissions,
     this.hasDmPermission,
     this.isNsfw,
+    this.integrationTypes,
+    this.contexts,
   })  : type = ApplicationCommandType.user,
         description = null,
         descriptionLocalizations = null,
@@ -80,9 +97,12 @@ class ApplicationCommandBuilder extends CreateBuilder<ApplicationCommand> {
           'description_localizations': {for (final MapEntry(:key, :value) in descriptionLocalizations!.entries) key.identifier: value},
         if (options != null) 'options': options!.map((e) => e.build()).toList(),
         if (defaultMemberPermissions != null) 'default_member_permissions': defaultMemberPermissions!.value.toString(),
+        // ignore: deprecated_member_use_from_same_package
         if (hasDmPermission != null) 'dm_permission': hasDmPermission,
         'type': type.value,
         if (isNsfw != null) 'nsfw': isNsfw,
+        if (integrationTypes != null) 'integration_types': integrationTypes!.map((type) => type.value).toList(),
+        if (contexts != null) 'contexts': contexts!.map((type) => type.value).toList(),
       };
 }
 
@@ -99,9 +119,16 @@ class ApplicationCommandUpdateBuilder extends UpdateBuilder<ApplicationCommand> 
 
   Flags<Permissions>? defaultMemberPermissions;
 
+  @Deprecated('Use `contexts`')
   bool? hasDmPermission;
 
   bool? isNsfw;
+
+  /// Installation context(s) where the command is available, only for globally-scoped commands. Defaults to [ApplicationIntegrationType.guildInstall].
+  List<ApplicationIntegrationType>? integrationTypes;
+
+  /// Interaction context(s) where the command can be used, only for globally-scoped commands. By default, all interaction context types included.
+  List<InteractionContextType>? contexts;
 
   ApplicationCommandUpdateBuilder({
     this.name,
@@ -112,6 +139,8 @@ class ApplicationCommandUpdateBuilder extends UpdateBuilder<ApplicationCommand> 
     this.defaultMemberPermissions = sentinelFlags,
     this.hasDmPermission,
     this.isNsfw,
+    this.integrationTypes,
+    this.contexts,
   });
 
   ApplicationCommandUpdateBuilder.chatInput({
@@ -123,6 +152,8 @@ class ApplicationCommandUpdateBuilder extends UpdateBuilder<ApplicationCommand> 
     this.defaultMemberPermissions,
     this.hasDmPermission,
     this.isNsfw,
+    this.integrationTypes,
+    this.contexts,
   });
 
   ApplicationCommandUpdateBuilder.message({
@@ -131,6 +162,8 @@ class ApplicationCommandUpdateBuilder extends UpdateBuilder<ApplicationCommand> 
     this.defaultMemberPermissions,
     this.hasDmPermission,
     this.isNsfw,
+    this.integrationTypes,
+    this.contexts,
   })  : description = null,
         descriptionLocalizations = null,
         options = null;
@@ -141,6 +174,8 @@ class ApplicationCommandUpdateBuilder extends UpdateBuilder<ApplicationCommand> 
     this.defaultMemberPermissions,
     this.hasDmPermission,
     this.isNsfw,
+    this.integrationTypes,
+    this.contexts,
   })  : description = null,
         descriptionLocalizations = null,
         options = null;
@@ -154,8 +189,11 @@ class ApplicationCommandUpdateBuilder extends UpdateBuilder<ApplicationCommand> 
           'description_localizations': descriptionLocalizations?.map((key, value) => MapEntry(key.toString(), value)),
         if (options != null) 'options': options!.map((e) => e.build()).toList(),
         if (!identical(defaultMemberPermissions, sentinelFlags)) 'default_member_permissions': defaultMemberPermissions?.value.toString(),
+        // ignore: deprecated_member_use_from_same_package
         if (hasDmPermission != null) 'dm_permission': hasDmPermission,
         if (isNsfw != null) 'nsfw': isNsfw,
+        if (integrationTypes != null) 'integration_types': integrationTypes!.map((type) => type.value).toList(),
+        if (contexts != null) 'contexts': contexts!.map((type) => type.value).toList(),
       };
 }
 

--- a/lib/src/http/managers/application_command_manager.dart
+++ b/lib/src/http/managers/application_command_manager.dart
@@ -6,10 +6,12 @@ import 'package:nyxx/src/http/managers/manager.dart';
 import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/response.dart';
 import 'package:nyxx/src/http/route.dart';
+import 'package:nyxx/src/models/application.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/commands/application_command.dart';
 import 'package:nyxx/src/models/commands/application_command_option.dart';
 import 'package:nyxx/src/models/commands/application_command_permissions.dart';
+import 'package:nyxx/src/models/interaction.dart';
 import 'package:nyxx/src/models/locale.dart';
 import 'package:nyxx/src/models/permissions.dart';
 import 'package:nyxx/src/models/snowflake.dart';
@@ -57,6 +59,8 @@ abstract class ApplicationCommandManager extends Manager<ApplicationCommand> {
       defaultMemberPermissions: maybeParse(raw['default_member_permissions'], (String raw) => Permissions(int.parse(raw))),
       hasDmPermission: raw['dm_permission'] as bool?,
       isNsfw: raw['nsfw'] as bool?,
+      integrationTypes: (raw['integration_types'] as List).cast<int>().map(ApplicationIntegrationType.parse).toList(),
+      contexts: (raw['contexts'] as List).cast<int>().map(InteractionContextType.parse).toList(),
       version: Snowflake.parse(raw['version']!),
     );
   }

--- a/lib/src/http/managers/application_command_manager.dart
+++ b/lib/src/http/managers/application_command_manager.dart
@@ -59,8 +59,8 @@ abstract class ApplicationCommandManager extends Manager<ApplicationCommand> {
       defaultMemberPermissions: maybeParse(raw['default_member_permissions'], (String raw) => Permissions(int.parse(raw))),
       hasDmPermission: raw['dm_permission'] as bool?,
       isNsfw: raw['nsfw'] as bool?,
-      integrationTypes: (raw['integration_types'] as List).cast<int>().map(ApplicationIntegrationType.parse).toList(),
-      contexts: (raw['contexts'] as List? ?? []).cast<int>().map(InteractionContextType.parse).toList(),
+      integrationTypes: parseMany(raw['integration_types']! as List, ApplicationIntegrationType.parse),
+      contexts: maybeParseMany(raw['contexts'], InteractionContextType.parse),
       version: Snowflake.parse(raw['version']!),
     );
   }

--- a/lib/src/http/managers/application_command_manager.dart
+++ b/lib/src/http/managers/application_command_manager.dart
@@ -60,7 +60,7 @@ abstract class ApplicationCommandManager extends Manager<ApplicationCommand> {
       hasDmPermission: raw['dm_permission'] as bool?,
       isNsfw: raw['nsfw'] as bool?,
       integrationTypes: (raw['integration_types'] as List).cast<int>().map(ApplicationIntegrationType.parse).toList(),
-      contexts: (raw['contexts'] as List).cast<int>().map(InteractionContextType.parse).toList(),
+      contexts: (raw['contexts'] as List? ?? []).cast<int>().map(InteractionContextType.parse).toList(),
       version: Snowflake.parse(raw['version']!),
     );
   }

--- a/lib/src/http/managers/application_manager.dart
+++ b/lib/src/http/managers/application_manager.dart
@@ -61,6 +61,10 @@ class ApplicationManager {
       tags: maybeParseMany(raw['tags']),
       installationParameters: maybeParse(raw['install_params'], parseInstallationParameters),
       customInstallUrl: maybeParse(raw['custom_install_url'], Uri.parse),
+      integrationTypesConfig: maybeParse(
+          raw['integration_types_config'],
+          (config) => (config as Map).cast<String, Object?>().map((key, value) =>
+              MapEntry(ApplicationIntegrationType.parse(int.parse(key)), parseApplicationIntegrationTypeConfiguration((value as Map).cast<String, Object>())))),
       roleConnectionsVerificationUrl: maybeParse(raw['role_connections_verification_url'], Uri.parse),
     );
   }
@@ -93,6 +97,12 @@ class ApplicationManager {
       scopes: parseMany(raw['scopes'] as List),
       permissions: Permissions(int.parse(raw['permissions'] as String)),
     );
+  }
+
+  /// Parse a [ApplicationIntegrationTypeConfiguration] from [raw].
+  ApplicationIntegrationTypeConfiguration parseApplicationIntegrationTypeConfiguration(Map<String, Object?> raw) {
+    return ApplicationIntegrationTypeConfiguration(
+        oauth2InstallParameters: parseInstallationParameters((raw['oauth2_install_params'] as Map).cast<String, Object>()));
   }
 
   /// Parse a [ApplicationRoleConnectionMetadata] from [raw].

--- a/lib/src/http/managers/application_manager.dart
+++ b/lib/src/http/managers/application_manager.dart
@@ -62,9 +62,12 @@ class ApplicationManager {
       installationParameters: maybeParse(raw['install_params'], parseInstallationParameters),
       customInstallUrl: maybeParse(raw['custom_install_url'], Uri.parse),
       integrationTypesConfig: maybeParse(
-          raw['integration_types_config'],
-          (config) => (config as Map).cast<String, Object?>().map((key, value) =>
-              MapEntry(ApplicationIntegrationType.parse(int.parse(key)), parseApplicationIntegrationTypeConfiguration((value as Map).cast<String, Object>())))),
+        raw['integration_types_config'],
+        (Map<String, Object?> config) => {
+          for (final MapEntry(:key, :value) in config.entries)
+            ApplicationIntegrationType.parse(int.parse(key)): parseApplicationIntegrationTypeConfiguration(value as Map<String, Object?>)
+        },
+      ),
       roleConnectionsVerificationUrl: maybeParse(raw['role_connections_verification_url'], Uri.parse),
     );
   }

--- a/lib/src/http/managers/application_manager.dart
+++ b/lib/src/http/managers/application_manager.dart
@@ -102,7 +102,8 @@ class ApplicationManager {
   /// Parse a [ApplicationIntegrationTypeConfiguration] from [raw].
   ApplicationIntegrationTypeConfiguration parseApplicationIntegrationTypeConfiguration(Map<String, Object?> raw) {
     return ApplicationIntegrationTypeConfiguration(
-        oauth2InstallParameters: parseInstallationParameters((raw['oauth2_install_params'] as Map).cast<String, Object>()));
+      oauth2InstallParameters: maybeParse(raw['oauth2_install_params'], parseInstallationParameters),
+    );
   }
 
   /// Parse a [ApplicationRoleConnectionMetadata] from [raw].

--- a/lib/src/http/managers/interaction_manager.dart
+++ b/lib/src/http/managers/interaction_manager.dart
@@ -49,7 +49,7 @@ class InteractionManager {
       raw['message'],
       (Map<String, Object?> raw) => (client.channels[channelId!] as PartialTextChannel).messages.parse(raw, guildId: guildId),
     );
-    final appPermissions = maybeParse(raw['app_permissions'], (String raw) => Permissions(int.parse(raw)));
+    final appPermissions = Permissions(int.parse(raw['app_permissions'] as String));
     final locale = maybeParse(raw['locale'], Locale.parse);
     final guildLocale = maybeParse(raw['guild_locale'], Locale.parse);
     final entitlements = parseMany(raw['entitlements'] as List, client.applications[applicationId].entitlements.parse);

--- a/lib/src/http/managers/interaction_manager.dart
+++ b/lib/src/http/managers/interaction_manager.dart
@@ -55,10 +55,11 @@ class InteractionManager {
     final entitlements = parseMany(raw['entitlements'] as List, client.applications[applicationId].entitlements.parse);
 
     final authorizingIntegrationOwners = maybeParse(
-            raw['authorizing_integration_owners'],
-            (map) =>
-                (map as Map).cast<String, Object>().map((key, value) => MapEntry(ApplicationIntegrationType.parse(int.parse(key)), Snowflake.parse(value)))) ??
-        {};
+      raw['authorizing_integration_owners'],
+      (Map<String, Object?> map) => {
+        for (final MapEntry(:key, :value) in map.entries) ApplicationIntegrationType.parse(int.parse(key)): Snowflake.parse(value!),
+      },
+    );
     final context = maybeParse(raw['context'], InteractionContextType.parse);
 
     return switch (type) {

--- a/lib/src/http/managers/interaction_manager.dart
+++ b/lib/src/http/managers/interaction_manager.dart
@@ -7,6 +7,7 @@ import 'package:nyxx/src/builders/sentinels.dart';
 import 'package:nyxx/src/client.dart';
 import 'package:nyxx/src/http/request.dart';
 import 'package:nyxx/src/http/route.dart';
+import 'package:nyxx/src/models/application.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/text_channel.dart';
 import 'package:nyxx/src/models/commands/application_command.dart';
@@ -53,6 +54,13 @@ class InteractionManager {
     final guildLocale = maybeParse(raw['guild_locale'], Locale.parse);
     final entitlements = parseMany(raw['entitlements'] as List, client.applications[applicationId].entitlements.parse);
 
+    final authorizingIntegrationOwners = maybeParse(
+            raw['authorizing_integration_owners'],
+            (map) =>
+                (map as Map).cast<String, Object>().map((key, value) => MapEntry(ApplicationIntegrationType.parse(int.parse(key)), Snowflake.parse(value)))) ??
+        {};
+    final context = maybeParse(raw['context'], InteractionContextType.parse);
+
     return switch (type) {
       InteractionType.ping => PingInteraction(
           manager: this,
@@ -71,6 +79,8 @@ class InteractionManager {
           locale: locale,
           guildLocale: guildLocale,
           entitlements: entitlements,
+          authorizingIntegrationOwners: authorizingIntegrationOwners,
+          context: context,
         ),
       InteractionType.applicationCommand => ApplicationCommandInteraction(
           manager: this,
@@ -90,6 +100,8 @@ class InteractionManager {
           locale: locale,
           guildLocale: guildLocale,
           entitlements: entitlements,
+          authorizingIntegrationOwners: authorizingIntegrationOwners,
+          context: context,
         ),
       InteractionType.messageComponent => MessageComponentInteraction(
           manager: this,
@@ -109,6 +121,8 @@ class InteractionManager {
           locale: locale,
           guildLocale: guildLocale,
           entitlements: entitlements,
+          authorizingIntegrationOwners: authorizingIntegrationOwners,
+          context: context,
         ),
       InteractionType.modalSubmit => ModalSubmitInteraction(
           manager: this,
@@ -128,6 +142,8 @@ class InteractionManager {
           locale: locale,
           guildLocale: guildLocale,
           entitlements: entitlements,
+          authorizingIntegrationOwners: authorizingIntegrationOwners,
+          context: context,
         ),
       InteractionType.applicationCommandAutocomplete => ApplicationCommandAutocompleteInteraction(
           manager: this,
@@ -147,6 +163,8 @@ class InteractionManager {
           locale: locale,
           guildLocale: guildLocale,
           entitlements: entitlements,
+          authorizingIntegrationOwners: authorizingIntegrationOwners,
+          context: context,
         ),
     } as Interaction;
   }

--- a/lib/src/http/managers/message_manager.dart
+++ b/lib/src/http/managers/message_manager.dart
@@ -81,6 +81,10 @@ class MessageManager extends Manager<Message> {
         raw['interaction'],
         (Map<String, Object?> raw) => parseMessageInteraction(raw, guildId: guildId),
       ),
+      interactionMetadata: maybeParse(
+        raw['interaction_metadata'],
+        (Map<dynamic, dynamic> raw) => parseMessageInteractionMetadata(raw.cast()),
+      ),
       thread: maybeParse(raw['thread'], client.channels.parse) as Thread?,
       components: maybeParseMany(raw['components'], parseMessageComponent),
       position: raw['position'] as int?,
@@ -299,9 +303,11 @@ class MessageManager extends Manager<Message> {
     );
   }
 
+  // ignore: deprecated_member_use_from_same_package
   MessageInteraction parseMessageInteraction(Map<String, Object?> raw, {Snowflake? guildId}) {
     final user = client.users.parse(raw['user'] as Map<String, Object?>);
 
+    // ignore: deprecated_member_use_from_same_package
     return MessageInteraction(
       id: Snowflake.parse(raw['id']!),
       type: InteractionType.parse(raw['type'] as int),
@@ -311,6 +317,20 @@ class MessageManager extends Manager<Message> {
         raw['member'],
         (Map<String, Object?> raw) => client.guilds[guildId ?? Snowflake.zero].members[user.id],
       ),
+    );
+  }
+
+  MessageInteractionMetadata parseMessageInteractionMetadata(Map<String, Object?> raw) {
+    return MessageInteractionMetadata(
+      id: Snowflake.parse(raw['id']!),
+      type: InteractionType.parse(raw['type'] as int),
+      userId: Snowflake.parse(raw['user_id']!),
+      authorizingIntegrationOwners: (raw['authorizing_integration_owners'] as Map)
+          .cast<String, Object>()
+          .map((key, value) => MapEntry(ApplicationIntegrationType.parse(int.parse(key)), Snowflake.parse(value))),
+      originalResponseMessageId: maybeParse(raw['original_response_message_id'], Snowflake.parse),
+      interactedMessageId: maybeParse(raw['interacted_message_id'], Snowflake.parse),
+      triggeringInteractionMetadata: maybeParse(raw['triggering_interaction_metadata'], parseMessageInteractionMetadata),
     );
   }
 

--- a/lib/src/http/managers/message_manager.dart
+++ b/lib/src/http/managers/message_manager.dart
@@ -83,7 +83,7 @@ class MessageManager extends Manager<Message> {
       ),
       interactionMetadata: maybeParse(
         raw['interaction_metadata'],
-        (Map<dynamic, dynamic> raw) => parseMessageInteractionMetadata(raw.cast()),
+        parseMessageInteractionMetadata,
       ),
       thread: maybeParse(raw['thread'], client.channels.parse) as Thread?,
       components: maybeParseMany(raw['components'], parseMessageComponent),
@@ -325,9 +325,10 @@ class MessageManager extends Manager<Message> {
       id: Snowflake.parse(raw['id']!),
       type: InteractionType.parse(raw['type'] as int),
       userId: Snowflake.parse(raw['user_id']!),
-      authorizingIntegrationOwners: (raw['authorizing_integration_owners'] as Map)
-          .cast<String, Object>()
-          .map((key, value) => MapEntry(ApplicationIntegrationType.parse(int.parse(key)), Snowflake.parse(value))),
+      authorizingIntegrationOwners: {
+        for (final MapEntry(:key, :value) in (raw['authorizing_integration_owners'] as Map<String, Object?>).entries)
+          ApplicationIntegrationType.parse(int.parse(key)): Snowflake.parse(value!),
+      },
       originalResponseMessageId: maybeParse(raw['original_response_message_id'], Snowflake.parse),
       interactedMessageId: maybeParse(raw['interacted_message_id'], Snowflake.parse),
       triggeringInteractionMetadata: maybeParse(raw['triggering_interaction_metadata'], parseMessageInteractionMetadata),

--- a/lib/src/models/application.dart
+++ b/lib/src/models/application.dart
@@ -41,7 +41,7 @@ class PartialApplication with ToStringHelper {
 
 class ApplicationIntegrationTypeConfiguration {
   /// Install params for each installation context's default in-app authorization link.
-  final InstallationParameters oauth2InstallParameters;
+  final InstallationParameters? oauth2InstallParameters;
 
   /// @nodoc
   ApplicationIntegrationTypeConfiguration({required this.oauth2InstallParameters});

--- a/lib/src/models/application.dart
+++ b/lib/src/models/application.dart
@@ -39,6 +39,14 @@ class PartialApplication with ToStringHelper {
   Future<List<Sku>> listSkus() => manager.listSkus(id);
 }
 
+class ApplicationIntegrationTypeConfiguration {
+  /// Install params for each installation context's default in-app authorization link.
+  final InstallationParameters oauth2InstallParameters;
+
+  /// @nodoc
+  ApplicationIntegrationTypeConfiguration({required this.oauth2InstallParameters});
+}
+
 /// {@template application}
 /// An OAuth2 application.
 /// {@endtemplate}
@@ -112,6 +120,9 @@ class Application extends PartialApplication {
   /// Settings for this application's default authorization link.
   final InstallationParameters? installationParameters;
 
+  /// Default scopes and permissions for each supported installation context.
+  final Map<ApplicationIntegrationType, ApplicationIntegrationTypeConfiguration>? integrationTypesConfig;
+
   /// The custom authorization link for this application.
   final Uri? customInstallUrl;
 
@@ -148,6 +159,7 @@ class Application extends PartialApplication {
     required this.interactionsEndpointUrl,
     required this.tags,
     required this.installationParameters,
+    required this.integrationTypesConfig,
     required this.customInstallUrl,
     required this.roleConnectionsVerificationUrl,
   });
@@ -169,6 +181,30 @@ class Application extends PartialApplication {
           base: HttpRoute()..appIcons(id: id.toString()),
           hash: coverImageHash!,
         );
+}
+
+enum ApplicationIntegrationType {
+  /// App is installable to servers.
+  guildInstall._(0),
+
+  /// App is installable to users.
+  userInstall._(1);
+
+  /// The value of this [ApplicationIntegrationType].
+  final int value;
+
+  const ApplicationIntegrationType._(this.value);
+
+  /// Parse an [ApplicationIntegrationType] from an [int].
+  ///
+  /// The [value] must be a valid application integration type.
+  factory ApplicationIntegrationType.parse(int value) => ApplicationIntegrationType.values.firstWhere(
+        (type) => type.value == value,
+        orElse: () => throw FormatException('Unknown ApplicationIntegrationType', value),
+      );
+
+  @override
+  String toString() => 'ApplicationIntegrationType($value)';
 }
 
 /// Flags for an [Application].

--- a/lib/src/models/commands/application_command.dart
+++ b/lib/src/models/commands/application_command.dart
@@ -66,7 +66,7 @@ class ApplicationCommand extends PartialApplicationCommand {
   final List<ApplicationIntegrationType> integrationTypes;
 
   /// Interaction context(s) where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
-  final List<InteractionContextType> contexts;
+  final List<InteractionContextType>? contexts;
 
   /// An auto-incrementing version number.
   final Snowflake version;

--- a/lib/src/models/commands/application_command.dart
+++ b/lib/src/models/commands/application_command.dart
@@ -65,7 +65,7 @@ class ApplicationCommand extends PartialApplicationCommand {
   /// Installation context(s) where the command is available, only for globally-scoped commands. Defaults to [InteractionContextType.guildInstall].
   final List<ApplicationIntegrationType> integrationTypes;
 
-  /// Interaction context(s) where the command can be used, only for globally-scoped commands. By default, all interaction context types included.
+  /// Interaction context(s) where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
   final List<InteractionContextType> contexts;
 
   /// An auto-incrementing version number.

--- a/lib/src/models/commands/application_command.dart
+++ b/lib/src/models/commands/application_command.dart
@@ -3,6 +3,7 @@ import 'package:nyxx/src/models/application.dart';
 import 'package:nyxx/src/models/commands/application_command_option.dart';
 import 'package:nyxx/src/models/commands/application_command_permissions.dart';
 import 'package:nyxx/src/models/guild/guild.dart';
+import 'package:nyxx/src/models/interaction.dart';
 import 'package:nyxx/src/models/locale.dart';
 import 'package:nyxx/src/models/permissions.dart';
 import 'package:nyxx/src/models/snowflake.dart';
@@ -55,10 +56,17 @@ class ApplicationCommand extends PartialApplicationCommand {
   final Permissions? defaultMemberPermissions;
 
   /// Whether this command can be ran in DMs.
+  @Deprecated('Use `contexts`')
   final bool? hasDmPermission;
 
   /// Whether this command is NSFW.
   final bool? isNsfw;
+
+  /// Installation context(s) where the command is available, only for globally-scoped commands. Defaults to [InteractionContextType.guildInstall].
+  final List<ApplicationIntegrationType> integrationTypes;
+
+  /// Interaction context(s) where the command can be used, only for globally-scoped commands. By default, all interaction context types included.
+  final List<InteractionContextType> contexts;
 
   /// An auto-incrementing version number.
   final Snowflake version;
@@ -79,6 +87,8 @@ class ApplicationCommand extends PartialApplicationCommand {
     required this.defaultMemberPermissions,
     required this.hasDmPermission,
     required this.isNsfw,
+    required this.integrationTypes,
+    required this.contexts,
     required this.version,
   });
 

--- a/lib/src/models/interaction.dart
+++ b/lib/src/models/interaction.dart
@@ -109,7 +109,7 @@ abstract class Interaction<T> with ToStringHelper {
   final List<Entitlement> entitlements;
 
   /// Mapping of installation contexts that the interaction was authorized for to related user or guild IDs.
-  final Map<ApplicationIntegrationType, Snowflake> authorizingIntegrationOwners;
+  final Map<ApplicationIntegrationType, Snowflake>? authorizingIntegrationOwners;
 
   /// Context where the interaction was triggered from.
   final InteractionContextType? context;

--- a/lib/src/models/interaction.dart
+++ b/lib/src/models/interaction.dart
@@ -97,7 +97,7 @@ abstract class Interaction<T> with ToStringHelper {
   final Message? message;
 
   /// The permissions of the application that triggered this interaction.
-  final Permissions? appPermissions;
+  final Permissions appPermissions;
 
   /// The preferred locale of the user that triggered this interaction.
   final Locale? locale;

--- a/lib/src/models/interaction.dart
+++ b/lib/src/models/interaction.dart
@@ -4,6 +4,7 @@ import 'package:nyxx/src/builders/interaction_response.dart';
 import 'package:nyxx/src/builders/message/message.dart';
 import 'package:nyxx/src/errors.dart';
 import 'package:nyxx/src/http/managers/interaction_manager.dart';
+import 'package:nyxx/src/models/application.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/commands/application_command.dart';
 import 'package:nyxx/src/models/commands/application_command_option.dart';
@@ -19,6 +20,37 @@ import 'package:nyxx/src/models/role.dart';
 import 'package:nyxx/src/models/snowflake.dart';
 import 'package:nyxx/src/models/user/user.dart';
 import 'package:nyxx/src/utils/to_string_helper/to_string_helper.dart';
+
+/// A language locale available in the Discord client.
+///
+/// External references:
+/// * Discord API Reference: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-context-types
+enum InteractionContextType {
+  /// Interaction can be used within servers.
+  guild._(0),
+
+  /// Interaction can be used within DMs with the app's bot user.
+  botDm._(1),
+
+  /// Interaction can be used within Group DMs and DMs other than the app's bot user.
+  privateChannel._(2);
+
+  /// The value of this [InteractionContextType].
+  final int value;
+
+  const InteractionContextType._(this.value);
+
+  /// Parse an [InteractionContextType] from an [int].
+  ///
+  /// The [value] must be a valid interaction context type.
+  factory InteractionContextType.parse(int value) => InteractionContextType.values.firstWhere(
+        (type) => type.value == value,
+        orElse: () => throw FormatException('Unknown InteractionContextType', value),
+      );
+
+  @override
+  String toString() => 'InteractionContextType($value)';
+}
 
 /// {@template interaction}
 /// An interaction sent by Discord when a user interacts with an [ApplicationCommand], a [MessageComponent]
@@ -76,6 +108,12 @@ abstract class Interaction<T> with ToStringHelper {
   /// The entitlements for the user and guild of this interaction.
   final List<Entitlement> entitlements;
 
+  /// Mapping of installation contexts that the interaction was authorized for to related user or guild IDs.
+  final Map<ApplicationIntegrationType, Snowflake> authorizingIntegrationOwners;
+
+  /// Context where the interaction was triggered from.
+  final InteractionContextType? context;
+
   /// {@macro interaction}
   /// @nodoc
   Interaction({
@@ -96,6 +134,8 @@ abstract class Interaction<T> with ToStringHelper {
     required this.locale,
     required this.guildLocale,
     required this.entitlements,
+    required this.authorizingIntegrationOwners,
+    required this.context,
   });
 
   /// The guild in which this interaction was triggered.
@@ -200,6 +240,8 @@ class PingInteraction extends Interaction<void> {
     required super.locale,
     required super.guildLocale,
     required super.entitlements,
+    required super.authorizingIntegrationOwners,
+    required super.context,
   }) : super(data: null);
 
   /// Send a pong response to this interaction.
@@ -231,6 +273,8 @@ class ApplicationCommandInteraction extends Interaction<ApplicationCommandIntera
     required super.locale,
     required super.guildLocale,
     required super.entitlements,
+    required super.authorizingIntegrationOwners,
+    required super.context,
   });
 }
 
@@ -259,6 +303,8 @@ class MessageComponentInteraction extends Interaction<MessageComponentInteractio
     required super.locale,
     required super.guildLocale,
     required super.entitlements,
+    required super.authorizingIntegrationOwners,
+    required super.context,
   });
 
   bool? _didUpdateMessage;
@@ -342,6 +388,8 @@ class ModalSubmitInteraction extends Interaction<ModalSubmitInteractionData> wit
     required super.locale,
     required super.guildLocale,
     required super.entitlements,
+    required super.authorizingIntegrationOwners,
+    required super.context,
   });
 }
 
@@ -369,6 +417,8 @@ class ApplicationCommandAutocompleteInteraction extends Interaction<ApplicationC
     required super.locale,
     required super.guildLocale,
     required super.entitlements,
+    required super.authorizingIntegrationOwners,
+    required super.context,
   });
 
   /// Send a response to this interaction.

--- a/lib/src/models/message/message.dart
+++ b/lib/src/models/message/message.dart
@@ -167,6 +167,10 @@ class Message extends PartialMessage {
   final Message? referencedMessage;
 
   /// Information about the interaction related to this message.
+  final MessageInteractionMetadata? interactionMetadata;
+
+  /// Information about the interaction related to this message.
+  // ignore: deprecated_member_use_from_same_package
   final MessageInteraction? interaction;
 
   /// The thread that was started from this message if any, `null` otherwise.
@@ -216,6 +220,7 @@ class Message extends PartialMessage {
     required this.reference,
     required this.flags,
     required this.referencedMessage,
+    required this.interactionMetadata,
     required this.interaction,
     required this.thread,
     required this.components,
@@ -364,6 +369,8 @@ class MessageFlags extends Flags<MessageFlags> {
   const MessageFlags(super.value);
 }
 
+@Deprecated('Use MessageInteractionMetadata')
+
 /// {@template message_interaction}
 /// Information about an interaction associated with a message.
 /// {@endtemplate}
@@ -391,5 +398,43 @@ class MessageInteraction with ToStringHelper {
     required this.name,
     required this.user,
     required this.member,
+  });
+}
+
+/// {@template message_interaction_metadata}
+/// Metadata about the interaction, including the source of the interaction and relevant server and user IDs.
+/// {@endtemplate}
+class MessageInteractionMetadata with ToStringHelper {
+  /// The ID of the interaction.
+  final Snowflake id;
+
+  /// The type of the interaction.
+  final InteractionType type;
+
+  /// ID of the user that triggered the interaction.
+  final Snowflake userId;
+
+  /// IDs for installation context(s) related to an interaction.
+  final Map<ApplicationIntegrationType, Snowflake> authorizingIntegrationOwners;
+
+  /// ID of the original response message, present only on follow-up messages.
+  final Snowflake? originalResponseMessageId;
+
+  /// ID of the message that contained interactive component, present only on messages created from component interactions.
+  final Snowflake? interactedMessageId;
+
+  /// Metadata for the interaction that was used to open the modal, present only on modal submit interactions
+  final MessageInteractionMetadata? triggeringInteractionMetadata;
+
+  /// {@macro message_interaction_metadata}
+  /// @nodoc
+  MessageInteractionMetadata({
+    required this.id,
+    required this.type,
+    required this.userId,
+    required this.authorizingIntegrationOwners,
+    required this.originalResponseMessageId,
+    required this.interactedMessageId,
+    required this.triggeringInteractionMetadata,
   });
 }

--- a/lib/src/models/message/message.dart
+++ b/lib/src/models/message/message.dart
@@ -171,6 +171,7 @@ class Message extends PartialMessage {
 
   /// Information about the interaction related to this message.
   // ignore: deprecated_member_use_from_same_package
+  @Deprecated('Use `interactionMetadata`')
   final MessageInteraction? interaction;
 
   /// The thread that was started from this message if any, `null` otherwise.

--- a/lib/src/models/oauth2.dart
+++ b/lib/src/models/oauth2.dart
@@ -14,5 +14,6 @@ class OAuth2Information {
   /// The user who has authorized, if the user has authorized with the `identify` scope.
   final User? user;
 
+  /// @nodoc
   OAuth2Information({required this.application, required this.scopes, required this.expiresOn, this.user});
 }

--- a/lib/src/utils/cache_helpers.dart
+++ b/lib/src/utils/cache_helpers.dart
@@ -129,6 +129,7 @@ extension CacheUpdates on NyxxRest {
             members.forEach(updateCacheWith);
           }(),
         ThreadMember(:final member) => updateCacheWith(member),
+        // ignore: deprecated_member_use_from_same_package
         MessageInteraction(:final user) => updateCacheWith(user),
         ResolvedData(:final users, :final roles, :final members) => () {
             users?.values.forEach(updateCacheWith);

--- a/test/unit/http/managers/application_command_manager_test.dart
+++ b/test/unit/http/managers/application_command_manager_test.dart
@@ -14,24 +14,39 @@ final sampleCommand = {
   "description": "Ping the bot",
   "description_localizations": null,
   "dm_permission": true,
-  "contexts": null,
   "nsfw": false,
+  "integration_types": [0, 1],
+  "contexts": [0, 1, 2],
 };
 
 void checkCommand(ApplicationCommand command) {
   expect(command.id, equals(Snowflake(1102343284505968762)));
-  expect(command.type, equals(ApplicationCommandType.chatInput));
   expect(command.applicationId, equals(Snowflake(1033681843708510238)));
-  expect(command.guildId, isNull);
+  expect(command.version, equals(Snowflake(1107729458535878799)));
+  expect(command.defaultMemberPermissions, isNull);
+  expect(command.type, equals(ApplicationCommandType.chatInput));
   expect(command.name, equals('ping'));
   expect(command.nameLocalizations, isNull);
   expect(command.description, equals('Ping the bot'));
   expect(command.descriptionLocalizations, isNull);
+  expect(command.guildId, isNull);
   expect(command.options, isNull);
-  expect(command.defaultMemberPermissions, isNull);
+  // ignore: deprecated_member_use_from_same_package
   expect(command.hasDmPermission, isTrue);
   expect(command.isNsfw, isFalse);
-  expect(command.version, equals(Snowflake(1107729458535878799)));
+  expect(
+      command.integrationTypes,
+      equals([
+        ApplicationIntegrationType.guildInstall,
+        ApplicationIntegrationType.userInstall,
+      ]));
+  expect(
+      command.contexts,
+      equals([
+        InteractionContextType.guild,
+        InteractionContextType.botDm,
+        InteractionContextType.privateChannel,
+      ]));
 }
 
 final sampleCommandPermissions = {

--- a/test/unit/http/managers/interaction_manager_test.dart
+++ b/test/unit/http/managers/interaction_manager_test.dart
@@ -38,6 +38,11 @@ final sampleCommandInteraction = {
   },
   "channel_id": "645027906669510667",
   "entitlements": [],
+  "authorizing_integration_owners": {
+    "0": "846136758470443069",
+    "1": "302359032612651009",
+  },
+  "context": 0,
 
   // Fields not present in the example but documented
   "application_id": "0",
@@ -63,6 +68,13 @@ void checkCommandInteraction(Interaction<dynamic> interaction) {
   expect(interaction.locale, equals(Locale.enUs));
   expect(interaction.guildLocale, equals(Locale.enUs));
   expect(interaction.entitlements, equals([]));
+  expect(
+      interaction.authorizingIntegrationOwners,
+      equals({
+        ApplicationIntegrationType.guildInstall: Snowflake(846136758470443069),
+        ApplicationIntegrationType.userInstall: Snowflake(302359032612651009),
+      }));
+  expect(interaction.context, equals(InteractionContextType.guild));
 }
 
 final sampleCommandInteraction2 = {
@@ -157,6 +169,10 @@ final sampleCommandInteraction2 = {
   },
   "application_id": "1033681843708510238",
   "app_permissions": "562949953421311",
+  "authorizing_integration_owners": {
+    "0": "846136758470443069",
+    "1": "302359032612651009",
+  },
 };
 
 void checkCommandInteraction2(Interaction<dynamic> interaction) {

--- a/test/unit/http/managers/message_manager_test.dart
+++ b/test/unit/http/managers/message_manager_test.dart
@@ -140,6 +140,55 @@ void checkCrosspostedMessage(Message message) {
   expect(message.roleSubscriptionData, isNull);
 }
 
+final sampleMessageInteractionMetadata = {
+  "id": "1234567891234567800",
+  "type": 2,
+  "user_id": "1234567891234567801",
+  "authorizing_integration_owners": {
+    "0": "1234567891234567802",
+    "1": "1234567891234567803",
+  },
+  "original_response_message_id": "1234567891234567804",
+  "interacted_message_id": "1234567891234567805",
+  "triggering_interaction_metadata": {
+    "id": "1234567891234567806",
+    "type": 2,
+    "user_id": "1234567891234567807",
+    "authorizing_integration_owners": {
+      "0": "1234567891234567808",
+      "1": "1234567891234567809",
+    },
+  },
+};
+
+void checkMessageInteractionMetadata(MessageInteractionMetadata metadata) {
+  expect(metadata.id, equals(Snowflake(1234567891234567800)));
+  expect(metadata.type, equals(InteractionType.applicationCommand));
+  expect(metadata.userId, equals(Snowflake(1234567891234567801)));
+  expect(
+      metadata.authorizingIntegrationOwners,
+      equals({
+        ApplicationIntegrationType.guildInstall: Snowflake(1234567891234567802),
+        ApplicationIntegrationType.userInstall: Snowflake(1234567891234567803),
+      }));
+  expect(metadata.originalResponseMessageId, Snowflake(1234567891234567804));
+  expect(metadata.interactedMessageId, Snowflake(1234567891234567805));
+  expect(metadata.triggeringInteractionMetadata, isNotNull);
+  MessageInteractionMetadata metadata2 = metadata.triggeringInteractionMetadata!;
+  expect(metadata2.id, equals(Snowflake(1234567891234567806)));
+  expect(metadata2.type, equals(InteractionType.applicationCommand));
+  expect(metadata2.userId, equals(Snowflake(1234567891234567807)));
+  expect(
+      metadata2.authorizingIntegrationOwners,
+      equals({
+        ApplicationIntegrationType.guildInstall: Snowflake(1234567891234567808),
+        ApplicationIntegrationType.userInstall: Snowflake(1234567891234567809),
+      }));
+  expect(metadata2.originalResponseMessageId, isNull);
+  expect(metadata2.interactedMessageId, isNull);
+  expect(metadata2.triggeringInteractionMetadata, isNull);
+}
+
 void main() {
   testManager<Message, MessageManager>(
     'MessageManager',
@@ -152,7 +201,14 @@ void main() {
     additionalSampleMatchers: [checkCrosspostedMessage],
     createBuilder: MessageBuilder(),
     updateBuilder: MessageUpdateBuilder(),
-    additionalParsingTests: [],
+    additionalParsingTests: [
+      ParsingTest<MessageManager, MessageInteractionMetadata, Map<String, Object?>>(
+        name: 'parseMessageInteractionMetadata',
+        source: sampleMessageInteractionMetadata,
+        parse: (manager) => manager.parseMessageInteractionMetadata,
+        check: checkMessageInteractionMetadata,
+      ),
+    ],
     additionalEndpointTests: [
       EndpointTest<MessageManager, List<Message>, List<Object?>>(
         name: 'fetchMany',


### PR DESCRIPTION
# Description

- Add `integrationTypes`/`context` to Interaction
- Add `integrationTypesConfig` to Application
- Add `integrationTypes`/`contexts` to ApplicationCommandBuilder/ApplicationCommandUpdateBuilder
- Deprecate `MessageInteraction`, and `message.interaction`
- `Interaction.appPermissions` is no longer null
- Add tests 

PRs:
- https://github.com/discord/discord-api-docs/pull/6723
- https://github.com/discord/discord-api-docs/pull/6726
- https://github.com/discord/discord-api-docs/pull/6727
- https://github.com/discord/discord-api-docs/pull/6728

Breaking changes are made by Discord

## Connected issues & other potential problems

Probably `nyxx_commands`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
