### PR TITLE
Adding toBuilder() method on GuildChannel

### DIFF
--- a/lib/src/models/channel/guild_channel.dart
+++ b/lib/src/models/channel/guild_channel.dart
@@ -1,5 +1,6 @@
 import 'package:nyxx/src/builders/invite.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
+import 'package:nyxx/src/builders/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/guild/guild.dart';
 import 'package:nyxx/src/models/invite/invite.dart';
@@ -58,4 +59,7 @@ abstract class GuildChannel implements Channel {
 
   /// Create an invite to this channel.
   Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason});
+
+  /// Creates a builder with the exact same properties of this channel.
+  GuildChannelBuilder toBuilder();
 }

--- a/lib/src/models/channel/types/announcement_thread.dart
+++ b/lib/src/models/channel/types/announcement_thread.dart
@@ -108,8 +108,7 @@ class AnnouncementThread extends TextChannel implements Thread {
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialMessage? get lastMessage =>
-      lastMessageId == null ? null : messages[lastMessageId!];
+  PartialMessage? get lastMessage => lastMessageId == null ? null : messages[lastMessageId!];
 
   @override
   PartialUser get owner => manager.client.users[ownerId];
@@ -118,54 +117,40 @@ class AnnouncementThread extends TextChannel implements Thread {
   PartialMember get ownerMember => guild.members[ownerId];
 
   @override
-  PartialChannel? get parent =>
-      parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<void> addThreadMember(Snowflake memberId) =>
-      manager.addThreadMember(id, memberId);
+  Future<void> addThreadMember(Snowflake memberId) => manager.addThreadMember(id, memberId);
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) =>
-      manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadMember> fetchThreadMember(Snowflake memberId) =>
-      manager.fetchThreadMember(id, memberId);
+  Future<ThreadMember> fetchThreadMember(Snowflake memberId) => manager.fetchThreadMember(id, memberId);
 
   @override
-  Future<List<ThreadMember>> listThreadMembers(
-          {bool? withMembers, Snowflake? after, int? limit}) =>
-      manager.listThreadMembers(id,
-          after: after, limit: limit, withMembers: withMembers);
+  Future<List<ThreadMember>> listThreadMembers({bool? withMembers, Snowflake? after, int? limit}) =>
+      manager.listThreadMembers(id, after: after, limit: limit, withMembers: withMembers);
 
   @override
-  Future<void> removeThreadMember(Snowflake memberId) =>
-      manager.removeThreadMember(id, memberId);
+  Future<void> removeThreadMember(Snowflake memberId) => manager.removeThreadMember(id, memberId);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
-      manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() =>
-      manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder,
-          {String? auditLogReason}) =>
-      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
 
   @override
   GuildChannelBuilder<AnnouncementThread> toBuilder() => GuildChannelBuilder(
       name: name,
       type: type,
-      permissionOverwrites: permissionOverwrites
-          .map((e) => PermissionOverwriteBuilder(
-              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-          .toList(),
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
       position: position);
 }

--- a/lib/src/models/channel/types/announcement_thread.dart
+++ b/lib/src/models/channel/types/announcement_thread.dart
@@ -1,5 +1,6 @@
 import 'package:nyxx/src/builders/invite.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
+import 'package:nyxx/src/builders/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/text_channel.dart';
 import 'package:nyxx/src/models/channel/thread.dart';
@@ -107,7 +108,8 @@ class AnnouncementThread extends TextChannel implements Thread {
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialMessage? get lastMessage => lastMessageId == null ? null : messages[lastMessageId!];
+  PartialMessage? get lastMessage =>
+      lastMessageId == null ? null : messages[lastMessageId!];
 
   @override
   PartialUser get owner => manager.client.users[ownerId];
@@ -116,33 +118,54 @@ class AnnouncementThread extends TextChannel implements Thread {
   PartialMember get ownerMember => guild.members[ownerId];
 
   @override
-  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent =>
+      parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<void> addThreadMember(Snowflake memberId) => manager.addThreadMember(id, memberId);
+  Future<void> addThreadMember(Snowflake memberId) =>
+      manager.addThreadMember(id, memberId);
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) =>
+      manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadMember> fetchThreadMember(Snowflake memberId) => manager.fetchThreadMember(id, memberId);
+  Future<ThreadMember> fetchThreadMember(Snowflake memberId) =>
+      manager.fetchThreadMember(id, memberId);
 
   @override
-  Future<List<ThreadMember>> listThreadMembers({bool? withMembers, Snowflake? after, int? limit}) =>
-      manager.listThreadMembers(id, after: after, limit: limit, withMembers: withMembers);
+  Future<List<ThreadMember>> listThreadMembers(
+          {bool? withMembers, Snowflake? after, int? limit}) =>
+      manager.listThreadMembers(id,
+          after: after, limit: limit, withMembers: withMembers);
 
   @override
-  Future<void> removeThreadMember(Snowflake memberId) => manager.removeThreadMember(id, memberId);
+  Future<void> removeThreadMember(Snowflake memberId) =>
+      manager.removeThreadMember(id, memberId);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
+      manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() =>
+      manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder,
+          {String? auditLogReason}) =>
+      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+
+  @override
+  GuildChannelBuilder<AnnouncementThread> toBuilder() => GuildChannelBuilder(
+      name: name,
+      type: type,
+      permissionOverwrites: permissionOverwrites
+          .map((e) => PermissionOverwriteBuilder(
+              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+          .toList(),
+      position: position);
 }

--- a/lib/src/models/channel/types/forum.dart
+++ b/lib/src/models/channel/types/forum.dart
@@ -102,67 +102,48 @@ class ForumChannel extends Channel implements GuildChannel, ThreadsOnlyChannel {
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialChannel? get parent =>
-      parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<Thread> createForumThread(ForumThreadBuilder builder) =>
-      manager.createForumThread(id, builder);
+  Future<Thread> createForumThread(ForumThreadBuilder builder) => manager.createForumThread(id, builder);
 
   @override
-  Future<Thread> createThread(ThreadBuilder builder) => throw UnsupportedError(
-      'Cannot create a non forum thread in a forum channel');
+  Future<Thread> createThread(ThreadBuilder builder) => throw UnsupportedError('Cannot create a non forum thread in a forum channel');
 
   @override
-  Future<Thread> createThreadFromMessage(
-          Snowflake messageId, ThreadFromMessageBuilder builder) =>
-      throw UnsupportedError(
-          'Cannot create a non forum thread in a forum channel');
+  Future<Thread> createThreadFromMessage(Snowflake messageId, ThreadFromMessageBuilder builder) =>
+      throw UnsupportedError('Cannot create a non forum thread in a forum channel');
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) =>
-      manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadList> listPrivateArchivedThreads(
-          {DateTime? before, int? limit}) =>
-      manager.listPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) => manager.listPrivateArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listPublicArchivedThreads(
-          {DateTime? before, int? limit}) =>
-      manager.listPublicArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) => manager.listPublicArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listJoinedPrivateArchivedThreads(
-          {DateTime? before, int? limit}) =>
-      manager.listJoinedPrivateArchivedThreads(id,
-          before: before, limit: limit);
+  Future<ThreadList> listJoinedPrivateArchivedThreads({DateTime? before, int? limit}) =>
+      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
-      manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() =>
-      manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder,
-          {String? auditLogReason}) =>
-      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
 
   @override
   GuildChannelBuilder<ForumChannel> toBuilder() => GuildChannelBuilder(
       name: name,
       type: type,
-      permissionOverwrites: permissionOverwrites
-          .map((e) => PermissionOverwriteBuilder(
-              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-          .toList(),
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
       position: position);
 }
 
@@ -219,8 +200,7 @@ final class ForumSort extends EnumLike<int, ForumSort> {
   /// @nodoc
   const ForumSort(super.value);
 
-  @Deprecated(
-      'The .parse() constructor is deprecated. Use the unnamed constructor instead.')
+  @Deprecated('The .parse() constructor is deprecated. Use the unnamed constructor instead.')
   ForumSort.parse(int value) : this(value);
 }
 
@@ -233,7 +213,6 @@ final class ForumLayout extends EnumLike<int, ForumLayout> {
   /// @nodoc
   const ForumLayout(super.value);
 
-  @Deprecated(
-      'The .parse() constructor is deprecated. Use the unnamed constructor instead.')
+  @Deprecated('The .parse() constructor is deprecated. Use the unnamed constructor instead.')
   ForumLayout.parse(int value) : this(value);
 }

--- a/lib/src/models/channel/types/forum.dart
+++ b/lib/src/models/channel/types/forum.dart
@@ -1,6 +1,7 @@
 import 'package:nyxx/src/builders/channel/thread.dart';
 import 'package:nyxx/src/builders/invite.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
+import 'package:nyxx/src/builders/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/thread.dart';
@@ -101,42 +102,68 @@ class ForumChannel extends Channel implements GuildChannel, ThreadsOnlyChannel {
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent =>
+      parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<Thread> createForumThread(ForumThreadBuilder builder) => manager.createForumThread(id, builder);
+  Future<Thread> createForumThread(ForumThreadBuilder builder) =>
+      manager.createForumThread(id, builder);
 
   @override
-  Future<Thread> createThread(ThreadBuilder builder) => throw UnsupportedError('Cannot create a non forum thread in a forum channel');
+  Future<Thread> createThread(ThreadBuilder builder) => throw UnsupportedError(
+      'Cannot create a non forum thread in a forum channel');
 
   @override
-  Future<Thread> createThreadFromMessage(Snowflake messageId, ThreadFromMessageBuilder builder) =>
-      throw UnsupportedError('Cannot create a non forum thread in a forum channel');
+  Future<Thread> createThreadFromMessage(
+          Snowflake messageId, ThreadFromMessageBuilder builder) =>
+      throw UnsupportedError(
+          'Cannot create a non forum thread in a forum channel');
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) =>
+      manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) => manager.listPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPrivateArchivedThreads(
+          {DateTime? before, int? limit}) =>
+      manager.listPrivateArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) => manager.listPublicArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPublicArchivedThreads(
+          {DateTime? before, int? limit}) =>
+      manager.listPublicArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listJoinedPrivateArchivedThreads({DateTime? before, int? limit}) =>
-      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listJoinedPrivateArchivedThreads(
+          {DateTime? before, int? limit}) =>
+      manager.listJoinedPrivateArchivedThreads(id,
+          before: before, limit: limit);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
+      manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() =>
+      manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder,
+          {String? auditLogReason}) =>
+      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+
+  @override
+  GuildChannelBuilder<ForumChannel> toBuilder() => GuildChannelBuilder(
+      name: name,
+      type: type,
+      permissionOverwrites: permissionOverwrites
+          .map((e) => PermissionOverwriteBuilder(
+              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+          .toList(),
+      position: position);
 }
 
 /// {@template forum_tag}
@@ -192,7 +219,8 @@ final class ForumSort extends EnumLike<int, ForumSort> {
   /// @nodoc
   const ForumSort(super.value);
 
-  @Deprecated('The .parse() constructor is deprecated. Use the unnamed constructor instead.')
+  @Deprecated(
+      'The .parse() constructor is deprecated. Use the unnamed constructor instead.')
   ForumSort.parse(int value) : this(value);
 }
 
@@ -205,6 +233,7 @@ final class ForumLayout extends EnumLike<int, ForumLayout> {
   /// @nodoc
   const ForumLayout(super.value);
 
-  @Deprecated('The .parse() constructor is deprecated. Use the unnamed constructor instead.')
+  @Deprecated(
+      'The .parse() constructor is deprecated. Use the unnamed constructor instead.')
   ForumLayout.parse(int value) : this(value);
 }

--- a/lib/src/models/channel/types/guild_announcement.dart
+++ b/lib/src/models/channel/types/guild_announcement.dart
@@ -1,6 +1,7 @@
 import 'package:nyxx/src/builders/channel/thread.dart';
 import 'package:nyxx/src/builders/invite.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
+import 'package:nyxx/src/builders/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/text_channel.dart';
@@ -18,7 +19,8 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template guild_announcement_channel}
 /// An announcement channel in a [Guild].
 /// {@endtemplate}
-class GuildAnnouncementChannel extends TextChannel implements GuildChannel, HasThreadsChannel {
+class GuildAnnouncementChannel extends TextChannel
+    implements GuildChannel, HasThreadsChannel {
   /// The topic of this channel.
   final String? topic;
 
@@ -81,39 +83,66 @@ class GuildAnnouncementChannel extends TextChannel implements GuildChannel, HasT
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialMessage? get lastMessage => lastMessageId == null ? null : messages[lastMessageId!];
+  PartialMessage? get lastMessage =>
+      lastMessageId == null ? null : messages[lastMessageId!];
 
   @override
-  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent =>
+      parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<Thread> createThread(ThreadBuilder builder) => manager.createThread(id, builder);
+  Future<Thread> createThread(ThreadBuilder builder) =>
+      manager.createThread(id, builder);
 
   @override
-  Future<Thread> createThreadFromMessage(Snowflake messageId, ThreadFromMessageBuilder builder) => manager.createThreadFromMessage(id, messageId, builder);
+  Future<Thread> createThreadFromMessage(
+          Snowflake messageId, ThreadFromMessageBuilder builder) =>
+      manager.createThreadFromMessage(id, messageId, builder);
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) =>
+      manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) => manager.listPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPrivateArchivedThreads(
+          {DateTime? before, int? limit}) =>
+      manager.listPrivateArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) => manager.listPublicArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPublicArchivedThreads(
+          {DateTime? before, int? limit}) =>
+      manager.listPublicArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listJoinedPrivateArchivedThreads({DateTime? before, int? limit}) =>
-      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listJoinedPrivateArchivedThreads(
+          {DateTime? before, int? limit}) =>
+      manager.listJoinedPrivateArchivedThreads(id,
+          before: before, limit: limit);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
+      manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() =>
+      manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder,
+          {String? auditLogReason}) =>
+      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+
+  @override
+  GuildChannelBuilder<GuildAnnouncementChannel> toBuilder() =>
+      GuildChannelBuilder(
+          name: name,
+          type: type,
+          permissionOverwrites: permissionOverwrites
+              .map((e) => PermissionOverwriteBuilder(
+                  id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+              .toList(),
+          position: position);
 }

--- a/lib/src/models/channel/types/guild_announcement.dart
+++ b/lib/src/models/channel/types/guild_announcement.dart
@@ -19,8 +19,7 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template guild_announcement_channel}
 /// An announcement channel in a [Guild].
 /// {@endtemplate}
-class GuildAnnouncementChannel extends TextChannel
-    implements GuildChannel, HasThreadsChannel {
+class GuildAnnouncementChannel extends TextChannel implements GuildChannel, HasThreadsChannel {
   /// The topic of this channel.
   final String? topic;
 
@@ -83,66 +82,46 @@ class GuildAnnouncementChannel extends TextChannel
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialMessage? get lastMessage =>
-      lastMessageId == null ? null : messages[lastMessageId!];
+  PartialMessage? get lastMessage => lastMessageId == null ? null : messages[lastMessageId!];
 
   @override
-  PartialChannel? get parent =>
-      parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<Thread> createThread(ThreadBuilder builder) =>
-      manager.createThread(id, builder);
+  Future<Thread> createThread(ThreadBuilder builder) => manager.createThread(id, builder);
 
   @override
-  Future<Thread> createThreadFromMessage(
-          Snowflake messageId, ThreadFromMessageBuilder builder) =>
-      manager.createThreadFromMessage(id, messageId, builder);
+  Future<Thread> createThreadFromMessage(Snowflake messageId, ThreadFromMessageBuilder builder) => manager.createThreadFromMessage(id, messageId, builder);
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) =>
-      manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadList> listPrivateArchivedThreads(
-          {DateTime? before, int? limit}) =>
-      manager.listPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) => manager.listPrivateArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listPublicArchivedThreads(
-          {DateTime? before, int? limit}) =>
-      manager.listPublicArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) => manager.listPublicArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listJoinedPrivateArchivedThreads(
-          {DateTime? before, int? limit}) =>
-      manager.listJoinedPrivateArchivedThreads(id,
-          before: before, limit: limit);
+  Future<ThreadList> listJoinedPrivateArchivedThreads({DateTime? before, int? limit}) =>
+      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
-      manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() =>
-      manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder,
-          {String? auditLogReason}) =>
-      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
 
   @override
-  GuildChannelBuilder<GuildAnnouncementChannel> toBuilder() =>
-      GuildChannelBuilder(
-          name: name,
-          type: type,
-          permissionOverwrites: permissionOverwrites
-              .map((e) => PermissionOverwriteBuilder(
-                  id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-              .toList(),
-          position: position);
+  GuildChannelBuilder<GuildAnnouncementChannel> toBuilder() => GuildChannelBuilder(
+      name: name,
+      type: type,
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+      position: position);
 }

--- a/lib/src/models/channel/types/guild_category.dart
+++ b/lib/src/models/channel/types/guild_category.dart
@@ -52,36 +52,27 @@ class GuildCategory extends Channel implements GuildChannel {
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialChannel? get parent =>
-      parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) =>
-      manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
-      manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() =>
-      throw UnsupportedError('Cannot fetch webhooks in guild category');
+  Future<List<Webhook>> fetchWebhooks() => throw UnsupportedError('Cannot fetch webhooks in guild category');
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder,
-          {String? auditLogReason}) =>
-      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
 
   @override
   GuildChannelBuilder<GuildCategory> toBuilder() => GuildChannelBuilder(
       name: name,
       type: type,
-      permissionOverwrites: permissionOverwrites
-          .map((e) => PermissionOverwriteBuilder(
-              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-          .toList(),
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
       position: position);
 }

--- a/lib/src/models/channel/types/guild_category.dart
+++ b/lib/src/models/channel/types/guild_category.dart
@@ -1,5 +1,6 @@
 import 'package:nyxx/src/builders/invite.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
+import 'package:nyxx/src/builders/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/guild_channel.dart';
 import 'package:nyxx/src/models/guild/guild.dart';
@@ -51,20 +52,36 @@ class GuildCategory extends Channel implements GuildChannel {
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent =>
+      parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) =>
+      manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
+      manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() => throw UnsupportedError('Cannot fetch webhooks in guild category');
+  Future<List<Webhook>> fetchWebhooks() =>
+      throw UnsupportedError('Cannot fetch webhooks in guild category');
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder,
+          {String? auditLogReason}) =>
+      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+
+  @override
+  GuildChannelBuilder<GuildCategory> toBuilder() => GuildChannelBuilder(
+      name: name,
+      type: type,
+      permissionOverwrites: permissionOverwrites
+          .map((e) => PermissionOverwriteBuilder(
+              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+          .toList(),
+      position: position);
 }

--- a/lib/src/models/channel/types/guild_media.dart
+++ b/lib/src/models/channel/types/guild_media.dart
@@ -1,6 +1,7 @@
 import 'package:nyxx/src/builders/channel/thread.dart';
 import 'package:nyxx/src/builders/invite.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
+import 'package:nyxx/src/builders/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/thread.dart';
@@ -17,7 +18,8 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template guild_media_channel}
 /// A channel in a guild in which threads can be posted, similarly to a [ForumChannel].
 /// {@endtemplate}
-class GuildMediaChannel extends Channel implements GuildChannel, ThreadsOnlyChannel {
+class GuildMediaChannel extends Channel
+    implements GuildChannel, ThreadsOnlyChannel {
   @override
   final String? topic;
 
@@ -96,40 +98,66 @@ class GuildMediaChannel extends Channel implements GuildChannel, ThreadsOnlyChan
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent =>
+      parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<Thread> createForumThread(ForumThreadBuilder builder) => manager.createForumThread(id, builder);
+  Future<Thread> createForumThread(ForumThreadBuilder builder) =>
+      manager.createForumThread(id, builder);
 
   @override
-  Future<Thread> createThread(ThreadBuilder builder) => throw UnsupportedError('Cannot create a non forum thread in a forum channel');
+  Future<Thread> createThread(ThreadBuilder builder) => throw UnsupportedError(
+      'Cannot create a non forum thread in a forum channel');
 
   @override
-  Future<Thread> createThreadFromMessage(Snowflake messageId, ThreadFromMessageBuilder builder) =>
-      throw UnsupportedError('Cannot create a non forum thread in a forum channel');
+  Future<Thread> createThreadFromMessage(
+          Snowflake messageId, ThreadFromMessageBuilder builder) =>
+      throw UnsupportedError(
+          'Cannot create a non forum thread in a forum channel');
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) =>
+      manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) => manager.listPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPrivateArchivedThreads(
+          {DateTime? before, int? limit}) =>
+      manager.listPrivateArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) => manager.listPublicArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPublicArchivedThreads(
+          {DateTime? before, int? limit}) =>
+      manager.listPublicArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listJoinedPrivateArchivedThreads({DateTime? before, int? limit}) =>
-      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listJoinedPrivateArchivedThreads(
+          {DateTime? before, int? limit}) =>
+      manager.listJoinedPrivateArchivedThreads(id,
+          before: before, limit: limit);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
+      manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() =>
+      manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder,
+          {String? auditLogReason}) =>
+      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+
+  @override
+  GuildChannelBuilder<GuildMediaChannel> toBuilder() => GuildChannelBuilder(
+      name: name,
+      type: type,
+      permissionOverwrites: permissionOverwrites
+          .map((e) => PermissionOverwriteBuilder(
+              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+          .toList(),
+      position: position);
 }

--- a/lib/src/models/channel/types/guild_media.dart
+++ b/lib/src/models/channel/types/guild_media.dart
@@ -18,8 +18,7 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template guild_media_channel}
 /// A channel in a guild in which threads can be posted, similarly to a [ForumChannel].
 /// {@endtemplate}
-class GuildMediaChannel extends Channel
-    implements GuildChannel, ThreadsOnlyChannel {
+class GuildMediaChannel extends Channel implements GuildChannel, ThreadsOnlyChannel {
   @override
   final String? topic;
 
@@ -98,66 +97,47 @@ class GuildMediaChannel extends Channel
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialChannel? get parent =>
-      parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<Thread> createForumThread(ForumThreadBuilder builder) =>
-      manager.createForumThread(id, builder);
+  Future<Thread> createForumThread(ForumThreadBuilder builder) => manager.createForumThread(id, builder);
 
   @override
-  Future<Thread> createThread(ThreadBuilder builder) => throw UnsupportedError(
-      'Cannot create a non forum thread in a forum channel');
+  Future<Thread> createThread(ThreadBuilder builder) => throw UnsupportedError('Cannot create a non forum thread in a forum channel');
 
   @override
-  Future<Thread> createThreadFromMessage(
-          Snowflake messageId, ThreadFromMessageBuilder builder) =>
-      throw UnsupportedError(
-          'Cannot create a non forum thread in a forum channel');
+  Future<Thread> createThreadFromMessage(Snowflake messageId, ThreadFromMessageBuilder builder) =>
+      throw UnsupportedError('Cannot create a non forum thread in a forum channel');
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) =>
-      manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadList> listPrivateArchivedThreads(
-          {DateTime? before, int? limit}) =>
-      manager.listPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) => manager.listPrivateArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listPublicArchivedThreads(
-          {DateTime? before, int? limit}) =>
-      manager.listPublicArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) => manager.listPublicArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listJoinedPrivateArchivedThreads(
-          {DateTime? before, int? limit}) =>
-      manager.listJoinedPrivateArchivedThreads(id,
-          before: before, limit: limit);
+  Future<ThreadList> listJoinedPrivateArchivedThreads({DateTime? before, int? limit}) =>
+      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
-      manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() =>
-      manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder,
-          {String? auditLogReason}) =>
-      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
 
   @override
   GuildChannelBuilder<GuildMediaChannel> toBuilder() => GuildChannelBuilder(
       name: name,
       type: type,
-      permissionOverwrites: permissionOverwrites
-          .map((e) => PermissionOverwriteBuilder(
-              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-          .toList(),
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
       position: position);
 }

--- a/lib/src/models/channel/types/guild_stage.dart
+++ b/lib/src/models/channel/types/guild_stage.dart
@@ -1,5 +1,6 @@
 import 'package:nyxx/src/builders/invite.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
+import 'package:nyxx/src/builders/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/text_channel.dart';
@@ -15,7 +16,8 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template guild_stage_channel}
 /// A stage channel.
 /// {@endtemplate}
-class GuildStageChannel extends TextChannel implements VoiceChannel, GuildChannel {
+class GuildStageChannel extends TextChannel
+    implements VoiceChannel, GuildChannel {
   @override
   final int bitrate;
 
@@ -82,23 +84,40 @@ class GuildStageChannel extends TextChannel implements VoiceChannel, GuildChanne
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialMessage? get lastMessage => lastMessageId == null ? null : messages[lastMessageId!];
+  PartialMessage? get lastMessage =>
+      lastMessageId == null ? null : messages[lastMessageId!];
 
   @override
-  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent =>
+      parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) =>
+      manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
+      manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() =>
+      manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder,
+          {String? auditLogReason}) =>
+      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+
+  @override
+  GuildChannelBuilder<GuildStageChannel> toBuilder() => GuildChannelBuilder(
+      name: name,
+      type: type,
+      permissionOverwrites: permissionOverwrites
+          .map((e) => PermissionOverwriteBuilder(
+              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+          .toList(),
+      position: position);
 }

--- a/lib/src/models/channel/types/guild_stage.dart
+++ b/lib/src/models/channel/types/guild_stage.dart
@@ -16,8 +16,7 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template guild_stage_channel}
 /// A stage channel.
 /// {@endtemplate}
-class GuildStageChannel extends TextChannel
-    implements VoiceChannel, GuildChannel {
+class GuildStageChannel extends TextChannel implements VoiceChannel, GuildChannel {
   @override
   final int bitrate;
 
@@ -84,40 +83,30 @@ class GuildStageChannel extends TextChannel
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialMessage? get lastMessage =>
-      lastMessageId == null ? null : messages[lastMessageId!];
+  PartialMessage? get lastMessage => lastMessageId == null ? null : messages[lastMessageId!];
 
   @override
-  PartialChannel? get parent =>
-      parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) =>
-      manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
-      manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() =>
-      manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder,
-          {String? auditLogReason}) =>
-      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
 
   @override
   GuildChannelBuilder<GuildStageChannel> toBuilder() => GuildChannelBuilder(
       name: name,
       type: type,
-      permissionOverwrites: permissionOverwrites
-          .map((e) => PermissionOverwriteBuilder(
-              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-          .toList(),
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
       position: position);
 }

--- a/lib/src/models/channel/types/guild_text.dart
+++ b/lib/src/models/channel/types/guild_text.dart
@@ -1,6 +1,7 @@
 import 'package:nyxx/src/builders/channel/thread.dart';
 import 'package:nyxx/src/builders/invite.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
+import 'package:nyxx/src/builders/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/text_channel.dart';
@@ -18,7 +19,8 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template guild_text_channel}
 /// A [TextChannel] in a [Guild].
 /// {@endtemplate}
-class GuildTextChannel extends TextChannel implements GuildChannel, HasThreadsChannel {
+class GuildTextChannel extends TextChannel
+    implements GuildChannel, HasThreadsChannel {
   /// The topic of this channel.
   final String? topic;
 
@@ -81,39 +83,65 @@ class GuildTextChannel extends TextChannel implements GuildChannel, HasThreadsCh
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialMessage? get lastMessage => lastMessageId == null ? null : messages[lastMessageId!];
+  PartialMessage? get lastMessage =>
+      lastMessageId == null ? null : messages[lastMessageId!];
 
   @override
-  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent =>
+      parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<Thread> createThread(ThreadBuilder builder) => manager.createThread(id, builder);
+  Future<Thread> createThread(ThreadBuilder builder) =>
+      manager.createThread(id, builder);
 
   @override
-  Future<Thread> createThreadFromMessage(Snowflake messageId, ThreadFromMessageBuilder builder) => manager.createThreadFromMessage(id, messageId, builder);
+  Future<Thread> createThreadFromMessage(
+          Snowflake messageId, ThreadFromMessageBuilder builder) =>
+      manager.createThreadFromMessage(id, messageId, builder);
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) =>
+      manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) => manager.listPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPrivateArchivedThreads(
+          {DateTime? before, int? limit}) =>
+      manager.listPrivateArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) => manager.listPublicArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPublicArchivedThreads(
+          {DateTime? before, int? limit}) =>
+      manager.listPublicArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listJoinedPrivateArchivedThreads({DateTime? before, int? limit}) =>
-      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listJoinedPrivateArchivedThreads(
+          {DateTime? before, int? limit}) =>
+      manager.listJoinedPrivateArchivedThreads(id,
+          before: before, limit: limit);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
+      manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() =>
+      manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder,
+          {String? auditLogReason}) =>
+      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+
+  @override
+  GuildChannelBuilder<GuildTextChannel> toBuilder() => GuildChannelBuilder(
+      name: name,
+      type: type,
+      permissionOverwrites: permissionOverwrites
+          .map((e) => PermissionOverwriteBuilder(
+              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+          .toList(),
+      position: position);
 }

--- a/lib/src/models/channel/types/guild_text.dart
+++ b/lib/src/models/channel/types/guild_text.dart
@@ -19,8 +19,7 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template guild_text_channel}
 /// A [TextChannel] in a [Guild].
 /// {@endtemplate}
-class GuildTextChannel extends TextChannel
-    implements GuildChannel, HasThreadsChannel {
+class GuildTextChannel extends TextChannel implements GuildChannel, HasThreadsChannel {
   /// The topic of this channel.
   final String? topic;
 
@@ -83,65 +82,46 @@ class GuildTextChannel extends TextChannel
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialMessage? get lastMessage =>
-      lastMessageId == null ? null : messages[lastMessageId!];
+  PartialMessage? get lastMessage => lastMessageId == null ? null : messages[lastMessageId!];
 
   @override
-  PartialChannel? get parent =>
-      parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<Thread> createThread(ThreadBuilder builder) =>
-      manager.createThread(id, builder);
+  Future<Thread> createThread(ThreadBuilder builder) => manager.createThread(id, builder);
 
   @override
-  Future<Thread> createThreadFromMessage(
-          Snowflake messageId, ThreadFromMessageBuilder builder) =>
-      manager.createThreadFromMessage(id, messageId, builder);
+  Future<Thread> createThreadFromMessage(Snowflake messageId, ThreadFromMessageBuilder builder) => manager.createThreadFromMessage(id, messageId, builder);
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) =>
-      manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadList> listPrivateArchivedThreads(
-          {DateTime? before, int? limit}) =>
-      manager.listPrivateArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPrivateArchivedThreads({DateTime? before, int? limit}) => manager.listPrivateArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listPublicArchivedThreads(
-          {DateTime? before, int? limit}) =>
-      manager.listPublicArchivedThreads(id, before: before, limit: limit);
+  Future<ThreadList> listPublicArchivedThreads({DateTime? before, int? limit}) => manager.listPublicArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<ThreadList> listJoinedPrivateArchivedThreads(
-          {DateTime? before, int? limit}) =>
-      manager.listJoinedPrivateArchivedThreads(id,
-          before: before, limit: limit);
+  Future<ThreadList> listJoinedPrivateArchivedThreads({DateTime? before, int? limit}) =>
+      manager.listJoinedPrivateArchivedThreads(id, before: before, limit: limit);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
-      manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() =>
-      manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder,
-          {String? auditLogReason}) =>
-      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
 
   @override
   GuildChannelBuilder<GuildTextChannel> toBuilder() => GuildChannelBuilder(
       name: name,
       type: type,
-      permissionOverwrites: permissionOverwrites
-          .map((e) => PermissionOverwriteBuilder(
-              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-          .toList(),
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
       position: position);
 }

--- a/lib/src/models/channel/types/guild_voice.dart
+++ b/lib/src/models/channel/types/guild_voice.dart
@@ -16,8 +16,7 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template guild_voice_channel}
 /// A [VoiceChannel] in a [Guild].
 /// {@endtemplate}
-class GuildVoiceChannel extends TextChannel
-    implements GuildChannel, VoiceChannel {
+class GuildVoiceChannel extends TextChannel implements GuildChannel, VoiceChannel {
   @override
   final int bitrate;
 
@@ -84,40 +83,30 @@ class GuildVoiceChannel extends TextChannel
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialMessage? get lastMessage =>
-      lastMessageId == null ? null : messages[lastMessageId!];
+  PartialMessage? get lastMessage => lastMessageId == null ? null : messages[lastMessageId!];
 
   @override
-  PartialChannel? get parent =>
-      parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) =>
-      manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
-      manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() =>
-      manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder,
-          {String? auditLogReason}) =>
-      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
 
   @override
   GuildChannelBuilder<GuildVoiceChannel> toBuilder() => GuildChannelBuilder(
       name: name,
       type: type,
-      permissionOverwrites: permissionOverwrites
-          .map((e) => PermissionOverwriteBuilder(
-              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-          .toList(),
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
       position: position);
 }

--- a/lib/src/models/channel/types/guild_voice.dart
+++ b/lib/src/models/channel/types/guild_voice.dart
@@ -1,5 +1,6 @@
 import 'package:nyxx/src/builders/invite.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
+import 'package:nyxx/src/builders/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/text_channel.dart';
@@ -15,7 +16,8 @@ import 'package:nyxx/src/models/webhook.dart';
 /// {@template guild_voice_channel}
 /// A [VoiceChannel] in a [Guild].
 /// {@endtemplate}
-class GuildVoiceChannel extends TextChannel implements GuildChannel, VoiceChannel {
+class GuildVoiceChannel extends TextChannel
+    implements GuildChannel, VoiceChannel {
   @override
   final int bitrate;
 
@@ -82,23 +84,40 @@ class GuildVoiceChannel extends TextChannel implements GuildChannel, VoiceChanne
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialMessage? get lastMessage => lastMessageId == null ? null : messages[lastMessageId!];
+  PartialMessage? get lastMessage =>
+      lastMessageId == null ? null : messages[lastMessageId!];
 
   @override
-  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent =>
+      parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) =>
+      manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
+      manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() =>
+      manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder,
+          {String? auditLogReason}) =>
+      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+
+  @override
+  GuildChannelBuilder<GuildVoiceChannel> toBuilder() => GuildChannelBuilder(
+      name: name,
+      type: type,
+      permissionOverwrites: permissionOverwrites
+          .map((e) => PermissionOverwriteBuilder(
+              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+          .toList(),
+      position: position);
 }

--- a/lib/src/models/channel/types/private_thread.dart
+++ b/lib/src/models/channel/types/private_thread.dart
@@ -1,5 +1,6 @@
 import 'package:nyxx/src/builders/invite.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
+import 'package:nyxx/src/builders/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/text_channel.dart';
 import 'package:nyxx/src/models/channel/thread.dart';
@@ -114,7 +115,8 @@ class PrivateThread extends TextChannel implements Thread {
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialMessage? get lastMessage => lastMessageId == null ? null : messages[lastMessageId!];
+  PartialMessage? get lastMessage =>
+      lastMessageId == null ? null : messages[lastMessageId!];
 
   @override
   PartialUser get owner => manager.client.users[ownerId];
@@ -123,33 +125,54 @@ class PrivateThread extends TextChannel implements Thread {
   PartialMember get ownerMember => guild.members[ownerId];
 
   @override
-  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent =>
+      parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<void> addThreadMember(Snowflake memberId) => manager.addThreadMember(id, memberId);
+  Future<void> addThreadMember(Snowflake memberId) =>
+      manager.addThreadMember(id, memberId);
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) =>
+      manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadMember> fetchThreadMember(Snowflake memberId) => manager.fetchThreadMember(id, memberId);
+  Future<ThreadMember> fetchThreadMember(Snowflake memberId) =>
+      manager.fetchThreadMember(id, memberId);
 
   @override
-  Future<List<ThreadMember>> listThreadMembers({bool? withMembers, Snowflake? after, int? limit}) =>
-      manager.listThreadMembers(id, after: after, limit: limit, withMembers: withMembers);
+  Future<List<ThreadMember>> listThreadMembers(
+          {bool? withMembers, Snowflake? after, int? limit}) =>
+      manager.listThreadMembers(id,
+          after: after, limit: limit, withMembers: withMembers);
 
   @override
-  Future<void> removeThreadMember(Snowflake memberId) => manager.removeThreadMember(id, memberId);
+  Future<void> removeThreadMember(Snowflake memberId) =>
+      manager.removeThreadMember(id, memberId);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
+      manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() =>
+      manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder,
+          {String? auditLogReason}) =>
+      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+
+  @override
+  GuildChannelBuilder<PrivateThread> toBuilder() => GuildChannelBuilder(
+      name: name,
+      type: type,
+      permissionOverwrites: permissionOverwrites
+          .map((e) => PermissionOverwriteBuilder(
+              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+          .toList(),
+      position: position);
 }

--- a/lib/src/models/channel/types/private_thread.dart
+++ b/lib/src/models/channel/types/private_thread.dart
@@ -115,8 +115,7 @@ class PrivateThread extends TextChannel implements Thread {
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialMessage? get lastMessage =>
-      lastMessageId == null ? null : messages[lastMessageId!];
+  PartialMessage? get lastMessage => lastMessageId == null ? null : messages[lastMessageId!];
 
   @override
   PartialUser get owner => manager.client.users[ownerId];
@@ -125,54 +124,40 @@ class PrivateThread extends TextChannel implements Thread {
   PartialMember get ownerMember => guild.members[ownerId];
 
   @override
-  PartialChannel? get parent =>
-      parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<void> addThreadMember(Snowflake memberId) =>
-      manager.addThreadMember(id, memberId);
+  Future<void> addThreadMember(Snowflake memberId) => manager.addThreadMember(id, memberId);
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) =>
-      manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadMember> fetchThreadMember(Snowflake memberId) =>
-      manager.fetchThreadMember(id, memberId);
+  Future<ThreadMember> fetchThreadMember(Snowflake memberId) => manager.fetchThreadMember(id, memberId);
 
   @override
-  Future<List<ThreadMember>> listThreadMembers(
-          {bool? withMembers, Snowflake? after, int? limit}) =>
-      manager.listThreadMembers(id,
-          after: after, limit: limit, withMembers: withMembers);
+  Future<List<ThreadMember>> listThreadMembers({bool? withMembers, Snowflake? after, int? limit}) =>
+      manager.listThreadMembers(id, after: after, limit: limit, withMembers: withMembers);
 
   @override
-  Future<void> removeThreadMember(Snowflake memberId) =>
-      manager.removeThreadMember(id, memberId);
+  Future<void> removeThreadMember(Snowflake memberId) => manager.removeThreadMember(id, memberId);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
-      manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() =>
-      manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder,
-          {String? auditLogReason}) =>
-      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
 
   @override
   GuildChannelBuilder<PrivateThread> toBuilder() => GuildChannelBuilder(
       name: name,
       type: type,
-      permissionOverwrites: permissionOverwrites
-          .map((e) => PermissionOverwriteBuilder(
-              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-          .toList(),
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
       position: position);
 }

--- a/lib/src/models/channel/types/public_thread.dart
+++ b/lib/src/models/channel/types/public_thread.dart
@@ -1,5 +1,6 @@
 import 'package:nyxx/src/builders/invite.dart';
 import 'package:nyxx/src/builders/permission_overwrite.dart';
+import 'package:nyxx/src/builders/channel/guild_channel.dart';
 import 'package:nyxx/src/models/channel/channel.dart';
 import 'package:nyxx/src/models/channel/text_channel.dart';
 import 'package:nyxx/src/models/channel/thread.dart';
@@ -111,7 +112,8 @@ class PublicThread extends TextChannel implements Thread {
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialMessage? get lastMessage => lastMessageId == null ? null : messages[lastMessageId!];
+  PartialMessage? get lastMessage =>
+      lastMessageId == null ? null : messages[lastMessageId!];
 
   @override
   PartialUser get owner => manager.client.users[ownerId];
@@ -120,33 +122,54 @@ class PublicThread extends TextChannel implements Thread {
   PartialMember get ownerMember => guild.members[ownerId];
 
   @override
-  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent =>
+      parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<void> addThreadMember(Snowflake memberId) => manager.addThreadMember(id, memberId);
+  Future<void> addThreadMember(Snowflake memberId) =>
+      manager.addThreadMember(id, memberId);
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) =>
+      manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadMember> fetchThreadMember(Snowflake memberId) => manager.fetchThreadMember(id, memberId);
+  Future<ThreadMember> fetchThreadMember(Snowflake memberId) =>
+      manager.fetchThreadMember(id, memberId);
 
   @override
-  Future<List<ThreadMember>> listThreadMembers({bool? withMembers, Snowflake? after, int? limit}) =>
-      manager.listThreadMembers(id, after: after, limit: limit, withMembers: withMembers);
+  Future<List<ThreadMember>> listThreadMembers(
+          {bool? withMembers, Snowflake? after, int? limit}) =>
+      manager.listThreadMembers(id,
+          after: after, limit: limit, withMembers: withMembers);
 
   @override
-  Future<void> removeThreadMember(Snowflake memberId) => manager.removeThreadMember(id, memberId);
+  Future<void> removeThreadMember(Snowflake memberId) =>
+      manager.removeThreadMember(id, memberId);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
+      manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() =>
+      manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder,
+          {String? auditLogReason}) =>
+      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+
+  @override
+  GuildChannelBuilder<PublicThread> toBuilder() => GuildChannelBuilder(
+      name: name,
+      type: type,
+      permissionOverwrites: permissionOverwrites
+          .map((e) => PermissionOverwriteBuilder(
+              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+          .toList(),
+      position: position);
 }

--- a/lib/src/models/channel/types/public_thread.dart
+++ b/lib/src/models/channel/types/public_thread.dart
@@ -112,8 +112,7 @@ class PublicThread extends TextChannel implements Thread {
   PartialGuild get guild => manager.client.guilds[guildId];
 
   @override
-  PartialMessage? get lastMessage =>
-      lastMessageId == null ? null : messages[lastMessageId!];
+  PartialMessage? get lastMessage => lastMessageId == null ? null : messages[lastMessageId!];
 
   @override
   PartialUser get owner => manager.client.users[ownerId];
@@ -122,54 +121,40 @@ class PublicThread extends TextChannel implements Thread {
   PartialMember get ownerMember => guild.members[ownerId];
 
   @override
-  PartialChannel? get parent =>
-      parentId == null ? null : manager.client.channels[parentId!];
+  PartialChannel? get parent => parentId == null ? null : manager.client.channels[parentId!];
 
   @override
-  Future<void> addThreadMember(Snowflake memberId) =>
-      manager.addThreadMember(id, memberId);
+  Future<void> addThreadMember(Snowflake memberId) => manager.addThreadMember(id, memberId);
 
   @override
-  Future<void> deletePermissionOverwrite(Snowflake id) =>
-      manager.deletePermissionOverwrite(this.id, id);
+  Future<void> deletePermissionOverwrite(Snowflake id) => manager.deletePermissionOverwrite(this.id, id);
 
   @override
-  Future<ThreadMember> fetchThreadMember(Snowflake memberId) =>
-      manager.fetchThreadMember(id, memberId);
+  Future<ThreadMember> fetchThreadMember(Snowflake memberId) => manager.fetchThreadMember(id, memberId);
 
   @override
-  Future<List<ThreadMember>> listThreadMembers(
-          {bool? withMembers, Snowflake? after, int? limit}) =>
-      manager.listThreadMembers(id,
-          after: after, limit: limit, withMembers: withMembers);
+  Future<List<ThreadMember>> listThreadMembers({bool? withMembers, Snowflake? after, int? limit}) =>
+      manager.listThreadMembers(id, after: after, limit: limit, withMembers: withMembers);
 
   @override
-  Future<void> removeThreadMember(Snowflake memberId) =>
-      manager.removeThreadMember(id, memberId);
+  Future<void> removeThreadMember(Snowflake memberId) => manager.removeThreadMember(id, memberId);
 
   @override
-  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) =>
-      manager.updatePermissionOverwrite(id, builder);
+  Future<void> updatePermissionOverwrite(PermissionOverwriteBuilder builder) => manager.updatePermissionOverwrite(id, builder);
 
   @override
-  Future<List<Webhook>> fetchWebhooks() =>
-      manager.client.webhooks.fetchChannelWebhooks(id);
+  Future<List<Webhook>> fetchWebhooks() => manager.client.webhooks.fetchChannelWebhooks(id);
 
   @override
   Future<List<InviteWithMetadata>> listInvites() => manager.listInvites(id);
 
   @override
-  Future<Invite> createInvite(InviteBuilder builder,
-          {String? auditLogReason}) =>
-      manager.createInvite(id, builder, auditLogReason: auditLogReason);
+  Future<Invite> createInvite(InviteBuilder builder, {String? auditLogReason}) => manager.createInvite(id, builder, auditLogReason: auditLogReason);
 
   @override
   GuildChannelBuilder<PublicThread> toBuilder() => GuildChannelBuilder(
       name: name,
       type: type,
-      permissionOverwrites: permissionOverwrites
-          .map((e) => PermissionOverwriteBuilder(
-              id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-          .toList(),
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
       position: position);
 }


### PR DESCRIPTION
# Description

I created and implemented the toBuilder method on GuildChannel and all its variants. This way you can "clone" a channel of a guild without copying the data manually. Also you can use an existing channel as a template for new channels.

## Connected issues & other potential problems

https://github.com/nyxx-discord/nyxx_extensions/issues/38#issuecomment-2198307221
PS: I don't know how to tag an issue of another repo :(

## Type of change

- [ -] New feature (non-breaking change which adds functionality)

# Checklist:

- [ -] Ran `dart analyze` or `make analyze` and fixed all issues
- [ -] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [ -] I have performed a self-review of my own code
- [ -] I have commented my code, particularly in hard-to-understand areas

# Todo:

- [ ] I have made corresponding changes to the documentation
