### PR TITLE
Correctly encode the audit log header to a URI component

### DIFF
--- a/lib/src/http/request.dart
+++ b/lib/src/http/request.dart
@@ -74,7 +74,7 @@ abstract class HttpRequest {
 
   Map<String, String> _getHeaders(Nyxx client) => {
         userAgent: client.apiOptions.userAgent,
-        if (auditLogReason != null) xAuditLogReason: auditLogReason!,
+        if (auditLogReason != null) xAuditLogReason: Uri.encodeComponent(auditLogReason!),
         if (authenticated) authorization: client.apiOptions.authorizationHeader,
         ...headers,
       };


### PR DESCRIPTION
# Description
Audit log reason should now correctly handle UTF-8 strings.

Tests are still missing, I'm planning to do them tomorrow

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
