### PR TITLE
Add `attachmentSizeLimit` field to `Interaction`

### DIFF
--- a/lib/src/http/managers/interaction_manager.dart
+++ b/lib/src/http/managers/interaction_manager.dart
@@ -62,6 +62,7 @@ class InteractionManager {
       },
     );
     final context = maybeParse(raw['context'], InteractionContextType.new);
+    final attachmentSizeLimit = raw['attachment_size_limit'] as int;
 
     final mapping = <InteractionType, Interaction Function()>{
       InteractionType.ping: () => PingInteraction(
@@ -83,6 +84,7 @@ class InteractionManager {
             entitlements: entitlements,
             authorizingIntegrationOwners: authorizingIntegrationOwners,
             context: context,
+            attachmentSizeLimit: attachmentSizeLimit,
           ),
       InteractionType.applicationCommand: () => ApplicationCommandInteraction(
             manager: this,
@@ -104,6 +106,7 @@ class InteractionManager {
             entitlements: entitlements,
             authorizingIntegrationOwners: authorizingIntegrationOwners,
             context: context,
+            attachmentSizeLimit: attachmentSizeLimit,
           ),
       InteractionType.messageComponent: () => MessageComponentInteraction(
             manager: this,
@@ -125,6 +128,7 @@ class InteractionManager {
             entitlements: entitlements,
             authorizingIntegrationOwners: authorizingIntegrationOwners,
             context: context,
+            attachmentSizeLimit: attachmentSizeLimit,
           ),
       InteractionType.modalSubmit: () => ModalSubmitInteraction(
             manager: this,
@@ -146,6 +150,7 @@ class InteractionManager {
             entitlements: entitlements,
             authorizingIntegrationOwners: authorizingIntegrationOwners,
             context: context,
+            attachmentSizeLimit: attachmentSizeLimit,
           ),
       InteractionType.applicationCommandAutocomplete: () => ApplicationCommandAutocompleteInteraction(
             manager: this,
@@ -167,6 +172,7 @@ class InteractionManager {
             entitlements: entitlements,
             authorizingIntegrationOwners: authorizingIntegrationOwners,
             context: context,
+            attachmentSizeLimit: attachmentSizeLimit,
           ),
     };
 
@@ -190,6 +196,7 @@ class InteractionManager {
           entitlements: entitlements,
           authorizingIntegrationOwners: authorizingIntegrationOwners,
           context: context,
+          attachmentSizeLimit: attachmentSizeLimit,
         );
   }
 

--- a/lib/src/models/interaction.dart
+++ b/lib/src/models/interaction.dart
@@ -105,6 +105,9 @@ abstract class Interaction<T> with ToStringHelper {
   /// Context where the interaction was triggered from.
   final InteractionContextType? context;
 
+  /// Represents the maximun allowed size per-attachment for the given interaction
+  final int attachmentSizeLimit;
+
   /// {@macro interaction}
   /// @nodoc
   Interaction({
@@ -127,6 +130,7 @@ abstract class Interaction<T> with ToStringHelper {
     required this.entitlements,
     required this.authorizingIntegrationOwners,
     required this.context,
+    required this.attachmentSizeLimit,
   });
 
   /// The guild in which this interaction was triggered.
@@ -152,7 +156,7 @@ mixin MessageResponse<T> on Interaction<T> {
   }
 
   /// Send a response to this interaction.
-  Future<void> respond(MessageBuilder builder, {bool? isEphemeral}) async {
+  Future<void> respond(MessageBuilder builder, {@Deprecated('Use MessageBuilder.flags instead') bool? isEphemeral}) async {
     if (_didRespond) {
       throw AlreadyRespondedError(this);
     }
@@ -162,6 +166,7 @@ mixin MessageResponse<T> on Interaction<T> {
       _didRespond = true;
       _wasEphemeral = isEphemeral;
 
+      // ignore: deprecated_member_use_from_same_package
       await manager.createResponse(id, token, InteractionResponseBuilder.channelMessage(builder, isEphemeral: isEphemeral));
     } else {
       assert(isEphemeral == _wasEphemeral || isEphemeral == null, 'Cannot change the value of isEphemeral between acknowledge and respond');
@@ -233,6 +238,7 @@ class PingInteraction extends Interaction<void> {
     required super.entitlements,
     required super.authorizingIntegrationOwners,
     required super.context,
+    required super.attachmentSizeLimit,
   }) : super(data: null);
 
   /// Send a pong response to this interaction.
@@ -266,6 +272,7 @@ class ApplicationCommandInteraction extends Interaction<ApplicationCommandIntera
     required super.entitlements,
     required super.authorizingIntegrationOwners,
     required super.context,
+    required super.attachmentSizeLimit,
   });
 }
 
@@ -296,6 +303,7 @@ class MessageComponentInteraction extends Interaction<MessageComponentInteractio
     required super.entitlements,
     required super.authorizingIntegrationOwners,
     required super.context,
+    required super.attachmentSizeLimit,
   });
 
   bool? _didUpdateMessage;
@@ -320,7 +328,7 @@ class MessageComponentInteraction extends Interaction<MessageComponentInteractio
   }
 
   @override
-  Future<void> respond(Builder<Message> builder, {bool? updateMessage, bool? isEphemeral}) async {
+  Future<void> respond(Builder<Message> builder, {bool? updateMessage, @Deprecated('Use MessageBuilder.flags instead') bool? isEphemeral}) async {
     assert(updateMessage != true || isEphemeral != true, 'Cannot set isEphemeral to true if updateMessage is set to true');
     assert(updateMessage != true || builder is MessageUpdateBuilder, 'builder must be a MessageUpdateBuilder if updateMessage is true');
     assert(updateMessage == true || builder is MessageBuilder, 'builder must be a MessageBuilder if updateMessage is null or false');
@@ -338,6 +346,7 @@ class MessageComponentInteraction extends Interaction<MessageComponentInteractio
       if (updateMessage == true) {
         await manager.createResponse(id, token, InteractionResponseBuilder.updateMessage(builder as MessageUpdateBuilder));
       } else {
+        // ignore: deprecated_member_use_from_same_package
         await manager.createResponse(id, token, InteractionResponseBuilder.channelMessage(builder as MessageBuilder, isEphemeral: isEphemeral));
       }
     } else {
@@ -381,6 +390,7 @@ class ModalSubmitInteraction extends Interaction<ModalSubmitInteractionData> wit
     required super.entitlements,
     required super.authorizingIntegrationOwners,
     required super.context,
+    required super.attachmentSizeLimit,
   });
 }
 
@@ -410,6 +420,7 @@ class ApplicationCommandAutocompleteInteraction extends Interaction<ApplicationC
     required super.entitlements,
     required super.authorizingIntegrationOwners,
     required super.context,
+    required super.attachmentSizeLimit,
   });
 
   /// Send a response to this interaction.
@@ -592,5 +603,6 @@ class UnknownInteraction extends Interaction<void> {
     required super.entitlements,
     required super.authorizingIntegrationOwners,
     required super.context,
+    required super.attachmentSizeLimit,
   }) : super(data: null);
 }

--- a/test/unit/http/managers/interaction_manager_test.dart
+++ b/test/unit/http/managers/interaction_manager_test.dart
@@ -47,6 +47,7 @@ final sampleCommandInteraction = {
   // Fields not present in the example but documented
   "application_id": "0",
   "version": 1,
+  "attachment_size_limit": 4096
 };
 
 void checkCommandInteraction(Interaction<dynamic> interaction) {
@@ -75,6 +76,7 @@ void checkCommandInteraction(Interaction<dynamic> interaction) {
         ApplicationIntegrationType.userInstall: Snowflake(302359032612651009),
       }));
   expect(interaction.context, equals(InteractionContextType.guild));
+  expect(interaction.attachmentSizeLimit, equals(4096));
 }
 
 final sampleCommandInteraction2 = {
@@ -173,6 +175,7 @@ final sampleCommandInteraction2 = {
     "0": "846136758470443069",
     "1": "302359032612651009",
   },
+  'attachment_size_limit': 4096
 };
 
 void checkCommandInteraction2(Interaction<dynamic> interaction) {


### PR DESCRIPTION
# Description
https://github.com/discord/discord-api-docs/pull/7451

<!-- ## Connected issues & other potential problems

If changes in PR are connected to other issues or are affecting code in other parts of framework
(e.g. in main package or any other subpackage) make sure to link issue/PR and describe said problem.

Uncomment this part to add context if needed.
-->

## Type of change
- [x] New feature (non-breaking change which adds functionality)
<!-- 
- [x] Bug fix (non-breaking change which fixes an issue)

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
Move/Copy lines that apply out of the comment.
-->

## Checklist:
- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have made corresponding changes to the documentation
<!--

- [x] I have added tests that prove my fix is effective or that my feature works
Move/Copy lines that apply out of the comment.
-->
