### PR TITLE
Add warning for rate limits

### DIFF
--- a/lib/src/client_options.dart
+++ b/lib/src/client_options.dart
@@ -33,8 +33,20 @@ abstract class ClientOptions {
   /// The logger to use for this client.
   Logger get logger => Logger(loggerName);
 
+  /// The threshold after which a warning will be logged if a request is waiting for rate limits.
+  ///
+  /// If this value is `null`, no warnings are emitted when a long rate limit is encountered.
+  ///
+  /// This value is also used to prevent log spam. Requests will only emit a warning once per [rateLimitWarningThreshold], even if they are rate limited
+  /// multiple times during that period.
+  final Duration? rateLimitWarningThreshold;
+
   /// Create a new [ClientOptions].
-  const ClientOptions({this.plugins = const [], this.loggerName = 'Nyxx'});
+  const ClientOptions({
+    this.plugins = const [],
+    this.loggerName = 'Nyxx',
+    this.rateLimitWarningThreshold = const Duration(seconds: 10),
+  });
 }
 
 /// Options for controlling the behavior of a [NyxxRest] client.
@@ -100,6 +112,7 @@ class RestClientOptions extends ClientOptions {
   const RestClientOptions({
     super.plugins,
     super.loggerName,
+    super.rateLimitWarningThreshold,
     this.userCacheConfig = const CacheConfig(),
     this.channelCacheConfig = const CacheConfig(),
     this.messageCacheConfig = const CacheConfig(),
@@ -136,6 +149,7 @@ class GatewayClientOptions extends RestClientOptions {
     this.minimumSessionStarts = 10,
     super.plugins,
     super.loggerName,
+    super.rateLimitWarningThreshold,
     super.userCacheConfig,
     super.channelCacheConfig,
     super.messageCacheConfig,

--- a/lib/src/http/handler.dart
+++ b/lib/src/http/handler.dart
@@ -97,7 +97,34 @@ class HttpHandler {
   /// Create a new [HttpHandler].
   ///
   /// {@macro http_handler}
-  HttpHandler(this.client);
+  HttpHandler(this.client) {
+    if (client.options.rateLimitWarningThreshold case final threshold?) {
+      onRateLimit.listen((info) {
+        final (:request, :delay, :isGlobal, :isAnticipated) = info;
+        final requestStopwatch = _latencyStopwatches[request];
+        if (requestStopwatch == null) return;
+
+        final totalDelay = requestStopwatch.elapsed + delay;
+
+        // Prevent warnings being emitted too often. This limits warnings to once per [threshold].
+        if (totalDelay.inMicroseconds ~/ threshold.inMicroseconds <= requestStopwatch.elapsedMicroseconds ~/ threshold.inMicroseconds) return;
+
+        if (totalDelay > threshold) {
+          logger.warning(
+            '${request.loggingId} has been pending for ${requestStopwatch.elapsed} and will be sent in $delay due to rate limiting.'
+            ' The request will have been pending for $totalDelay.',
+          );
+          if (isAnticipated) {
+            logger.info('This is a predicted rate limit and was anticipated based on previous responses');
+          } else if (isGlobal) {
+            logger.info('This is a global rate limit and will apply to all requests for the next $delay');
+          } else {
+            logger.info('This rate limit was returned by the API');
+          }
+        }
+      });
+    }
+  }
 
   /// Send [request] to the API and return the response.
   ///


### PR DESCRIPTION
# Description

Adds a warning message that is triggered when a request is rate limited for a long period of time.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
