### PR TITLE
Add support for subscriptions

### DIFF
--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -102,6 +102,7 @@ export 'src/http/managers/sticker_manager.dart' show GuildStickerManager, Global
 export 'src/http/managers/application_command_manager.dart' show ApplicationCommandManager, GlobalApplicationCommandManager, GuildApplicationCommandManager;
 export 'src/http/managers/interaction_manager.dart' show InteractionManager;
 export 'src/http/managers/entitlement_manager.dart' show EntitlementManager;
+export 'src/http/managers/sku_manager.dart' show SkuManager;
 
 export 'src/gateway/gateway.dart' show Gateway;
 export 'src/gateway/message.dart'
@@ -315,7 +316,7 @@ export 'src/models/interaction.dart'
         PingInteraction,
         InteractionContextType;
 export 'src/models/entitlement.dart' show Entitlement, PartialEntitlement, EntitlementType;
-export 'src/models/sku.dart' show Sku, SkuType, SkuFlags;
+export 'src/models/sku.dart' show Sku, SkuType, SkuFlags, PartialSku;
 export 'src/models/oauth2.dart' show OAuth2Information;
 
 export 'src/utils/flags.dart' show Flag, Flags;

--- a/lib/nyxx.dart
+++ b/lib/nyxx.dart
@@ -103,6 +103,7 @@ export 'src/http/managers/application_command_manager.dart' show ApplicationComm
 export 'src/http/managers/interaction_manager.dart' show InteractionManager;
 export 'src/http/managers/entitlement_manager.dart' show EntitlementManager;
 export 'src/http/managers/sku_manager.dart' show SkuManager;
+export 'src/http/managers/subscription_manager.dart' show SubscriptionManager;
 
 export 'src/gateway/gateway.dart' show Gateway;
 export 'src/gateway/message.dart'
@@ -318,6 +319,7 @@ export 'src/models/interaction.dart'
 export 'src/models/entitlement.dart' show Entitlement, PartialEntitlement, EntitlementType;
 export 'src/models/sku.dart' show Sku, SkuType, SkuFlags, PartialSku;
 export 'src/models/oauth2.dart' show OAuth2Information;
+export 'src/models/subscription.dart' show PartialSubscription, Subscription, SubscriptionStatus;
 
 export 'src/utils/flags.dart' show Flag, Flags;
 export 'src/intents.dart' show GatewayIntents;

--- a/lib/src/client_options.dart
+++ b/lib/src/client_options.dart
@@ -15,6 +15,7 @@ import 'package:nyxx/src/models/guild/member.dart';
 import 'package:nyxx/src/models/guild/scheduled_event.dart';
 import 'package:nyxx/src/models/message/message.dart';
 import 'package:nyxx/src/models/role.dart';
+import 'package:nyxx/src/models/sku.dart';
 import 'package:nyxx/src/models/sticker/global_sticker.dart';
 import 'package:nyxx/src/models/sticker/guild_sticker.dart';
 import 'package:nyxx/src/models/user/user.dart';
@@ -108,6 +109,9 @@ class RestClientOptions extends ClientOptions {
   /// The [CacheConfig] to use for the [Application.entitlements] manager.
   final CacheConfig<Entitlement> entitlementConfig;
 
+  /// The [CacheConfig] to use for the [Application.skus] manager.
+  final CacheConfig<Sku> skuConfig;
+
   /// Create a new [RestClientOptions].
   const RestClientOptions({
     super.plugins,
@@ -132,6 +136,7 @@ class RestClientOptions extends ClientOptions {
     this.applicationCommandConfig = const CacheConfig(),
     this.commandPermissionsConfig = const CacheConfig(),
     this.entitlementConfig = const CacheConfig(),
+    this.skuConfig = const CacheConfig(),
   });
 }
 
@@ -166,5 +171,9 @@ class GatewayClientOptions extends RestClientOptions {
     super.applicationCommandConfig,
     super.commandPermissionsConfig,
     super.entitlementConfig,
+    super.skuConfig,
+    super.emojiCacheConfig,
+    super.globalStickerCacheConfig,
+    super.stickerCacheConfig,
   });
 }

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -81,6 +81,18 @@ class EntitlementNotFoundException extends NyxxException {
   EntitlementNotFoundException(this.applicationId, this.entitlementId) : super('Entitlement $entitlementId not found for application $applicationId');
 }
 
+/// An exception thrown when an SKU is not found for an application.
+class SkuNotFoundException extends NyxxException {
+  /// The ID of the application.
+  final Snowflake applicationId;
+
+  /// The ID of the sku.
+  final Snowflake skuId;
+
+  /// Create a new [skuNotFoundException].
+  SkuNotFoundException(this.applicationId, this.skuId) : super('SKU $skuId not found for application $applicationId');
+}
+
 /// An error thrown when a shard disconnects unexpectedly.
 class ShardDisconnectedError extends Error {
   /// The shard that was disconnected.

--- a/lib/src/http/managers/application_manager.dart
+++ b/lib/src/http/managers/application_manager.dart
@@ -128,16 +128,11 @@ class ApplicationManager {
   }
 
   /// Parse a [Sku] from [raw].
+  @Deprecated('Use SkuManager.parse')
   Sku parseSku(Map<String, Object?> raw) {
-    return Sku(
-      manager: this,
-      id: Snowflake.parse(raw['id']!),
-      type: SkuType(raw['type'] as int),
-      applicationId: Snowflake.parse(raw['application_id']!),
-      name: raw['name'] as String,
-      slug: raw['slug'] as String,
-      flags: SkuFlags(raw['flags'] as int),
-    );
+    final applicationId = Snowflake.parse(raw['application_id']!);
+
+    return client.applications[applicationId].skus.parse(raw);
   }
 
   /// Fetch an application's role connection metadata.
@@ -194,13 +189,6 @@ class ApplicationManager {
   }
 
   /// List this application's SKUs.
-  Future<List<Sku>> listSkus(Snowflake id) async {
-    final route = HttpRoute()
-      ..applications(id: id.toString())
-      ..skus();
-    final request = BasicRequest(route);
-
-    final response = await client.httpHandler.executeSafe(request);
-    return parseMany(response.jsonBody as List, parseSku);
-  }
+  @Deprecated('Use SkuManager.list')
+  Future<List<Sku>> listSkus(Snowflake id) => client.applications[id].skus.list();
 }

--- a/lib/src/http/managers/sku_manager.dart
+++ b/lib/src/http/managers/sku_manager.dart
@@ -1,0 +1,53 @@
+import 'package:nyxx/src/errors.dart';
+import 'package:nyxx/src/http/managers/manager.dart';
+import 'package:nyxx/src/http/request.dart';
+import 'package:nyxx/src/http/route.dart';
+import 'package:nyxx/src/models/sku.dart';
+import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/utils/parsing_helpers.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
+
+class SkuManager extends ReadOnlyManager<Sku> {
+  final Snowflake applicationId;
+
+  SkuManager(super.config, super.client, {required this.applicationId}) : super(identifier: '$applicationId.skus');
+
+  @override
+  PartialSku operator [](Snowflake id) => PartialSku(manager: this, id: id);
+
+  @override
+  Sku parse(Map<String, Object?> raw) {
+    return Sku(
+      manager: this,
+      id: Snowflake.parse(raw['id']!),
+      type: SkuType(raw['type'] as int),
+      applicationId: Snowflake.parse(raw['application_id']!),
+      name: raw['name'] as String,
+      slug: raw['slug'] as String,
+      flags: SkuFlags(raw['flags'] as int),
+    );
+  }
+
+  Future<List<Sku>> list() async {
+    final route = HttpRoute()
+      ..applications(id: applicationId.toString())
+      ..skus();
+    final request = BasicRequest(route);
+
+    final response = await client.httpHandler.executeSafe(request);
+    final skus = parseMany(response.jsonBody as List, parse);
+
+    skus.forEach(client.updateCacheWith);
+    return skus;
+  }
+
+  @override
+  Future<Sku> fetch(Snowflake id) async {
+    final skus = await list();
+
+    return skus.firstWhere(
+      (sku) => sku.id == id,
+      orElse: () => throw SkuNotFoundException(applicationId, id),
+    );
+  }
+}

--- a/lib/src/http/managers/subscription_manager.dart
+++ b/lib/src/http/managers/subscription_manager.dart
@@ -1,0 +1,66 @@
+import 'package:nyxx/src/http/managers/manager.dart';
+import 'package:nyxx/src/http/request.dart';
+import 'package:nyxx/src/http/route.dart';
+import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/models/subscription.dart';
+import 'package:nyxx/src/utils/parsing_helpers.dart';
+import 'package:nyxx/src/utils/cache_helpers.dart';
+
+class SubscriptionManager extends ReadOnlyManager<Subscription> {
+  final Snowflake applicationId;
+  final Snowflake skuId;
+
+  SubscriptionManager(super.client, super.config, {required this.applicationId, required this.skuId})
+      : super(identifier: '$applicationId.$skuId.subscriptions');
+
+  @override
+  PartialSubscription operator [](Snowflake id) => PartialSubscription(manager: this, id: id);
+
+  @override
+  Subscription parse(Map<String, Object?> raw) {
+    return Subscription(
+      manager: this,
+      id: Snowflake.parse(raw['id']!),
+      userId: Snowflake.parse(raw['user_id']!),
+      skuIds: parseMany(raw['sku_ids'] as List, Snowflake.parse),
+      entitlementIds: parseMany(raw['entitlement_ids'] as List, Snowflake.parse),
+      currentPeriodStart: DateTime.parse(raw['current_period_start'] as String),
+      currentPeriodEnd: DateTime.parse(raw['current_period_end'] as String),
+      status: SubscriptionStatus(raw['status'] as int),
+      canceledAt: maybeParse(raw['canceled_at'], DateTime.parse),
+      countryCode: raw['country'] as String?,
+    );
+  }
+
+  @override
+  Future<Subscription> fetch(Snowflake id) async {
+    final route = HttpRoute()
+      ..skus(id: skuId.toString())
+      ..subscriptions(id: id.toString());
+    final request = BasicRequest(route);
+
+    final response = await client.httpHandler.executeSafe(request);
+    final subscription = parse(response.jsonBody as Map<String, Object?>);
+
+    client.updateCacheWith(subscription);
+    return subscription;
+  }
+
+  Future<List<Subscription>> list({Snowflake? before, Snowflake? after, int? limit, Snowflake? userId}) async {
+    final route = HttpRoute()
+      ..skus(id: skuId.toString())
+      ..subscriptions();
+    final request = BasicRequest(route, queryParameters: {
+      if (before != null) 'before': before.toString(),
+      if (after != null) 'after': after.toString(),
+      if (limit != null) 'limit': limit.toString(),
+      if (userId != null) 'user_id': userId.toString(),
+    });
+
+    final response = await client.httpHandler.executeSafe(request);
+    final subscriptions = parseMany(response.jsonBody as List, parse);
+
+    subscriptions.forEach(client.updateCacheWith);
+    return subscriptions;
+  }
+}

--- a/lib/src/http/route.dart
+++ b/lib/src/http/route.dart
@@ -329,4 +329,7 @@ extension RouteHelpers on HttpRoute {
 
   /// Adds the [`bulk-ban`](https://discord.com/developers/docs/resources/guild#bulk-guild-ban) part to this [HttpRoute].
   void bulkBan() => add(HttpRoutePart('bulk-ban'));
+
+  /// Adds the [`subscriptions`](https://discord.com/developers/docs/resources/subscription#list-sku-subscriptions) part to this [HttpRoute].
+  void subscriptions({String? id}) => add(HttpRoutePart('subscriptions', [if (id != null) HttpRouteParam(id)]));
 }

--- a/lib/src/http/route.dart
+++ b/lib/src/http/route.dart
@@ -307,7 +307,7 @@ extension RouteHelpers on HttpRoute {
   void entitlements({String? id}) => add(HttpRoutePart('entitlements', [if (id != null) HttpRouteParam(id)]));
 
   /// Adds the [`skus`](https://discord.com/developers/docs/monetization/skus#list-skus) part to this [HttpRoute].
-  void skus() => add(HttpRoutePart('skus'));
+  void skus({String? id}) => add(HttpRoutePart('skus', [if (id != null) HttpRouteParam(id)]));
 
   /// Adds the [`consume`](https://discord.com/developers/docs/monetization/entitlements#consume-an-entitlement) part to this [HttpRoute].
   void consume() => add(HttpRoutePart('consume'));

--- a/lib/src/models/application.dart
+++ b/lib/src/models/application.dart
@@ -1,6 +1,7 @@
 import 'package:nyxx/src/http/cdn/cdn_asset.dart';
 import 'package:nyxx/src/http/managers/application_manager.dart';
 import 'package:nyxx/src/http/managers/entitlement_manager.dart';
+import 'package:nyxx/src/http/managers/sku_manager.dart';
 import 'package:nyxx/src/http/route.dart';
 import 'package:nyxx/src/models/guild/guild.dart';
 import 'package:nyxx/src/models/locale.dart';
@@ -25,6 +26,9 @@ class PartialApplication with ToStringHelper {
 
   /// An [EntitlementManager] for this application's [Entitlement]s.
   EntitlementManager get entitlements => EntitlementManager(manager.client.options.entitlementConfig, manager.client, applicationId: id);
+
+  /// An [SkuManager] for this application's [Sku]s.
+  SkuManager get skus => SkuManager(manager.client.options.skuConfig, manager.client, applicationId: id);
 
   /// Create a new [PartialApplication].
   /// @nodoc

--- a/lib/src/models/sku.dart
+++ b/lib/src/models/sku.dart
@@ -1,20 +1,23 @@
-import 'package:nyxx/src/http/managers/application_manager.dart';
+import 'package:nyxx/src/http/managers/sku_manager.dart';
 import 'package:nyxx/src/models/application.dart';
 import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/models/snowflake_entity/snowflake_entity.dart';
 import 'package:nyxx/src/utils/enum_like.dart';
 import 'package:nyxx/src/utils/flags.dart';
-import 'package:nyxx/src/utils/to_string_helper/to_string_helper.dart';
+
+/// A partial [Sku].
+class PartialSku extends ManagedSnowflakeEntity<Sku> {
+  @override
+  final SkuManager manager;
+
+  /// @nodoc
+  PartialSku({required this.manager, required super.id});
+}
 
 /// {@template sku}
 /// A premium offering that can be made available to your application's users or guilds.
 /// {@endtemplate}
-class Sku with ToStringHelper {
-  /// The [Manager] for this SKU.
-  final ApplicationManager manager;
-
-  /// This SKU's ID.
-  final Snowflake id;
-
+class Sku extends PartialSku {
   /// This SKU's type.
   final SkuType type;
 
@@ -33,8 +36,8 @@ class Sku with ToStringHelper {
   /// {@macro sku}
   /// @nodoc
   Sku({
-    required this.manager,
-    required this.id,
+    required super.manager,
+    required super.id,
     required this.type,
     required this.applicationId,
     required this.name,
@@ -43,7 +46,7 @@ class Sku with ToStringHelper {
   });
 
   /// The application this SKU belongs to.
-  PartialApplication get application => PartialApplication(id: applicationId, manager: manager);
+  PartialApplication get application => PartialApplication(id: applicationId, manager: manager.client.applications);
 }
 
 /// The type of an [Sku].

--- a/lib/src/models/subscription.dart
+++ b/lib/src/models/subscription.dart
@@ -1,0 +1,81 @@
+import 'package:nyxx/src/http/managers/subscription_manager.dart';
+import 'package:nyxx/src/models/entitlement.dart';
+import 'package:nyxx/src/models/sku.dart';
+import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/src/models/snowflake_entity/snowflake_entity.dart';
+import 'package:nyxx/src/models/user/user.dart';
+import 'package:nyxx/src/utils/enum_like.dart';
+
+/// A partial [Subscription].
+class PartialSubscription extends ManagedSnowflakeEntity<Subscription> {
+  @override
+  final SubscriptionManager manager;
+
+  /// @nodoc
+  PartialSubscription({required this.manager, required super.id});
+}
+
+/// A subscription to an [Sku].
+class Subscription extends PartialSubscription {
+  /// The ID of the user this subscription is for.
+  final Snowflake userId;
+
+  /// The IDs of the SKUs this subscription is for.
+  final List<Snowflake> skuIds;
+
+  /// The IDs of the entitlements this subscription grants.
+  final List<Snowflake> entitlementIds;
+
+  /// The start of the current subscription period.
+  final DateTime currentPeriodStart;
+
+  /// The end of the current subscription period.
+  final DateTime currentPeriodEnd;
+
+  /// The status of this subscription.
+  final SubscriptionStatus status;
+
+  /// If this subscription was canceled, the time at which it was canceled.
+  ///
+  /// Otherwise, this field will be `null`.
+  final DateTime? canceledAt;
+
+  /// The ISO3166-1 alpha-2 country code of the payment source used to purchase this subscription.
+  final String? countryCode;
+
+  /// @nodoc
+  Subscription({
+    required super.manager,
+    required super.id,
+    required this.userId,
+    required this.skuIds,
+    required this.entitlementIds,
+    required this.currentPeriodStart,
+    required this.currentPeriodEnd,
+    required this.status,
+    required this.canceledAt,
+    required this.countryCode,
+  });
+
+  /// The user this subscription is for.
+  PartialUser get user => manager.client.users[userId];
+
+  /// The SKUs this subscription is for.
+  List<PartialSku> get skus => [
+        for (final skuId in skuIds) manager.client.applications[manager.applicationId].skus[skuId],
+      ];
+
+  /// The entitlements this subscription grants.
+  List<PartialEntitlement> get entitlements => [
+        for (final entitlementId in entitlementIds) manager.client.applications[manager.applicationId].entitlements[entitlementId],
+      ];
+}
+
+/// The status of a [Subscription].
+final class SubscriptionStatus extends EnumLike<int, SubscriptionStatus> {
+  static const active = SubscriptionStatus(0);
+  static const ending = SubscriptionStatus(1);
+  static const inactive = SubscriptionStatus(2);
+
+  const SubscriptionStatus(super.value);
+}

--- a/lib/src/utils/cache_helpers.dart
+++ b/lib/src/utils/cache_helpers.dart
@@ -41,6 +41,7 @@ import 'package:nyxx/src/models/role.dart';
 import 'package:nyxx/src/models/sticker/global_sticker.dart';
 import 'package:nyxx/src/models/sticker/guild_sticker.dart';
 import 'package:nyxx/src/models/sticker/sticker_pack.dart';
+import 'package:nyxx/src/models/sku.dart';
 import 'package:nyxx/src/models/user/user.dart';
 import 'package:nyxx/src/models/voice/voice_state.dart';
 import 'package:nyxx/src/models/webhook.dart';
@@ -121,6 +122,7 @@ extension CacheUpdates on NyxxRest {
 
             updateCacheWith(entity.user);
           }(),
+        Sku() => entity.manager.cache[entity.id] = entity,
 
         // "Aggregate" types - objects that contain other (potentially root) objects
 

--- a/lib/src/utils/cache_helpers.dart
+++ b/lib/src/utils/cache_helpers.dart
@@ -42,6 +42,7 @@ import 'package:nyxx/src/models/sticker/global_sticker.dart';
 import 'package:nyxx/src/models/sticker/guild_sticker.dart';
 import 'package:nyxx/src/models/sticker/sticker_pack.dart';
 import 'package:nyxx/src/models/sku.dart';
+import 'package:nyxx/src/models/subscription.dart';
 import 'package:nyxx/src/models/user/user.dart';
 import 'package:nyxx/src/models/voice/voice_state.dart';
 import 'package:nyxx/src/models/webhook.dart';
@@ -123,6 +124,7 @@ extension CacheUpdates on NyxxRest {
             updateCacheWith(entity.user);
           }(),
         Sku() => entity.manager.cache[entity.id] = entity,
+        Subscription() => entity.manager.cache[entity.id] = entity,
 
         // "Aggregate" types - objects that contain other (potentially root) objects
 

--- a/test/integration/rest_integration_test.dart
+++ b/test/integration/rest_integration_test.dart
@@ -64,8 +64,11 @@ void main() {
       late Application application;
 
       await expectLater(() async => application = await client.applications.fetchCurrentApplication(), completes);
-      await expectLater(application.listSkus(), completes);
       await expectLater(client.applications.updateCurrentApplication(ApplicationUpdateBuilder(description: application.description)), completes);
+    });
+
+    test('skus', () async {
+      await expectLater(client.application.skus.list(), completes);
     });
 
     test('users', () async {

--- a/test/unit/http/managers/application_manager_test.dart
+++ b/test/unit/http/managers/application_manager_test.dart
@@ -78,30 +78,6 @@ void checkRoleConnectionMetadata(ApplicationRoleConnectionMetadata metadata) {
   expect(metadata.localizedDescriptions, isNull);
 }
 
-final sampleSku = {
-  "id": "1088510058284990888",
-  "type": 5,
-  "dependent_sku_id": null,
-  "application_id": "788708323867885999",
-  "manifest_labels": null,
-  "access_type": 1,
-  "name": "Test Premium",
-  "features": [],
-  "release_date": null,
-  "premium": false,
-  "slug": "test-premium",
-  "flags": 128,
-  "show_age_gate": false
-};
-
-void checkSku(Sku sku) {
-  expect(sku.id, equals(Snowflake(1088510058284990888)));
-  expect(sku.type, equals(SkuType.subscription));
-  expect(sku.applicationId, equals(Snowflake(788708323867885999)));
-  expect(sku.name, equals('Test Premium'));
-  expect(sku.slug, equals('test-premium'));
-}
-
 void main() {
   group('ApplicationManager', () {
     test('parse', () {
@@ -127,19 +103,6 @@ void main() {
         source: sampleRoleConnectionMetadata,
         parse: (manager) => manager.parseApplicationRoleConnectionMetadata,
         check: checkRoleConnectionMetadata,
-      ).runWithManager(ApplicationManager(client));
-    });
-
-    test('parseSku', () {
-      final client = MockNyxx();
-      when(() => client.apiOptions).thenReturn(RestApiOptions(token: 'TEST_TOKEN'));
-      when(() => client.options).thenReturn(RestClientOptions());
-
-      ParsingTest<ApplicationManager, Sku, Map<String, Object?>>(
-        name: 'parseSku',
-        source: sampleSku,
-        parse: (manager) => manager.parseSku,
-        check: checkSku,
       ).runWithManager(ApplicationManager(client));
     });
 
@@ -169,12 +132,6 @@ void main() {
       method: 'PATCH',
       (client) => client.applications.updateCurrentApplication(ApplicationUpdateBuilder()),
       response: sampleApplication,
-    );
-
-    testEndpoint(
-      '/applications/0/skus',
-      (client) => client.applications.listSkus(Snowflake.zero),
-      response: [sampleSku],
     );
   });
 }

--- a/test/unit/http/managers/sku_manager_test.dart
+++ b/test/unit/http/managers/sku_manager_test.dart
@@ -1,0 +1,54 @@
+import 'package:nyxx/nyxx.dart';
+import 'package:nyxx/src/http/managers/sku_manager.dart';
+import 'package:test/test.dart';
+
+import '../../../test_manager.dart';
+
+final sampleSku = {
+  "id": "1",
+  "type": 5,
+  "dependent_sku_id": null,
+  "application_id": "788708323867885999",
+  "manifest_labels": null,
+  "access_type": 1,
+  "name": "Test Premium",
+  "features": [],
+  "release_date": null,
+  "premium": false,
+  "slug": "test-premium",
+  "flags": 128,
+  "show_age_gate": false
+};
+
+void checkSku(Sku sku) {
+  expect(sku.id, equals(Snowflake(1)));
+  expect(sku.type, equals(SkuType.subscription));
+  expect(sku.applicationId, equals(Snowflake(788708323867885999)));
+  expect(sku.name, equals('Test Premium'));
+  expect(sku.slug, equals('test-premium'));
+}
+
+void main() {
+  testReadOnlyManager<Sku, SkuManager>(
+    'SkuManager',
+    (config, client) => SkuManager(config, client, applicationId: Snowflake.zero),
+    '/applications/0/skus',
+    sampleObject: sampleSku,
+    fetchObjectOverride: [sampleSku],
+    sampleMatches: checkSku,
+    additionalParsingTests: [],
+    additionalEndpointTests: [
+      EndpointTest<SkuManager, List<Sku>, List<Map<String, Object?>>>(
+        name: 'list',
+        source: [sampleSku],
+        urlMatcher: '/applications/0/skus',
+        execute: (manager) => manager.list(),
+        check: (skus) {
+          expect(skus, hasLength(1));
+
+          checkSku(skus.single);
+        },
+      ),
+    ],
+  );
+}

--- a/test/unit/http/managers/subscription_manager_test.dart
+++ b/test/unit/http/managers/subscription_manager_test.dart
@@ -1,0 +1,51 @@
+import 'package:nyxx/nyxx.dart';
+import 'package:test/test.dart';
+
+import '../../../test_manager.dart';
+
+final sampleSubscription = {
+  "id": "1278078770116427839",
+  "user_id": "1088605110638227537",
+  "sku_ids": ["1158857122189168803"],
+  "entitlement_ids": [],
+  "current_period_start": "2024-08-27T19:48:44.406602+00:00",
+  "current_period_end": "2024-09-27T19:48:44.406602+00:00",
+  "status": 0,
+  "canceled_at": null
+};
+
+void checkSubscription(Subscription subscription) {
+  expect(subscription.id, equals(Snowflake(1278078770116427839)));
+  expect(subscription.userId, equals(Snowflake(1088605110638227537)));
+  expect(subscription.skuIds, equals([Snowflake(1158857122189168803)]));
+  expect(subscription.entitlementIds, equals([]));
+  expect(subscription.currentPeriodStart, equals(DateTime.utc(2024, 08, 27, 19, 48, 44, 406, 602)));
+  expect(subscription.currentPeriodEnd, equals(DateTime.utc(2024, 09, 27, 19, 48, 44, 406, 602)));
+  expect(subscription.status, equals(SubscriptionStatus.active));
+  expect(subscription.canceledAt, isNull);
+  expect(subscription.countryCode, isNull);
+}
+
+void main() {
+  testReadOnlyManager<Subscription, SubscriptionManager>(
+    'SubscriptionManager',
+    (client, config) => SubscriptionManager(client, config, applicationId: Snowflake.zero, skuId: Snowflake(1)),
+    RegExp(r'/skus/1/subscriptions/\d+'),
+    sampleObject: sampleSubscription,
+    sampleMatches: checkSubscription,
+    additionalParsingTests: [],
+    additionalEndpointTests: [
+      EndpointTest<SubscriptionManager, List<Subscription>, List<Map<String, Object?>>>(
+        name: 'list',
+        source: [sampleSubscription],
+        urlMatcher: '/skus/1/subscriptions',
+        execute: (manager) => manager.list(),
+        check: (subscriptions) {
+          expect(subscriptions, hasLength(1));
+
+          checkSubscription(subscriptions.single);
+        },
+      ),
+    ],
+  );
+}


### PR DESCRIPTION
# Description

Moves SKUs to their own manager and adds Subscriptions.

This PR is technically a breaking change due to the type of `manager` changing in the `Sku` constructor (`ApplicationManager` -> `SkuManager`). However, since this object is not intended to be constructed by users anyway (and the constructor is excluded from documentation), I think we can still publish this in the next minor version.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
