### PR TITLE
Fix case where `ApplicationCommand.integrationTypes` is null

### DIFF
--- a/lib/src/http/managers/application_command_manager.dart
+++ b/lib/src/http/managers/application_command_manager.dart
@@ -59,7 +59,7 @@ abstract class ApplicationCommandManager extends Manager<ApplicationCommand> {
       defaultMemberPermissions: maybeParse(raw['default_member_permissions'], (String raw) => Permissions(int.parse(raw))),
       hasDmPermission: raw['dm_permission'] as bool?,
       isNsfw: raw['nsfw'] as bool?,
-      integrationTypes: maybeParseMany(raw['integration_types'], ApplicationIntegrationType.parse) ?? [],
+      integrationTypes: maybeParseMany(raw['integration_types'], ApplicationIntegrationType.parse) ?? [ApplicationIntegrationType.guildInstall],
       contexts: maybeParseMany(raw['contexts'], InteractionContextType.parse),
       version: Snowflake.parse(raw['version']!),
     );

--- a/lib/src/http/managers/application_command_manager.dart
+++ b/lib/src/http/managers/application_command_manager.dart
@@ -59,7 +59,7 @@ abstract class ApplicationCommandManager extends Manager<ApplicationCommand> {
       defaultMemberPermissions: maybeParse(raw['default_member_permissions'], (String raw) => Permissions(int.parse(raw))),
       hasDmPermission: raw['dm_permission'] as bool?,
       isNsfw: raw['nsfw'] as bool?,
-      integrationTypes: parseMany(raw['integration_types']! as List, ApplicationIntegrationType.parse),
+      integrationTypes: maybeParseMany(raw['integration_types'], ApplicationIntegrationType.parse) ?? [],
       contexts: maybeParseMany(raw['contexts'], InteractionContextType.parse),
       version: Snowflake.parse(raw['version']!),
     );


### PR DESCRIPTION

# Description

<title>

[Docs](https://github.com/discord/discord-api-docs/blob/main/docs%2Finteractions%2FApplication_Commands.md#Application_Command_Structure)

## Connected issues & other potential problems

None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
