### PR TITLE
fix the readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ void main() async {
     if (event.mentions.contains(botUser)) {
       await event.message.channel.sendMessage(MessageBuilder(
         content: 'You mentioned me!',
-        replyId: event.message.id,
+        referencedMessage: MessageReferenceBuilder.reply(messageId: event.message.id),
       ));
     }
   });


### PR DESCRIPTION
# Description

`replyId` is deprecated since 6.4.0, using it in the main example is kinda misleading since users will use this property.
