### PR TITLE
Allow polls to be constructed in a interation response

### DIFF
--- a/lib/src/builders/message/message.dart
+++ b/lib/src/builders/message/message.dart
@@ -123,6 +123,9 @@ class MessageUpdateBuilder extends UpdateBuilder<Message> {
 
   List<AttachmentBuilder>? attachments;
 
+  /// Can only be used when editing a deferred interaction.
+  PollBuilder? poll;
+
   MessageUpdateBuilder({
     this.content = sentinelString,
     this.embeds = sentinelList,
@@ -130,6 +133,7 @@ class MessageUpdateBuilder extends UpdateBuilder<Message> {
     this.allowedMentions,
     this.components,
     this.attachments = sentinelList,
+    this.poll,
   });
 
   @override
@@ -140,6 +144,7 @@ class MessageUpdateBuilder extends UpdateBuilder<Message> {
         if (components != null) 'components': components!.map((e) => e.build()).toList(),
         if (!identical(attachments, sentinelList)) 'attachments': attachments!.map((e) => e.build()).toList(),
         if (suppressEmbeds != null) 'flags': (suppressEmbeds == true ? MessageFlags.suppressEmbeds.value : 0),
+        if (poll != null) 'poll': poll!.build(),
       };
 }
 


### PR DESCRIPTION
# Description

title

- https://github.com/discord/discord-api-docs/pull/7090

## Type of change
- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [ ] Ran `dart analyze` or `make analyze` and fixed all issues
- [ ] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
