### PR TITLE
make webhook execute always apply name/avatar

### DIFF
--- a/lib/src/http/managers/webhook_manager.dart
+++ b/lib/src/http/managers/webhook_manager.dart
@@ -197,6 +197,8 @@ class WebhookManager extends Manager<Webhook> {
           ...builder.build(),
           if (threadName != null) 'thread_name': threadName,
           if (appliedTags != null) 'applied_tags': appliedTags.map((e) => e.toString()),
+          if (username != null) 'username': username,
+          if (avatarUrl != null) 'avatar_url': avatarUrl,
         }),
         queryParameters: queryParameters,
         authenticated: false,


### PR DESCRIPTION

# Description

Literally just made the [branch](https://github.com/chyzman/nyxx-chyz/blob/facfff47cabc1423d4b1af8013163b3201c84fe4/lib/src/http/managers/webhook_manager.dart#L193) of webhook.execute that doesn't include attachments not ignore name and avatar

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
