### PR TITLE
Add recurrence rules for scheduled events

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -187,7 +187,19 @@ export 'src/models/guild/integration.dart' show PartialIntegration, Integration,
 export 'src/models/guild/member.dart' show Member, MemberFlags, PartialMember;
 export 'src/models/guild/onboarding.dart' show Onboarding, OnboardingPrompt, OnboardingPromptOption, OnboardingPromptType;
 export 'src/models/guild/welcome_screen.dart' show WelcomeScreen, WelcomeScreenChannel;
-export 'src/models/guild/scheduled_event.dart' show EntityMetadata, PartialScheduledEvent, ScheduledEvent, ScheduledEventUser, EventStatus, ScheduledEntityType;
+export 'src/models/guild/scheduled_event.dart'
+    show
+        EntityMetadata,
+        PartialScheduledEvent,
+        ScheduledEvent,
+        ScheduledEventUser,
+        EventStatus,
+        ScheduledEntityType,
+        RecurrenceRule,
+        RecurrenceRuleFrequency,
+        RecurrenceRuleMonth,
+        RecurrenceRuleNWeekday,
+        RecurrenceRuleWeekday;
 export 'src/models/guild/audit_log.dart' show AuditLogChange, AuditLogEntry, AuditLogEntryInfo, PartialAuditLogEntry, AuditLogEvent;
 export 'src/models/application.dart'
     show

--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -54,7 +54,7 @@ export 'src/builders/guild/guild.dart' show GuildBuilder, GuildUpdateBuilder;
 export 'src/builders/guild/member.dart' show CurrentMemberUpdateBuilder, MemberBuilder, MemberUpdateBuilder;
 export 'src/builders/guild/welcome_screen.dart' show WelcomeScreenUpdateBuilder;
 export 'src/builders/guild/widget.dart' show WidgetSettingsUpdateBuilder;
-export 'src/builders/guild/scheduled_event.dart' show ScheduledEventBuilder, ScheduledEventUpdateBuilder;
+export 'src/builders/guild/scheduled_event.dart' show ScheduledEventBuilder, ScheduledEventUpdateBuilder, RecurrenceRuleBuilder;
 export 'src/builders/guild/template.dart' show GuildTemplateBuilder, GuildTemplateUpdateBuilder;
 export 'src/builders/guild/auto_moderation.dart'
     show AutoModerationRuleBuilder, AutoModerationRuleUpdateBuilder, ActionMetadataBuilder, AutoModerationActionBuilder;

--- a/lib/src/builders/guild/scheduled_event.dart
+++ b/lib/src/builders/guild/scheduled_event.dart
@@ -39,6 +39,40 @@ class ScheduledEventBuilder extends CreateBuilder<ScheduledEvent> {
     this.recurrenceRule,
   });
 
+  ScheduledEventBuilder.stageInstance({
+    required Snowflake this.channelId,
+    required this.name,
+    required this.privacyLevel,
+    required this.scheduledStartTime,
+    this.scheduledEndTime,
+    this.description,
+    this.image,
+    this.recurrenceRule,
+  }) : type = ScheduledEntityType.stageInstance;
+
+  ScheduledEventBuilder.voice({
+    required Snowflake this.channelId,
+    required this.name,
+    required this.privacyLevel,
+    required this.scheduledStartTime,
+    this.scheduledEndTime,
+    this.description,
+    this.image,
+    this.recurrenceRule,
+  }) : type = ScheduledEntityType.voice;
+
+  ScheduledEventBuilder.external({
+    required this.name,
+    required this.privacyLevel,
+    required this.scheduledStartTime,
+    required DateTime this.scheduledEndTime,
+    required String location,
+    this.description,
+    this.image,
+    this.recurrenceRule,
+  })  : type = ScheduledEntityType.external,
+        metadata = EntityMetadata(location: location);
+
   @override
   Map<String, Object?> build() => {
         if (channelId != null) 'channel_id': channelId.toString(),

--- a/lib/src/builders/guild/scheduled_event.dart
+++ b/lib/src/builders/guild/scheduled_event.dart
@@ -42,7 +42,7 @@ class ScheduledEventBuilder extends CreateBuilder<ScheduledEvent> {
   @override
   Map<String, Object?> build() => {
         if (channelId != null) 'channel_id': channelId.toString(),
-        if (metadata != null) 'metadata': {'location': metadata!.location},
+        if (metadata != null) 'entity_metadata': {'location': metadata!.location},
         'name': name,
         'privacy_level': privacyLevel.value,
         'scheduled_start_time': scheduledStartTime.toIso8601String(),

--- a/lib/src/builders/guild/scheduled_event.dart
+++ b/lib/src/builders/guild/scheduled_event.dart
@@ -126,6 +126,30 @@ class RecurrenceRuleBuilder extends CreateBuilder<RecurrenceRule> {
     this.byMonthDay,
   });
 
+  RecurrenceRuleBuilder.daily({required this.start, this.byWeekday})
+      : frequency = RecurrenceRuleFrequency.daily,
+        interval = 1;
+
+  RecurrenceRuleBuilder.weekly({
+    required this.start,
+    required this.interval,
+    RecurrenceRuleWeekday? day,
+  })  : frequency = RecurrenceRuleFrequency.weekly,
+        byWeekday = day == null ? null : [day];
+
+  RecurrenceRuleBuilder.monthly({
+    required this.start,
+    RecurrenceRuleNWeekday? day,
+  })  : frequency = RecurrenceRuleFrequency.monthly,
+        interval = 1,
+        byNWeekday = day == null ? null : [day];
+
+  RecurrenceRuleBuilder.yearly({required this.start, (RecurrenceRuleMonth, int)? day})
+      : frequency = RecurrenceRuleFrequency.yearly,
+        interval = 1,
+        byMonth = day == null ? null : [day.$1],
+        byMonthDay = day == null ? null : [day.$2];
+
   @override
   Map<String, Object?> build() => {
         'start': start.toIso8601String(),

--- a/lib/src/builders/guild/scheduled_event.dart
+++ b/lib/src/builders/guild/scheduled_event.dart
@@ -27,12 +27,12 @@ class ScheduledEventBuilder extends CreateBuilder<ScheduledEvent> {
   RecurrenceRuleBuilder? recurrenceRule;
 
   ScheduledEventBuilder({
-    required this.channelId,
+    this.channelId,
     this.metadata,
     required this.name,
     required this.privacyLevel,
     required this.scheduledStartTime,
-    required this.scheduledEndTime,
+    this.scheduledEndTime,
     this.description,
     required this.type,
     this.image,

--- a/lib/src/builders/guild/scheduled_event.dart
+++ b/lib/src/builders/guild/scheduled_event.dart
@@ -24,6 +24,8 @@ class ScheduledEventBuilder extends CreateBuilder<ScheduledEvent> {
 
   ImageBuilder? image;
 
+  RecurrenceRuleBuilder? recurrenceRule;
+
   ScheduledEventBuilder({
     required this.channelId,
     this.metadata,
@@ -34,6 +36,7 @@ class ScheduledEventBuilder extends CreateBuilder<ScheduledEvent> {
     this.description,
     required this.type,
     this.image,
+    this.recurrenceRule,
   });
 
   @override
@@ -47,6 +50,7 @@ class ScheduledEventBuilder extends CreateBuilder<ScheduledEvent> {
         if (description != null) 'description': description,
         'entity_type': type.value,
         if (image != null) 'image': image!.buildDataString(),
+        if (recurrenceRule != null) 'recurrence_rule': recurrenceRule!.build(),
       };
 }
 
@@ -71,6 +75,8 @@ class ScheduledEventUpdateBuilder extends UpdateBuilder<ScheduledEvent> {
 
   ImageBuilder? image;
 
+  RecurrenceRuleBuilder? recurrenceRule;
+
   ScheduledEventUpdateBuilder({
     this.channelId = sentinelSnowflake,
     this.metadata = sentinelEntityMetadata,
@@ -82,6 +88,7 @@ class ScheduledEventUpdateBuilder extends UpdateBuilder<ScheduledEvent> {
     this.type,
     this.status,
     this.image,
+    this.recurrenceRule,
   });
 
   @override
@@ -96,5 +103,37 @@ class ScheduledEventUpdateBuilder extends UpdateBuilder<ScheduledEvent> {
         if (type != null) 'entity_type': type!.value,
         if (status != null) 'status': status!.value,
         if (image != null) 'image': image!.buildDataString(),
+        if (recurrenceRule != null) 'recurrence_rule': recurrenceRule!.build(),
+      };
+}
+
+class RecurrenceRuleBuilder extends CreateBuilder<RecurrenceRule> {
+  DateTime start;
+  RecurrenceRuleFrequency frequency;
+  int interval;
+  List<RecurrenceRuleWeekday>? byWeekday;
+  List<RecurrenceRuleNWeekday>? byNWeekday;
+  List<RecurrenceRuleMonth>? byMonth;
+  List<int>? byMonthDay;
+
+  RecurrenceRuleBuilder({
+    required this.start,
+    required this.frequency,
+    required this.interval,
+    this.byWeekday,
+    this.byNWeekday,
+    this.byMonth,
+    this.byMonthDay,
+  });
+
+  @override
+  Map<String, Object?> build() => {
+        'start': start.toIso8601String(),
+        'frequency': frequency.value,
+        'interval': interval,
+        'by_weekday': byWeekday?.map((weekday) => weekday.value).toList(),
+        'by_n_weekday': byNWeekday?.map((nWeekday) => {'n': nWeekday.n, 'day': nWeekday.day.value}).toList(),
+        'by_month': byMonth?.map((month) => month.value).toList(),
+        'by_month_day': byMonthDay,
       };
 }

--- a/lib/src/http/managers/scheduled_event_manager.dart
+++ b/lib/src/http/managers/scheduled_event_manager.dart
@@ -40,6 +40,7 @@ class ScheduledEventManager extends Manager<ScheduledEvent> {
       creator: maybeParse(raw['creator'], client.users.parse),
       userCount: raw['user_count'] as int?,
       coverImageHash: raw['image'] as String?,
+      recurrenceRule: maybeParse(raw['recurrence_rule'], parseRecurrenceRule),
     );
   }
 
@@ -57,6 +58,28 @@ class ScheduledEventManager extends Manager<ScheduledEvent> {
       scheduledEventId: Snowflake.parse(raw['guild_scheduled_event_id']!),
       user: user,
       member: maybeParse(raw['member'], (Map<String, Object?> raw) => client.guilds[guildId].members.parse(raw, userId: user.id)),
+    );
+  }
+
+  RecurrenceRule parseRecurrenceRule(Map<String, Object?> raw) {
+    return RecurrenceRule(
+      start: DateTime.parse(raw['start'] as String),
+      end: maybeParse(raw['end'], DateTime.parse),
+      frequency: RecurrenceRuleFrequency(raw['frequency'] as int),
+      interval: raw['interval'] as int,
+      byWeekday: maybeParseMany(raw['by_weekday'], RecurrenceRuleWeekday.new),
+      byNWeekday: maybeParseMany(raw['by_n_weekday'], parseRecurrenceRuleNWeekday),
+      byMonth: maybeParseMany(raw['by_month'], RecurrenceRuleMonth.new),
+      byMonthDay: maybeParseMany(raw['by_month_day']),
+      byYearDay: maybeParseMany(raw['by_year_day']),
+      count: raw['count'] as int?,
+    );
+  }
+
+  RecurrenceRuleNWeekday parseRecurrenceRuleNWeekday(Map<String, Object?> raw) {
+    return RecurrenceRuleNWeekday(
+      n: raw['n'] as int,
+      day: RecurrenceRuleWeekday(raw['day'] as int),
     );
   }
 

--- a/lib/src/models/guild/scheduled_event.dart
+++ b/lib/src/models/guild/scheduled_event.dart
@@ -76,6 +76,9 @@ class ScheduledEvent extends PartialScheduledEvent {
   /// The hash of this event's cover image.
   final String? coverImageHash;
 
+  /// The rule defining how often this event should recur.
+  final RecurrenceRule? recurrenceRule;
+
   /// {@macro scheduled_event}
   /// @nodoc
   ScheduledEvent({
@@ -96,6 +99,7 @@ class ScheduledEvent extends PartialScheduledEvent {
     required this.creator,
     required this.userCount,
     required this.coverImageHash,
+    required this.recurrenceRule,
   });
 
   /// The guild this event is in.
@@ -182,4 +186,119 @@ class ScheduledEventUser with ToStringHelper {
 
   /// The event the user followed.
   PartialScheduledEvent get scheduledEvent => manager[scheduledEventId];
+}
+
+/// Indicates how often a [ScheduledEvent] should recur.
+///
+/// See also:
+/// * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-recurrence-rule-object
+class RecurrenceRule with ToStringHelper {
+  /// The start of the interval within which the event recurs.
+  final DateTime start;
+
+  /// The end of the interval within which the event recurs.
+  final DateTime? end;
+
+  /// The frequency this rule applies to.
+  final RecurrenceRuleFrequency frequency;
+
+  /// The spacing between each recurrence of the event, in multiples of [frequency].
+  final int interval;
+
+  /// The specific days within a week the event recurs on.
+  final List<RecurrenceRuleWeekday>? byWeekday;
+
+  /// The specific days within a specific week the event recurs on.
+  final List<RecurrenceRuleNWeekday>? byNWeekday;
+
+  /// The specific months the event recurs on.
+  final List<RecurrenceRuleMonth>? byMonth;
+
+  /// The specific days within a month the event recurs on.
+  final List<int>? byMonthDay;
+
+  /// The specific days within a year the event recurs on.
+  final List<int>? byYearDay;
+
+  /// The total number of times the event is allowed to recur before stopping.
+  final int? count;
+
+  /// @nodoc
+  RecurrenceRule({
+    required this.start,
+    required this.end,
+    required this.frequency,
+    required this.interval,
+    required this.byWeekday,
+    required this.byNWeekday,
+    required this.byMonth,
+    required this.byMonthDay,
+    required this.byYearDay,
+    required this.count,
+  });
+}
+
+/// The frequency with which a [ScheduledEvent] can recur.
+final class RecurrenceRuleFrequency extends EnumLike<int, RecurrenceRuleFrequency> {
+  /// The event recurs at an interval in years.
+  static const yearly = RecurrenceRuleFrequency(0);
+
+  /// The event recurs at an interval in months.
+  static const monthly = RecurrenceRuleFrequency(1);
+
+  /// The event recurs at an interval in weeks.
+  static const weekly = RecurrenceRuleFrequency(2);
+
+  /// The event recurs at an interval in days.
+  static const daily = RecurrenceRuleFrequency(3);
+
+  /// @nodoc
+  const RecurrenceRuleFrequency(super.value);
+}
+
+/// The weekday on which a [ScheduledEvent] recurs.
+final class RecurrenceRuleWeekday extends EnumLike<int, RecurrenceRuleWeekday> {
+  static const monday = RecurrenceRuleWeekday(0);
+  static const tuesday = RecurrenceRuleWeekday(1);
+  static const wednesday = RecurrenceRuleWeekday(2);
+  static const thursday = RecurrenceRuleWeekday(3);
+  static const friday = RecurrenceRuleWeekday(4);
+  static const saturday = RecurrenceRuleWeekday(5);
+  static const sunday = RecurrenceRuleWeekday(6);
+
+  /// @nodoc
+  const RecurrenceRuleWeekday(super.value);
+}
+
+/// The week and weekday on which a [ScheduledEvent] recurs.
+class RecurrenceRuleNWeekday with ToStringHelper {
+  /// The index of the week in which the event recurs.
+  ///
+  /// This will always be at least 1 and at most 5.
+  final int n;
+
+  /// The day in the week on which the event recurs.
+  final RecurrenceRuleWeekday day;
+
+  /// @nodoc
+  RecurrenceRuleNWeekday({required this.n, required this.day});
+}
+
+/// The month on which a [ScheduledEvent] recurs.
+final class RecurrenceRuleMonth extends EnumLike<int, RecurrenceRuleMonth> {
+  static const january = RecurrenceRuleMonth(0);
+  static const february = RecurrenceRuleMonth(1);
+  static const march = RecurrenceRuleMonth(2);
+  static const april = RecurrenceRuleMonth(3);
+  static const may = RecurrenceRuleMonth(4);
+  static const june = RecurrenceRuleMonth(5);
+  static const july = RecurrenceRuleMonth(6);
+  static const august = RecurrenceRuleMonth(7);
+  static const september = RecurrenceRuleMonth(8);
+  static const october = RecurrenceRuleMonth(9);
+  static const november = RecurrenceRuleMonth(10);
+  static const december = RecurrenceRuleMonth(11);
+
+  /// @nodoc
+  const RecurrenceRuleMonth(super.value);
 }

--- a/test/unit/http/managers/scheduled_event_manager_test.dart
+++ b/test/unit/http/managers/scheduled_event_manager_test.dart
@@ -6,73 +6,104 @@ import 'member_manager_test.dart';
 import 'user_manager_test.dart';
 
 final sampleScheduledEvent = {
-  'id': '0',
-  'guild_id': '1',
-  'channel_id': '2',
-  'creator_id': '3',
-  'name': 'test',
-  'description': 'a test event',
-  'scheduled_start_time': '2023-06-10T16:37:18Z',
-  'scheduled_end_time': '2023-06-10T16:37:18Z',
-  'privacy_level': 2,
-  'status': 1,
-  'entity_type': 1,
-  'entity_id': '2',
-  'creator': sampleUser,
-  'user_count': null,
-  'image': null,
-};
-
-final sampleScheduledEvent2 = {
-  'id': '0',
-  'guild_id': '1',
-  'creator_id': '3',
-  'name': 'test',
-  'description': 'a test event',
-  'scheduled_start_time': '2023-06-10T16:37:18Z',
-  'scheduled_end_time': '2023-06-10T16:37:18Z',
-  'privacy_level': 2,
-  'status': 1,
-  'entity_type': 1,
-  'entity_id': '2',
-  'creator': sampleUser,
-  'user_count': null,
-  'image': null,
+  "id": "1278775959230611487",
+  "guild_id": "1033681997136146462",
+  "name": "test event",
+  "description": null,
+  "channel_id": null,
+  "creator_id": "1033681843708510238",
+  "image": null,
+  "scheduled_start_time": "2024-08-29T19:59:07.045563+00:00",
+  "scheduled_end_time": "2024-08-29T19:59:17.045564+00:00",
+  "status": 1,
+  "entity_type": 3,
+  "entity_id": null,
+  "recurrence_rule": {
+    "start": "2024-08-29T19:59:07.045594+00:00",
+    "end": null,
+    "frequency": 2,
+    "interval": 1,
+    "by_weekday": [2],
+    "by_n_weekday": null,
+    "by_month": null,
+    "by_month_day": null,
+    "by_year_day": null,
+    "count": null
+  },
+  "privacy_level": 2,
+  "sku_ids": [],
+  "guild_scheduled_event_exceptions": [],
+  "entity_metadata": {"location": "test location"}
 };
 
 void checkScheduledEvent(ScheduledEvent event) {
-  expect(event.id, equals(Snowflake.zero));
-  expect(event.guildId, equals(Snowflake(1)));
-  expect(event.channelId, equals(Snowflake(2)));
-  expect(event.creatorId, equals(Snowflake(3)));
-  expect(event.name, equals('test'));
-  expect(event.description, equals('a test event'));
-  expect(event.scheduledStartTime, equals(DateTime.utc(2023, 06, 10, 16, 37, 18)));
-  expect(event.scheduledEndTime, equals(DateTime.utc(2023, 06, 10, 16, 37, 18)));
+  expect(event.id, equals(Snowflake(1278775959230611487)));
+  expect(event.guildId, equals(Snowflake(1033681997136146462)));
+  expect(event.channelId, isNull);
+  expect(event.creatorId, equals(Snowflake(1033681843708510238)));
+  expect(event.name, equals('test event'));
+  expect(event.description, isNull);
+  expect(event.scheduledStartTime, equals(DateTime.utc(2024, 08, 29, 19, 59, 07, 45, 563)));
+  expect(event.scheduledEndTime, equals(DateTime.utc(2024, 08, 29, 19, 59, 17, 45, 564)));
   expect(event.privacyLevel, equals(PrivacyLevel.guildOnly));
   expect(event.status, equals(EventStatus.scheduled));
-  expect(event.type, equals(ScheduledEntityType.stageInstance));
-  expect(event.entityId, equals(Snowflake(2)));
-  expect(event.metadata, isNull);
-  checkSampleUser(event.creator!);
+  expect(event.type, equals(ScheduledEntityType.external));
+  expect(event.entityId, isNull);
+  expect(event.metadata?.location, equals('test location'));
   expect(event.userCount, isNull);
   expect(event.coverImageHash, isNull);
+  expect(event.recurrenceRule, isNotNull);
+  expect(event.recurrenceRule, (RecurrenceRule rule) {
+    expect(rule.byMonth, isNull);
+    expect(rule.byMonthDay, isNull);
+    expect(rule.byNWeekday, isNull);
+    expect(rule.byWeekday, equals([RecurrenceRuleWeekday.wednesday]));
+    expect(rule.byYearDay, isNull);
+    expect(rule.count, isNull);
+    expect(rule.end, isNull);
+    expect(rule.frequency, equals(RecurrenceRuleFrequency.weekly));
+    expect(rule.interval, equals(1));
+    expect(rule.start, equals(DateTime.utc(2024, 08, 29, 19, 59, 07, 045, 594)));
+    return true;
+  });
 }
 
+final sampleScheduledEvent2 = {
+  "id": "1278778514790944793",
+  "guild_id": "1033681997136146462",
+  "name": "test event",
+  "description": "",
+  "channel_id": "1105193130237632574",
+  "creator_id": "506759329068613643",
+  "creator": sampleUser,
+  "image": null,
+  "scheduled_start_time": "2024-08-29T19:00:00.859000+00:00",
+  "scheduled_end_time": null,
+  "status": 1,
+  "entity_type": 2,
+  "entity_id": null,
+  "recurrence_rule": null,
+  "privacy_level": 2,
+  "sku_ids": [],
+  "guild_scheduled_event_exceptions": [],
+  "entity_metadata": <String, Object?>{},
+};
+
 void checkScheduledEvent2(ScheduledEvent event) {
-  expect(event.id, equals(Snowflake.zero));
-  expect(event.guildId, equals(Snowflake(1)));
-  expect(event.channelId, isNull);
-  expect(event.creatorId, equals(Snowflake(3)));
-  expect(event.name, equals('test'));
-  expect(event.description, equals('a test event'));
-  expect(event.scheduledStartTime, equals(DateTime.utc(2023, 06, 10, 16, 37, 18)));
-  expect(event.scheduledEndTime, equals(DateTime.utc(2023, 06, 10, 16, 37, 18)));
+  expect(event.id, equals(Snowflake(1278778514790944793)));
+  expect(event.guildId, equals(Snowflake(1033681997136146462)));
+  expect(event.channelId, equals(Snowflake(1105193130237632574)));
+  expect(event.creatorId, equals(Snowflake(506759329068613643)));
+  expect(event.name, equals('test event'));
+  expect(event.description, equals(''));
+  expect(event.scheduledStartTime, equals(DateTime.utc(2024, 08, 29, 19, 00, 00, 859)));
+  expect(event.scheduledEndTime, isNull);
   expect(event.privacyLevel, equals(PrivacyLevel.guildOnly));
   expect(event.status, equals(EventStatus.scheduled));
-  expect(event.type, equals(ScheduledEntityType.stageInstance));
-  expect(event.entityId, equals(Snowflake(2)));
-  expect(event.metadata, isNull);
+  expect(event.type, equals(ScheduledEntityType.voice));
+  expect(event.entityId, isNull);
+  expect(event.metadata, isNotNull);
+  expect(event.metadata!.location, isNull);
   checkSampleUser(event.creator!);
   expect(event.userCount, isNull);
   expect(event.coverImageHash, isNull);
@@ -134,8 +165,8 @@ void main() {
       channelId: Snowflake.zero,
       name: 'test',
       privacyLevel: PrivacyLevel.guildOnly,
-      scheduledStartTime: DateTime(2023),
-      scheduledEndTime: DateTime(2023),
+      scheduledStartTime: DateTime.utc(2023),
+      scheduledEndTime: DateTime.utc(2023),
       type: ScheduledEntityType.stageInstance,
     ),
     updateBuilder: ScheduledEventUpdateBuilder(),


### PR DESCRIPTION
# Description

Adds the new recurrence rules for scheduled events, as well as fixing a serialization issue with scheduled event builders and adding some helper constructors due to field requirements changing based on event type.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
