### PR TITLE
Remove `label` and `emoji` parameters from ButtonBuilder.premium()

### DIFF
--- a/lib/src/builders/message/component.dart
+++ b/lib/src/builders/message/component.dart
@@ -95,8 +95,6 @@ class ButtonBuilder extends MessageComponentBuilder {
         super(type: MessageComponentType.button);
 
   ButtonBuilder.premium({
-    this.label,
-    this.emoji,
     required Snowflake this.skuId,
     this.isDisabled,
   })  : style = ButtonStyle.premium,

--- a/lib/src/utils/cache_helpers.dart
+++ b/lib/src/utils/cache_helpers.dart
@@ -105,7 +105,7 @@ extension CacheUpdates on NyxxRest {
             updateCacheWith(entity.author);
             entity.mentions.forEach(updateCacheWith);
             updateCacheWith(entity.referencedMessage);
-            updateCacheWith(entity.interaction);
+            updateCacheWith(entity.interaction); // ignore: deprecated_member_use_from_same_package
             updateCacheWith(entity.thread);
             updateCacheWith(entity.resolved);
           }(),


### PR DESCRIPTION
# Description

Removes the `label` and `emoji` parameters from the ButtonBuilder.premium() factory. As the [docs](https://discord.com/developers/docs/interactions/message-components#button-object-button-structure) state, premium buttons cannot have a label or emoji:
![image](https://github.com/nyxx-discord/nyxx/assets/67754395/8816dc38-819c-47ca-a82d-a303a2301631)


## Connected issues & other potential problems

If changes in PR are connected to other issues or are affecting code in other parts of framework
(e.g. in main package or any other subpackage) make sure to link issue/PR and describe said problem

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
