### PR TITLE
fix serialisation of `before` param in `listJoinedPrivateArchivedThreads`

### DIFF
--- a/lib/src/http/managers/channel_manager.dart
+++ b/lib/src/http/managers/channel_manager.dart
@@ -754,6 +754,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
   }
 
   /// List the private archived threads the current user has joined in a channel.
+  // TODO(lexedia): for nyxx v7, this needs to be updated to use `Snowflake` instead of `DateTime`.
   Future<ThreadList> listJoinedPrivateArchivedThreads(Snowflake id, {DateTime? before, int? limit}) async {
     final route = HttpRoute()
       ..channels(id: id.toString())
@@ -764,7 +765,7 @@ class ChannelManager extends ReadOnlyManager<Channel> {
     final request = BasicRequest(
       route,
       queryParameters: {
-        if (before != null) 'before': before.toIso8601String(),
+        if (before != null) 'before': Snowflake.fromDateTime(before).toString(),
         if (limit != null) 'limit': limit.toString(),
       },
     );


### PR DESCRIPTION
# Description

See: https://discord.com/developers/docs/resources/channel#list-joined-private-archived-threads

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
