### PR TITLE
Reduce the number of managers present in the process's memory

### DIFF
--- a/lib/src/manager_mixin.dart
+++ b/lib/src/manager_mixin.dart
@@ -19,38 +19,51 @@ mixin ManagerMixin implements Nyxx {
   RestClientOptions get options;
 
   /// A [UserManager] that manages users for this client.
-  UserManager get users => UserManager(options.userCacheConfig, this as NyxxRest);
+  UserManager get users => _users;
+  late final UserManager _users = UserManager(options.userCacheConfig, this as NyxxRest);
 
   /// A [ChannelManager] that manages channels for this client.
-  ChannelManager get channels => ChannelManager(options.channelCacheConfig, this as NyxxRest, stageInstanceConfig: options.stageInstanceCacheConfig);
+  ChannelManager get channels => _channels;
+  late final ChannelManager _channels = ChannelManager(options.channelCacheConfig, this as NyxxRest, stageInstanceConfig: options.stageInstanceCacheConfig);
 
   /// A [WebhookManager] that manages webhooks for this client.
-  WebhookManager get webhooks => WebhookManager(options.webhookCacheConfig, this as NyxxRest);
+  WebhookManager get webhooks => _webhooks;
+  late final WebhookManager _webhooks = WebhookManager(options.webhookCacheConfig, this as NyxxRest);
 
   /// A [GuildManager] that manages guilds for this client.
-  GuildManager get guilds => GuildManager(options.guildCacheConfig, this as NyxxRest);
+  GuildManager get guilds => _guilds;
+  late final GuildManager _guilds = GuildManager(options.guildCacheConfig, this as NyxxRest);
 
   /// An [ApplicationManager] that manages applications for this client.
-  ApplicationManager get applications => ApplicationManager(this as NyxxRest);
+  ApplicationManager get applications => _applications;
+  late final ApplicationManager _applications = ApplicationManager(this as NyxxRest);
 
   /// A [VoiceManager] that manages voice states for this client.
-  VoiceManager get voice => VoiceManager(this as NyxxRest);
+  VoiceManager get voice => _voice;
+  late final VoiceManager _voice = VoiceManager(this as NyxxRest);
 
   /// An [InviteManager] that manages invites for this client.
-  InviteManager get invites => InviteManager(this as NyxxRest);
+  InviteManager get invites => _invites;
+  late final InviteManager _invites = InviteManager(this as NyxxRest);
 
   /// A [GatewayManager] that manages gateway metadata for this client.
-  GatewayManager get gateway => GatewayManager(this as NyxxRest);
+  GatewayManager get gateway => _gateway;
+  late final GatewayManager _gateway = GatewayManager(this as NyxxRest);
 
   /// A [GlobalStickerManager] that manages global stickers.
-  GlobalStickerManager get stickers => GlobalStickerManager(options.globalStickerCacheConfig, this as NyxxRest);
+  GlobalStickerManager get stickers => _stickers;
+  late final GlobalStickerManager _stickers = GlobalStickerManager(options.globalStickerCacheConfig, this as NyxxRest);
 
   /// A [GlobalApplicationCommandManager] that manages global application commands.
-  GlobalApplicationCommandManager get commands =>
+  GlobalApplicationCommandManager get commands => _commands;
+  late final GlobalApplicationCommandManager _commands =
       GlobalApplicationCommandManager(options.applicationCommandConfig, this as NyxxRest, applicationId: (this as NyxxRest).application.id);
 
-  InteractionManager get interactions => InteractionManager(this as NyxxRest, applicationId: (this as NyxxRest).application.id);
+  /// An [InteractionManager] that manages interactions received by the client.
+  InteractionManager get interactions => _interactions;
+  late final InteractionManager _interactions = InteractionManager(this as NyxxRest, applicationId: (this as NyxxRest).application.id);
 
   /// A [GlobalSoundboardManager] that manages global soundboard sounds.
-  GlobalSoundboardManager get soundboard => GlobalSoundboardManager(options.globalSoundboardCacheConfig, this as NyxxRest);
+  GlobalSoundboardManager get soundboard => _soundboard;
+  late final GlobalSoundboardManager _soundboard = GlobalSoundboardManager(options.globalSoundboardCacheConfig, this as NyxxRest);
 }


### PR DESCRIPTION
# Description

Because managers are implemented as getters on the client, and the managers returned by those getters are then stored by entities that end up in the client's cache, nyxx ends up collecting a lot of managers in the process' memory (at least one per cache entity).

This PR alleviates this by only creating one manager of each type on the client. Managers that belong to entities (e.g TextChannel.messages) are still left as getters, seeing as making them fields would not reduce the total number of managers created (one manager would be created per instance of the entity, and because most of the parsing methods use partials to access the manager for parsing, this would result in just as many managers being created).

Ideally we would have some system like Cache that deduplicate instances based on an identifier. This is harder to do for managers though, seeing as they are their own distinct type.