### PR TITLE
Don't modify Cache.keys during iteration

### DIFF
--- a/lib/src/cache/cache.dart
+++ b/lib/src/cache/cache.dart
@@ -148,7 +148,7 @@ class Cache<T> extends MapBase<Snowflake, T> {
   factory Cache(Nyxx client, String identifier, CacheConfig<T> config) => client.cache.getCache(identifier, config);
 
   @override
-  Iterable<Snowflake> get keys => _mru.map((entry) => entry.id);
+  Iterable<Snowflake> get keys => _entries.keys;
 
   /// Filter the items in this cache so that it obeys the [config].
   ///

--- a/test/unit/cache/cache_test.dart
+++ b/test/unit/cache/cache_test.dart
@@ -116,5 +116,22 @@ void main() {
       cache1[entity.id] = entity;
       expect(cache2.containsKey(entity.id), isFalse);
     });
+
+    test('toList', () {
+      final cache = MockNyxx().cache.getCache<MockSnowflakeEntity>('test', CacheConfig());
+
+      final entity1 = MockSnowflakeEntity(id: Snowflake(1));
+      final entity2 = MockSnowflakeEntity(id: Snowflake(2));
+      final entity3 = MockSnowflakeEntity(id: Snowflake(3));
+      final entity4 = MockSnowflakeEntity(id: Snowflake(4));
+      final entity5 = MockSnowflakeEntity(id: Snowflake(5));
+
+      for (final entity in [entity1, entity2, entity3, entity4, entity5]) {
+        cache[entity.id] = entity;
+      }
+
+      expect(cache.keys.toList, returnsNormally);
+      expect(cache.values.toList, returnsNormally);
+    });
   });
 }


### PR DESCRIPTION
# Description

Fix an issue where iterating over `Cache.values` threw a `ConcurrentModificationError` due to the underlying `_mru` list being updated.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
