### PR TITLE
bug: Fix legacy accounts default avatar

### DIFF
--- a/lib/src/models/user/user.dart
+++ b/lib/src/models/user/user.dart
@@ -109,13 +109,18 @@ class User extends PartialUser implements MessageAuthor, CommandOptionMentionabl
         );
 
   /// This user's default avatar.
-  CdnAsset get defaultAvatar => CdnAsset(
-        client: manager.client,
-        base: HttpRoute()
-          ..embed()
-          ..avatars(),
-        hash: ((id.value >> 22) % 6).toString(),
-      );
+  CdnAsset get defaultAvatar {
+    final parsedDiscriminator = int.tryParse(discriminator);
+    final hash = parsedDiscriminator == null || parsedDiscriminator == 0 ? (id.value >> 22) % 6 : parsedDiscriminator % 5;
+
+    return CdnAsset(
+      client: manager.client,
+      base: HttpRoute()
+        ..embed()
+        ..avatars(),
+      hash: hash.toString(),
+    );
+  }
 
   @override
   CdnAsset get avatar => avatarHash == null


### PR DESCRIPTION
# Description

Fixes default avatar hash calculation for legacy accounts (with discrim).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
