### PR TITLE
Add missing `approximateUserInstallCount` to `Application`

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -197,7 +197,8 @@ export 'src/models/application.dart'
         PartialApplication,
         ApplicationRoleConnectionMetadata,
         ConnectionMetadataType,
-        ApplicationIntegrationType;
+        ApplicationIntegrationType,
+        ApplicationIntegrationTypeConfiguration;
 export 'src/models/guild/template.dart' show GuildTemplate;
 export 'src/models/guild/auto_moderation.dart'
     show

--- a/lib/src/http/managers/application_manager.dart
+++ b/lib/src/http/managers/application_manager.dart
@@ -69,6 +69,7 @@ class ApplicationManager {
         },
       ),
       roleConnectionsVerificationUrl: maybeParse(raw['role_connections_verification_url'], Uri.parse),
+      approximateUserInstallCount: raw['approximate_user_install_count'] as int?,
     );
   }
 

--- a/lib/src/models/application.dart
+++ b/lib/src/models/application.dart
@@ -132,6 +132,9 @@ class Application extends PartialApplication {
   /// When configured, this will render the app as a verification method in the guild role verification configuration.
   final Uri? roleConnectionsVerificationUrl;
 
+  /// The approximate number of users that have installed this application.
+  final int? approximateUserInstallCount;
+
   /// {@macro application}
   /// @nodoc
   Application({
@@ -163,6 +166,7 @@ class Application extends PartialApplication {
     required this.integrationTypesConfig,
     required this.customInstallUrl,
     required this.roleConnectionsVerificationUrl,
+    required this.approximateUserInstallCount,
   });
 
   /// This application's icon.

--- a/test/unit/http/managers/application_manager_test.dart
+++ b/test/unit/http/managers/application_manager_test.dart
@@ -14,6 +14,20 @@ final sampleApplication = {
   "guild_id": "290926798626357260",
   "icon": null,
   "id": "172150183260323840",
+  "integration_types_config": {
+    "0": {
+      "oauth2_install_params": {
+        "scopes": ["applications.commands", "bot"],
+        "permissions": "2048"
+      }
+    },
+    "1": {
+      "oauth2_install_params": {
+        "scopes": ["applications.commands"],
+        "permissions": "0"
+      }
+    }
+  },
   "name": "Baba O-Riley",
   "owner": {"avatar": null, "discriminator": "1738", "flags": 1024, "id": "172150183260323840", "username": "i own a bot"},
   "primary_sku_id": "172150183260323840",
@@ -25,9 +39,10 @@ final sampleApplication = {
     "members": [
       {
         "membership_state": 2,
+        "permissions": ["*"],
         "team_id": "531992624043786253",
-        "user": {"avatar": "d9e261cd35999608eb7e3de1fae3688b", "discriminator": "0001", "id": "511972282709709995", "username": "Mr Owner"},
         "role": "admin",
+        "user": {"avatar": "d9e261cd35999608eb7e3de1fae3688b", "discriminator": "0001", "id": "511972282709709995", "username": "Mr Owner"}
       }
     ],
 
@@ -60,6 +75,13 @@ void checkApplication(Application application) {
   expect(application.installationParameters, isNull);
   expect(application.customInstallUrl, isNull);
   expect(application.roleConnectionsVerificationUrl, isNull);
+  expect(application.integrationTypesConfig?[ApplicationIntegrationType.guildInstall], isNotNull);
+  expect(application.integrationTypesConfig![ApplicationIntegrationType.guildInstall]!, (ApplicationIntegrationTypeConfiguration config) {
+    expect(config.oauth2InstallParameters, isNotNull);
+    expect(config.oauth2InstallParameters!.scopes, equals(["applications.commands", "bot"]));
+    expect(config.oauth2InstallParameters!.permissions, equals(Permissions(2048)));
+    return true;
+  });
 }
 
 final sampleRoleConnectionMetadata = {


### PR DESCRIPTION
# Description

Updates `Application` to match current documentation. Also fixes an unexported type related to applications.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
