### PR TITLE
Added `final String? name` to `guild.dart` to respect partial guild r…

### DIFF
--- a/lib/src/http/managers/invite_manager.dart
+++ b/lib/src/http/managers/invite_manager.dart
@@ -29,7 +29,7 @@ class InviteManager {
   Invite parse(Map<String, Object?> raw) {
     final guild = maybeParse(
       raw['guild'],
-      (Map<String, Object?> raw) => PartialGuild(id: Snowflake.parse(raw['id']!), manager: client.guilds),
+      (Map<String, Object?> raw) => PartialGuild(id: Snowflake.parse(raw['id']!), manager: client.guilds, name: raw['name'] as String?),
     );
 
     return Invite(

--- a/lib/src/models/guild/guild.dart
+++ b/lib/src/models/guild/guild.dart
@@ -57,6 +57,9 @@ class PartialGuild extends WritableSnowflakeEntity<Guild> {
   @override
   final GuildManager manager;
 
+  /// This guild's name.
+  final String? name;
+
   /// A [MemberManager] for the members of this guild.
   MemberManager get members => MemberManager(manager.client.options.memberCacheConfig, manager.client, guildId: id);
 
@@ -98,7 +101,7 @@ class PartialGuild extends WritableSnowflakeEntity<Guild> {
 
   /// Create a new [PartialGuild].
   /// @nodoc
-  PartialGuild({required super.id, required this.manager});
+  PartialGuild({required super.id, required this.manager, this.name});
 
   @override
   Future<Guild> fetch({bool? withCounts}) => manager.fetch(id, withCounts: withCounts);
@@ -288,8 +291,6 @@ class PartialGuild extends WritableSnowflakeEntity<Guild> {
 /// {@category models}
 /// {@category entities}
 class UserGuild extends PartialGuild {
-  /// This guild's name.
-  final String name;
 
   /// The hash of this guild's icon.
   final String? iconHash;
@@ -323,7 +324,7 @@ class UserGuild extends PartialGuild {
   UserGuild({
     required super.id,
     required super.manager,
-    required this.name,
+    required super.name,
     required this.iconHash,
     required this.isOwnedByCurrentUser,
     required this.currentUserPermissions,


### PR DESCRIPTION
…esponse inside `Invite.fetch()`

# Description

Add a field String? name into PartialGuild to respect actual response from Invite.fetch() / Invite Object according to discord documentation : https://docs.discord.com/developers/resources/invite#invite-object 

Also updated UserGuild to use the super.name argument from parent

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

