### PR TITLE
Release 6.7.0-dev.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 6.7.0-dev.1
+__11.03.2025__
+
+- feat: Add support for Components V2 ([`#742`](https://github.com/nyxx-discord/nyxx/pull/742)) - ([`1b42b66`](https://github.com/nyxx-discord/nyxx/commit/1b42b6672b67824e49315eddf30ca7fdf24a0eff))
+- fix: Deprecate `GatewayIntents.guildEmojisAndStickers`, replaced by `GatewayIntents.guildExpressions` ([`#744`](https://github.com/nyxx-discord/nyxx/pull/744)) - ([`14a5110`](https://github.com/nyxx-discord/nyxx/commit/14a5110943149d38a7362103a3ad21a78691f503))
+- fix: Handle `abnormalClosure` in shard connections ([`#743`](https://github.com/nyxx-discord/nyxx/pull/743)) - ([`0361097`](https://github.com/nyxx-discord/nyxx/commit/036109709321a99b6c6ee8c9c5d78e4604ecc0b5))
+
 ## 6.6.1
 __22.03.2025__
 
@@ -6,7 +13,7 @@ __22.03.2025__
 ## 6.6.0
 __23.02.2025__
 
-- feat Make `SoundboardSound` have a CDN asset ([`#740`](https://github.com/nyxx-discord/nyxx/pull/740)) - ([`a8650288`](https://github.com/nyxx-discord/nyxx/commit/a8650288))
+- feat: Make `SoundboardSound` have a CDN asset ([`#740`](https://github.com/nyxx-discord/nyxx/pull/740)) - ([`a8650288`](https://github.com/nyxx-discord/nyxx/commit/a8650288))
 - feat: Add new connections services ([`#735`](https://github.com/nyxx-discord/nyxx/pull/735)) - ([`afe90236`](https://github.com/nyxx-discord/nyxx/commit/afe90236))
 - feat: Add `has_snapshot` message flag ([`#734`](https://github.com/nyxx-discord/nyxx/pull/734)) - ([`385a9667`](https://github.com/nyxx-discord/nyxx/commit/385a9667))
 - feat: Add `withComponents` param on webhooks ([`#738`](https://github.com/nyxx-discord/nyxx/pull/738)) - ([`2b8f229c`](https://github.com/nyxx-discord/nyxx/commit/2b8f229c))

--- a/lib/src/api_options.dart
+++ b/lib/src/api_options.dart
@@ -6,7 +6,7 @@ import 'package:oauth2/oauth2.dart';
 /// Options for connecting to the Discord API.
 abstract class ApiOptions {
   /// The version of nyxx used in [defaultUserAgent].
-  static const nyxxVersion = '6.6.1';
+  static const nyxxVersion = '6.7.0-dev.1';
 
   /// The URL to the nyxx repository used in [defaultUserAgent].
   static const nyxxRepositoryUrl = 'https://github.com/nyxx-discord/nyxx';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx
-version: 6.6.1
+version: 6.7.0-dev.1
 description: A complete, robust and efficient wrapper around Discord's API for bots & applications.
 homepage: https://github.com/nyxx-discord/nyxx
 repository: https://github.com/nyxx-discord/nyxx


### PR DESCRIPTION
For now, we will just merge this. We'll wait for Discord to disable the experiment gating, trigger test workflows, and if they pass we can trigger the release by tagging the commit.

Releasing as a dev release for now until Discord fully releases the feature.