### PR TITLE
add banner property to member

### DIFF
--- a/lib/src/http/cdn/cdn_request.dart
+++ b/lib/src/http/cdn/cdn_request.dart
@@ -10,6 +10,8 @@ class CdnRequest extends HttpRequest {
 
   @override
   BaseRequest prepare(Nyxx client) {
+    final queryParameters = this.queryParameters.isEmpty ? null : this.queryParameters;
+
     return Request(method, Uri.https(client.apiOptions.cdnHost, route.path, queryParameters));
   }
 }

--- a/lib/src/http/managers/member_manager.dart
+++ b/lib/src/http/managers/member_manager.dart
@@ -29,6 +29,7 @@ class MemberManager extends Manager<Member> {
       user: maybeParse(raw['user'], client.users.parse),
       nick: raw['nick'] as String?,
       avatarHash: raw['avatar'] as String?,
+      bannerHash: raw['banner'] as String?,
       roleIds: parseMany(raw['roles'] as List, Snowflake.parse),
       joinedAt: DateTime.parse(raw['joined_at'] as String),
       premiumSince: maybeParse(raw['premium_since'], DateTime.parse),

--- a/lib/src/models/guild/member.dart
+++ b/lib/src/models/guild/member.dart
@@ -61,6 +61,9 @@ class Member extends PartialMember {
   /// The hash of this member's avatar image.
   final String? avatarHash;
 
+  /// The hash of this member's banner image.
+  final String? bannerHash;
+
   /// A list of the IDs of the roles this member has.
   final List<Snowflake> roleIds;
 
@@ -96,6 +99,7 @@ class Member extends PartialMember {
     required this.user,
     required this.nick,
     required this.avatarHash,
+    required this.bannerHash,
     required this.roleIds,
     required this.joinedAt,
     required this.premiumSince,
@@ -121,6 +125,15 @@ class Member extends PartialMember {
             ..avatars(),
           hash: avatarHash!,
         );
+
+  CdnAsset get banner => CdnAsset(
+        client: manager.client,
+        base: HttpRoute()
+          ..guilds(id: manager.guildId.toString())
+          ..users(id: id.toString())
+          ..banners(),
+        hash: bannerHash!,
+      );
 }
 
 /// Flags that can be applied to a [Member].

--- a/test/mocks/client.dart
+++ b/test/mocks/client.dart
@@ -10,9 +10,6 @@ class MockNyxx with Mock, ManagerMixin implements NyxxRest {
 
   @override
   PartialUser get user => users[Snowflake.zero];
-
-  @override
-  RestApiOptions get apiOptions => RestApiOptions(token: '');
 }
 
 class MockNyxxGateway with Mock, ManagerMixin implements NyxxGateway {

--- a/test/mocks/client.dart
+++ b/test/mocks/client.dart
@@ -10,6 +10,9 @@ class MockNyxx with Mock, ManagerMixin implements NyxxRest {
 
   @override
   PartialUser get user => users[Snowflake.zero];
+
+  @override
+  RestApiOptions get apiOptions => RestApiOptions(token: '');
 }
 
 class MockNyxxGateway with Mock, ManagerMixin implements NyxxGateway {

--- a/test/unit/http/bucket_test.dart
+++ b/test/unit/http/bucket_test.dart
@@ -37,7 +37,7 @@ void main() {
 
         final bucket = HttpBucket.fromResponse(handler, response);
 
-        expect(bucket, isNot(isNull));
+        expect(bucket, isNotNull);
         expect(bucket?.id, equals('testBucketId'));
         expect(bucket?.remaining, equals(15));
 

--- a/test/unit/http/cdn_test.dart
+++ b/test/unit/http/cdn_test.dart
@@ -1,0 +1,18 @@
+import 'package:nyxx/nyxx.dart';
+import 'package:test/test.dart';
+
+import '../../mocks/client.dart';
+
+void main() {
+  test('CdnAsset', () {
+    final asset = CdnAsset(
+      client: MockNyxx(),
+      base: HttpRoute()
+        ..add(HttpRoutePart('hello'))
+        ..add(HttpRoutePart('world')),
+      hash: 'yup',
+    );
+
+    expect(asset.url.toString(), equals('https://cdn.discordapp.com/hello/world/yup.png'));
+  });
+}

--- a/test/unit/http/cdn_test.dart
+++ b/test/unit/http/cdn_test.dart
@@ -1,3 +1,4 @@
+import 'package:mocktail/mocktail.dart';
 import 'package:nyxx/nyxx.dart';
 import 'package:test/test.dart';
 
@@ -5,8 +6,12 @@ import '../../mocks/client.dart';
 
 void main() {
   test('CdnAsset', () {
+    final client = MockNyxx();
+
+    when(() => client.apiOptions).thenReturn(RestApiOptions(token: 'TEST_TOKEN'));
+
     final asset = CdnAsset(
-      client: MockNyxx(),
+      client: client,
       base: HttpRoute()
         ..add(HttpRoutePart('hello'))
         ..add(HttpRoutePart('world')),

--- a/test/unit/http/managers/member_manager_test.dart
+++ b/test/unit/http/managers/member_manager_test.dart
@@ -36,7 +36,6 @@ void checkMemberNoUser(Member member, {Snowflake expectedUserId = const Snowflak
   expect(member.isPending, isFalse);
   expect(member.permissions, isNull);
   expect(member.communicationDisabledUntil, isNull);
-  expect(member.bannerHash, isNotNull);
   expect(member.bannerHash, equals('a_coolHashDude'));
 }
 

--- a/test/unit/http/managers/member_manager_test.dart
+++ b/test/unit/http/managers/member_manager_test.dart
@@ -12,6 +12,7 @@ final sampleMemberNoUser = {
   "joined_at": "2015-04-26T06:26:56.936000+00:00",
   "deaf": false,
   "mute": false,
+  "banner": "a_coolHashDude",
 
   // These fields are documented as always present but are not in the provided sample
   "flags": 0,
@@ -35,6 +36,8 @@ void checkMemberNoUser(Member member, {Snowflake expectedUserId = const Snowflak
   expect(member.isPending, isFalse);
   expect(member.permissions, isNull);
   expect(member.communicationDisabledUntil, isNull);
+  expect(member.bannerHash, isNotNull);
+  expect(member.bannerHash, equals('a_coolHashDude'));
 }
 
 void checkMember(Member member, {Snowflake expectedUserId = const Snowflake(80351110224678912)}) {


### PR DESCRIPTION
# Description
This also fixes a bug where if you pass empty query parameters, the resulted URL would look like something like this `https://example.org?`

- https://github.com/discord/discord-api-docs/pull/6986


## Connected issues & other potential problems
-/-

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
