### PR TITLE
Add `guildId` to thread member

### DIFF
--- a/lib/src/http/managers/channel_manager.dart
+++ b/lib/src/http/managers/channel_manager.dart
@@ -665,7 +665,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
   }
 
   /// Fetch information about a member in a thread.
-  Future<ThreadMember> fetchThreadMember(Snowflake id, Snowflake memberId, {bool? withMember}) async {
+  Future<ThreadMember> fetchThreadMember(Snowflake id, Snowflake memberId, {bool? withMember, Snowflake? guildId}) async {
     final route = HttpRoute()
       ..channels(id: id.toString())
       ..threadMembers(id: memberId.toString());
@@ -677,13 +677,12 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     );
 
     final response = await client.httpHandler.executeSafe(request);
-    // TODO: Can we provide the guildId?
     // Don't update the cache since the guildId for the member will be Snowflake.zero
-    return parseThreadMember(response.jsonBody as Map<String, Object?>);
+    return parseThreadMember(response.jsonBody as Map<String, Object?>, guildId: guildId);
   }
 
   /// List the members of a thread.
-  Future<List<ThreadMember>> listThreadMembers(Snowflake id, {bool? withMembers, Snowflake? after, int? limit}) async {
+  Future<List<ThreadMember>> listThreadMembers(Snowflake id, {bool? withMembers, Snowflake? after, int? limit, Snowflake? guildId}) async {
     final route = HttpRoute()
       ..channels(id: id.toString())
       ..threadMembers();
@@ -697,13 +696,12 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     );
 
     final response = await client.httpHandler.executeSafe(request);
-    // TODO: Can we provide the guildId?
     // Don't update the cache since the guildId for the member will be Snowflake.zero
-    return parseMany(response.jsonBody as List, parseThreadMember);
+    return parseMany(response.jsonBody as List, (Map<String, Object?> raw) => parseThreadMember(raw, guildId: guildId));
   }
 
   /// List the public archived threads in a channel.
-  Future<ThreadList> listPublicArchivedThreads(Snowflake id, {DateTime? before, int? limit}) async {
+  Future<ThreadList> listPublicArchivedThreads(Snowflake id, {DateTime? before, int? limit, Snowflake? guildId}) async {
     final route = HttpRoute()
       ..channels(id: id.toString())
       ..threads()
@@ -718,15 +716,14 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     );
 
     final response = await client.httpHandler.executeSafe(request);
-    // TODO: Can we provide the guild ID?
-    final threadList = parseThreadList(response.jsonBody as Map<String, Object?>);
+    final threadList = parseThreadList(response.jsonBody as Map<String, Object?>, guildId: guildId);
 
     client.updateCacheWith(threadList);
     return threadList;
   }
 
   /// List the private archived threads in a channel.
-  Future<ThreadList> listPrivateArchivedThreads(Snowflake id, {DateTime? before, int? limit}) async {
+  Future<ThreadList> listPrivateArchivedThreads(Snowflake id, {DateTime? before, int? limit, Snowflake? guildId}) async {
     final route = HttpRoute()
       ..channels(id: id.toString())
       ..threads()
@@ -741,15 +738,14 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     );
 
     final response = await client.httpHandler.executeSafe(request);
-    // TODO: Can we provide the guild ID?
-    final threadList = parseThreadList(response.jsonBody as Map<String, Object?>);
+    final threadList = parseThreadList(response.jsonBody as Map<String, Object?>, guildId: guildId);
 
     client.updateCacheWith(threadList);
     return threadList;
   }
 
   /// List the private archived threads the current user has joined in a channel.
-  Future<ThreadList> listJoinedPrivateArchivedThreads(Snowflake id, {DateTime? before, int? limit}) async {
+  Future<ThreadList> listJoinedPrivateArchivedThreads(Snowflake id, {DateTime? before, int? limit, Snowflake? guildId}) async {
     final route = HttpRoute()
       ..channels(id: id.toString())
       ..users(id: '@me')
@@ -765,8 +761,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     );
 
     final response = await client.httpHandler.executeSafe(request);
-    // TODO: Can we provide the guild ID?
-    final threadList = parseThreadList(response.jsonBody as Map<String, Object?>);
+    final threadList = parseThreadList(response.jsonBody as Map<String, Object?>, guildId: guildId);
 
     client.updateCacheWith(threadList);
     return threadList;

--- a/lib/src/models/channel/thread.dart
+++ b/lib/src/models/channel/thread.dart
@@ -71,7 +71,7 @@ abstract class Thread implements TextChannel, GuildChannel {
   /// External reference:
   /// * [ChannelManager.fetchThreadMember]
   /// * Discord API References: https://discord.com/developers/docs/resources/channel#remove-thread-member
-  Future<ThreadMember> fetchThreadMember(Snowflake memberId);
+  Future<ThreadMember> fetchThreadMember(Snowflake memberId, {bool? withMember});
 
   /// List the members of this thread.
   ///

--- a/lib/src/models/channel/types/announcement_thread.dart
+++ b/lib/src/models/channel/types/announcement_thread.dart
@@ -125,11 +125,12 @@ class AnnouncementThread extends TextChannel implements Thread {
   Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadMember> fetchThreadMember(Snowflake memberId) => manager.fetchThreadMember(id, memberId);
+  Future<ThreadMember> fetchThreadMember(Snowflake memberId, {bool? withMember}) =>
+      manager.fetchThreadMember(id, memberId, guildId: guildId, withMember: withMember);
 
   @override
   Future<List<ThreadMember>> listThreadMembers({bool? withMembers, Snowflake? after, int? limit}) =>
-      manager.listThreadMembers(id, after: after, limit: limit, withMembers: withMembers);
+      manager.listThreadMembers(id, after: after, limit: limit, withMembers: withMembers, guildId: guildId);
 
   @override
   Future<void> removeThreadMember(Snowflake memberId) => manager.removeThreadMember(id, memberId);

--- a/lib/src/models/channel/types/forum.dart
+++ b/lib/src/models/channel/types/forum.dart
@@ -116,14 +116,16 @@ class ForumChannel extends Channel implements GuildChannel, ThreadsOnlyChannel {
   Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) => manager.listPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) =>
+      manager.listPrivateArchivedThreads(id, before: before, limit: limit, guildId: guildId);
 
   @override
-  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) => manager.listPublicArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) =>
+      manager.listPublicArchivedThreads(id, before: before, limit: limit, guildId: guildId);
 
   @override
   Future<ThreadList> listJoinedPrivateArchivedThreads({DateTime? before, int? limit}) =>
-      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit);
+      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit, guildId: guildId);
 
   @override
   Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);

--- a/lib/src/models/channel/types/guild_announcement.dart
+++ b/lib/src/models/channel/types/guild_announcement.dart
@@ -96,14 +96,16 @@ class GuildAnnouncementChannel extends TextChannel implements GuildChannel, HasT
   Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) => manager.listPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) =>
+      manager.listPrivateArchivedThreads(id, before: before, limit: limit, guildId: guildId);
 
   @override
-  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) => manager.listPublicArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) =>
+      manager.listPublicArchivedThreads(id, before: before, limit: limit, guildId: guildId);
 
   @override
   Future<ThreadList> listJoinedPrivateArchivedThreads({DateTime? before, int? limit}) =>
-      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit);
+      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit, guildId: guildId);
 
   @override
   Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);

--- a/lib/src/models/channel/types/guild_media.dart
+++ b/lib/src/models/channel/types/guild_media.dart
@@ -112,14 +112,16 @@ class GuildMediaChannel extends Channel implements GuildChannel, ThreadsOnlyChan
   Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) => manager.listPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) =>
+      manager.listPrivateArchivedThreads(id, before: before, limit: limit, guildId: guildId);
 
   @override
-  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) => manager.listPublicArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) =>
+      manager.listPublicArchivedThreads(id, before: before, limit: limit, guildId: guildId);
 
   @override
   Future<ThreadList> listJoinedPrivateArchivedThreads({DateTime? before, int? limit}) =>
-      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit);
+      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit, guildId: guildId);
 
   @override
   Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);

--- a/lib/src/models/channel/types/guild_text.dart
+++ b/lib/src/models/channel/types/guild_text.dart
@@ -96,14 +96,16 @@ class GuildTextChannel extends TextChannel implements GuildChannel, HasThreadsCh
   Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) => manager.listPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) =>
+      manager.listPrivateArchivedThreads(id, before: before, limit: limit, guildId: guildId);
 
   @override
-  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) => manager.listPublicArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) =>
+      manager.listPublicArchivedThreads(id, before: before, limit: limit, guildId: guildId);
 
   @override
   Future<ThreadList> listJoinedPrivateArchivedThreads({DateTime? before, int? limit}) =>
-      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit);
+      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit, guildId: guildId);
 
   @override
   Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);

--- a/lib/src/models/channel/types/private_thread.dart
+++ b/lib/src/models/channel/types/private_thread.dart
@@ -132,11 +132,12 @@ class PrivateThread extends TextChannel implements Thread {
   Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadMember> fetchThreadMember(Snowflake memberId) => manager.fetchThreadMember(id, memberId);
+  Future<ThreadMember> fetchThreadMember(Snowflake memberId, {bool? withMember}) =>
+      manager.fetchThreadMember(id, memberId, guildId: guildId, withMember: withMember);
 
   @override
   Future<List<ThreadMember>> listThreadMembers({bool? withMembers, Snowflake? after, int? limit}) =>
-      manager.listThreadMembers(id, after: after, limit: limit, withMembers: withMembers);
+      manager.listThreadMembers(id, after: after, limit: limit, withMembers: withMembers, guildId: guildId);
 
   @override
   Future<void> removeThreadMember(Snowflake memberId) => manager.removeThreadMember(id, memberId);

--- a/lib/src/models/channel/types/public_thread.dart
+++ b/lib/src/models/channel/types/public_thread.dart
@@ -129,11 +129,12 @@ class PublicThread extends TextChannel implements Thread {
   Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadMember> fetchThreadMember(Snowflake memberId) => manager.fetchThreadMember(id, memberId);
+  Future<ThreadMember> fetchThreadMember(Snowflake memberId, {bool? withMember}) =>
+      manager.fetchThreadMember(id, memberId, guildId: guildId, withMember: withMember);
 
   @override
   Future<List<ThreadMember>> listThreadMembers({bool? withMembers, Snowflake? after, int? limit}) =>
-      manager.listThreadMembers(id, after: after, limit: limit, withMembers: withMembers);
+      manager.listThreadMembers(id, after: after, limit: limit, withMembers: withMembers, guildId: guildId);
 
   @override
   Future<void> removeThreadMember(Snowflake memberId) => manager.removeThreadMember(id, memberId);


### PR DESCRIPTION
# Description
Adds the guild id to the thread member for the member manager.
This also adds `withMember` that was not present on fetchThreadMember


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
