### PR TITLE
Improve shard reconnection handling

### DIFF
--- a/lib/src/gateway/message.dart
+++ b/lib/src/gateway/message.dart
@@ -73,6 +73,13 @@ class Sent extends ShardMessage {
 /// A shard message sent when the shard is waiting to identify on the Gateway.
 class RequestingIdentify extends ShardMessage {}
 
+/// A shard message sent when the shard needs to reconnect to the Gateway.
+class Reconnecting extends ShardMessage {
+  final String reason;
+
+  Reconnecting({required this.reason});
+}
+
 /// The base class for all control messages sent from the client to the shard.
 abstract class GatewayMessage with ToStringHelper {}
 

--- a/lib/src/gateway/shard.dart
+++ b/lib/src/gateway/shard.dart
@@ -74,6 +74,8 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
         logger.warning('Error: ${message.error}', message.error, message.stackTrace);
       } else if (message is Disconnecting) {
         logger.info('Disconnecting: ${message.reason}');
+      } else if (message is Reconnecting) {
+        logger.info('Reconnecting: ${message.reason}');
       } else if (message is EventReceived) {
         final event = message.event;
 
@@ -82,16 +84,13 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
 
           switch (event) {
             case InvalidSessionEvent(:final isResumable):
-              logger.finest('Resumable: $isResumable');
               if (isResumable) {
-                logger.info('Reconnecting: invalid session');
+                logger.finest('Resumable: $isResumable');
               } else {
-                logger.warning('Reconnecting: unresumable invalid session');
+                logger.warning('Resumable: $isResumable');
               }
             case HelloEvent(:final heartbeatInterval):
               logger.finest('Heartbeat Interval: $heartbeatInterval');
-            case ReconnectEvent():
-              logger.info('Reconnecting: reconnect requested');
             case HeartbeatAckEvent(:final latency):
               _latency = latency;
             default:

--- a/lib/src/gateway/shard_runner.dart
+++ b/lib/src/gateway/shard_runner.dart
@@ -214,7 +214,7 @@ class ShardRunner {
           // Check if we can resume based on close code if the connection was closed by Discord.
           if (connection!.localCloseCode == null) {
             // https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes
-            const resumableCodes = [null, 4000, 4001, 4002, 4003, 4005, 4008];
+            const newSessionCodes = [4007, 4009];
             const errorCodes = [4004, 4010, 4011, 4012, 4013, 4014];
 
             if (errorCodes.contains(connection!.remoteCloseCode)) {
@@ -222,7 +222,7 @@ class ShardRunner {
               return;
             }
 
-            canResume = resumableCodes.contains(connection!.remoteCloseCode);
+            canResume = !newSessionCodes.contains(connection!.remoteCloseCode);
 
             controller.add(ErrorReceived(
               error: 'Connection was closed with code ${connection!.remoteCloseCode}',

--- a/lib/src/gateway/shard_runner.dart
+++ b/lib/src/gateway/shard_runner.dart
@@ -30,6 +30,9 @@ class ShardRunner {
   /// The current active connection.
   ShardConnection? connection;
 
+  // Add messages to this controller for them to be sent back to the main isolate.
+  final StreamController<ShardMessage> controller = StreamController();
+
   /// Whether the last heartbeat was ACKed.
   bool lastHeartbeatAcked = true;
 
@@ -58,9 +61,6 @@ class ShardRunner {
 
   /// Run the shard runner.
   Stream<ShardMessage> run(Stream<GatewayMessage> messages) async* {
-    // Add messages to this controller for them to be sent back to the main isolate.
-    final controller = StreamController<ShardMessage>();
-
     // sendHandler is responsible for handling requests for this shard to send messages to the Gateway.
     // It is paused whenever this shard isn't ready to send messages.
     final sendController = StreamController<Send>();
@@ -186,6 +186,7 @@ class ShardRunner {
                 sendHandler.resume();
               }
             } else if (event is ReconnectEvent) {
+              controller.add(Reconnecting(reason: 'Reconnect requested'));
               connection!.close(4000);
             } else if (event is InvalidSessionEvent) {
               if (!event.isResumable) {
@@ -193,6 +194,7 @@ class ShardRunner {
                 gatewayUri = originalGatewayUri;
               }
 
+              controller.add(Reconnecting(reason: 'Session invalidated'));
               connection!.close(4000);
             } else if (event is HeartbeatAckEvent) {
               lastHeartbeatAcked = true;
@@ -213,26 +215,29 @@ class ShardRunner {
 
           // Check if we can resume based on close code if the connection was closed by Discord.
           if (connection!.localCloseCode == null) {
-            // https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes
-            const newSessionCodes = [4007, 4009];
-            const errorCodes = [4004, 4010, 4011, 4012, 4013, 4014];
+            if (connection!.remoteCloseCode == WebSocketStatus.noStatusReceived) {
+              controller.add(Reconnecting(reason: 'Gateway connection was closed'));
+            } else {
+              // https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes
+              const newSessionCodes = [4007, 4009];
+              const errorCodes = [4004, 4010, 4011, 4012, 4013, 4014];
 
-            if (errorCodes.contains(connection!.remoteCloseCode)) {
-              controller.add(Disconnecting(reason: 'Received error close code: ${connection!.remoteCloseCode}'));
-              return;
+              if (errorCodes.contains(connection!.remoteCloseCode)) {
+                controller.add(Disconnecting(reason: 'Received error close code: ${connection!.remoteCloseCode}'));
+                return;
+              }
+
+              canResume = !newSessionCodes.contains(connection!.remoteCloseCode);
+
+              controller.add(Reconnecting(reason: 'Connection was closed with code ${connection!.remoteCloseCode}'));
             }
-
-            canResume = !newSessionCodes.contains(connection!.remoteCloseCode);
-
-            controller.add(ErrorReceived(
-              error: 'Connection was closed with code ${connection!.remoteCloseCode}',
-              stackTrace: StackTrace.current,
-            ));
           }
         } catch (error, stackTrace) {
           controller.add(ErrorReceived(error: error, stackTrace: stackTrace));
           // Prevents the while-true loop from looping too often when no internet is available.
           await Future.delayed(Duration(milliseconds: 100));
+
+          controller.add(Reconnecting(reason: 'Error on Gateway connection'));
         } finally {
           // Pause the send subscription until we are connected again.
           // The handler may already be paused if the error occurred before we had identified.
@@ -264,6 +269,7 @@ class ShardRunner {
 
   void heartbeat() {
     if (!lastHeartbeatAcked) {
+      controller.add(Reconnecting(reason: 'Missed heartbeat'));
       connection!.close(4000);
       return;
     }


### PR DESCRIPTION
# Description

It seems like some bots are experiencing random disconnections that nyxx is not considering as unexpected (which would cause a reconnect). This means the bot effectively goes offline, but is left in a limbo state where the client is still active.

Im not sure why the reconnect loop isn't triggering. This PR will be updated as I find more problems in the code; for now it only contains a fix the the `localCloseCode` being set even when Discord closes the connection (causing a race condition of sorts for detecting error close codes).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
